### PR TITLE
<vector> is required regardless of AOTRITON_USE_ZSTD

### DIFF
--- a/include/aotriton/_internal/triton_kernel.h
+++ b/include/aotriton/_internal/triton_kernel.h
@@ -10,9 +10,7 @@
 #endif
 
 #include "../runtime.h"
-#if AOTRITON_USE_ZSTD
 #include <vector>
-#endif
 
 namespace aotriton {
 


### PR DESCRIPTION
This fixes #18