### PR TITLE
[mGPU] Run hipModuleLoadDataEx for each GPU device.

### DIFF
--- a/include/aotriton/_internal/triton_kernel.h
+++ b/include/aotriton/_internal/triton_kernel.h
@@ -11,6 +11,9 @@
 
 #include "../runtime.h"
 #include <vector>
+#include <unordered_map>
+#include <shared_mutex>
+#include <tuple>
 
 namespace aotriton {
 
@@ -24,11 +27,24 @@ public:
   void clear_decompressed_image();
 #endif
 private:
+  std::tuple<hipFunction_t, hipError_t> load_for_device(int device_id, const char* kernel_name);
+  hipFunction_t cfind_function(int device_id) const;
+
   const void* kernel_image_ = nullptr;
   size_t image_size_ = 0;
+  struct DeviceFunction {
+    DeviceFunction(int device_id_,
+                   hipModule_t mod_,
+                   hipFunction_t func_);
+    ~DeviceFunction();
+    int device_id = -1;
+    hipModule_t mod = nullptr;
+    hipFunction_t func = nullptr; 
+  };
+  std::unordered_map<int, DeviceFunction> funcache_;
+  std::shared_mutex mutex_;
+
   dim3 block_ { 256, 1, 1 };
-  hipModule_t mod_ = nullptr;
-  hipFunction_t fun_ = nullptr;
   int shared_memory_size_;
 #if AOTRITON_USE_ZSTD
   std::vector<char> decompressed_kernel_image_;

--- a/v2src/triton_kernel.cc
+++ b/v2src/triton_kernel.cc
@@ -24,6 +24,19 @@
 
 namespace aotriton {
 
+TritonKernel::DeviceFunction::DeviceFunction(int device_id_, hipModule_t mod_, hipFunction_t func_)
+  : device_id(device_id_)
+  , mod(mod_)
+  , func(func_) {
+}
+
+TritonKernel::DeviceFunction::~DeviceFunction() {
+  if (mod != nullptr) {
+    (void)hipModuleUnload(mod);
+  }
+}
+
+
 TritonKernel::TritonKernel(const void* image, size_t image_size, dim3 block, int shared_memory_size)
   : kernel_image_(image)
   , image_size_(image_size)
@@ -36,36 +49,72 @@ TritonKernel::invoke(const char* kernel_name, dim3 grid, std::vector<void*>& arg
 #if AOTRITON_KERNEL_VERBOSE
   std::cerr << "Invoking TritonKernel " << this << " with kernel_name = " << kernel_name << std::endl;
 #endif
-  if (fun_ == nullptr) {
-    hipJitOption opt[] = { hipJitOptionErrorLogBufferSizeBytes,
-                           hipJitOptionErrorLogBuffer,
-                           hipJitOptionInfoLogBufferSizeBytes,
-                           hipJitOptionInfoLogBuffer,
-                           hipJitOptionLogVerbose };
-    const unsigned int errbufsize = 8192;
-    const unsigned int logbufsize = 8192;
-    std::vector<char> err(errbufsize, 0);
-    std::vector<char> log(errbufsize, 0);
-    void* optval[] = {
-      (void*)(uintptr_t)err.size(), err.data(), (void*)(uintptr_t)log.size(), log.data(), (void*)(uintptr_t)1
-    };
+  int device_id;
+  AOTRITON_HIP_CHECK_RETURN(hipGetDevice(&device_id));
+  // Use reader lock to peek the state
+  hipFunction_t func = nullptr;
+  {
+    std::shared_lock lock(mutex_);
+    func = cfind_function(device_id);
+  }
 
-#if AOTRITON_USE_ZSTD
-    auto image = decompress_kernel();
-#if AOTRITON_KERNEL_VERBOSE
-    std::cerr << "Decompress kernel from " << kernel_image_ << " with size " << image_size_ << " to " << image
-              << " with size " << decompressed_kernel_image_.size() << std::endl;
-#endif
-    if (!image)
-      return hipErrorInvalidImage;
-#else
-    auto image = kernel_image_;
-#endif
-    AOTRITON_HIP_CHECK_RETURN(hipModuleLoadDataEx(&mod_, image, 5, opt, optval));
-    AOTRITON_HIP_CHECK_RETURN(hipModuleGetFunction(&fun_, mod_, kernel_name));
+  if (!func) {
+    // Use writer lock to initialize the module for device
+    std::unique_lock lock(mutex_);
+    // Check again, in case another waiter has initialized the device
+    func = cfind_function(device_id);
+    if (!func) {
+      hipError_t err;
+      std::tie(func, err) = load_for_device(device_id, kernel_name);
+    }
   }
   return hipModuleLaunchKernel(
-    fun_, grid.x, grid.y, grid.z, block_.x, block_.y, block_.z, shared_memory_size_, stream, args.data(), 0);
+    func, grid.x, grid.y, grid.z, block_.x, block_.y, block_.z, shared_memory_size_, stream, args.data(), 0);
+}
+
+hipFunction_t
+TritonKernel::cfind_function(int device_id) const {
+  auto iter = funcache_.find(device_id);
+  if (iter == funcache_.end())
+    return nullptr;
+  return iter->second.func;
+}
+
+std::tuple<hipFunction_t, hipError_t>
+TritonKernel::load_for_device(int device_id, const char* kernel_name) {
+  hipJitOption opt[] = { hipJitOptionErrorLogBufferSizeBytes,
+                         hipJitOptionErrorLogBuffer,
+                         hipJitOptionInfoLogBufferSizeBytes,
+                         hipJitOptionInfoLogBuffer,
+                         hipJitOptionLogVerbose };
+  const unsigned int errbufsize = 8192;
+  const unsigned int logbufsize = 8192;
+  std::vector<char> err(errbufsize, 0);
+  std::vector<char> log(errbufsize, 0);
+  void* optval[] = {
+    (void*)(uintptr_t)err.size(), err.data(), (void*)(uintptr_t)log.size(), log.data(), (void*)(uintptr_t)1
+  };
+
+#if AOTRITON_USE_ZSTD
+  auto image = decompress_kernel();
+#if AOTRITON_KERNEL_VERBOSE
+  std::cerr << "Decompress kernel from " << kernel_image_ << " with size " << image_size_ << " to " << image
+            << " with size " << decompressed_kernel_image_.size() << std::endl;
+#endif
+  if (!image) {
+    return std::make_tuple(nullptr, hipErrorInvalidImage);
+  }
+#else
+  auto image = kernel_image_;
+#endif
+  hipModule_t mod;
+  hipFunction_t func;
+  AOTRITON_HIP_CHECK_RETURN(hipModuleLoadDataEx(&mod, image, 5, opt, optval));
+  AOTRITON_HIP_CHECK_RETURN(hipModuleGetFunction(&func, mod, kernel_name));
+  funcache_.emplace(std::piecewise_construct,
+                    std::forward_as_tuple(device_id),
+                    std::forward_as_tuple(device_id, mod, func));
+  return std::make_tuple(func, hipSuccess);
 }
 
 #if AOTRITON_USE_ZSTD


### PR DESCRIPTION
Fix `TritonKernel::invoke` for multi-GPU scenarios.

`hipModuleLoadDataEx` only loads the image into a module that is specific to current GPU. Hence if another `TritonKernel::invoke` was made on a different GPU, the function call will fail since the module is only valid for the previous GPU.