### PR TITLE
Add cmake option AOTRITON_NAME_SUFFIX to resolve name conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,7 @@ if(AOTRITON_MIN_PYTHON VERSION_LESS "3.8")
   message(FATAL_ERROR "Do not set AOTRITON_MIN_PYTHON lower than 3.8. The code itself does not support it.")
 endif()
 
-add_subdirectory(third_party/pybind11)
 find_package(Python3 ${AOTRITON_MIN_PYTHON} COMPONENTS Interpreter REQUIRED)
-
-set(CMAKE_CXX_COMPILER hipcc)
 
 set(VENV_DIR "${CMAKE_CURRENT_BINARY_DIR}/venv" CACHE STRING "Virtual Environment Directory")
 set(AOTRITON_HIPCC_PATH "hipcc" CACHE STRING "Set HIPCC Path")
@@ -27,7 +24,11 @@ set(TARGET_GPUS "MI200;MI300X;Navi31" CACHE STRING "Target Architecture (Note he
 # Early failure for python binding
 if(NOT AOTRITON_NO_PYTHON)
   find_package(Python3 ${AOTRITON_MIN_PYTHON} COMPONENTS Development REQUIRED)
+  add_subdirectory(third_party/pybind11)
 endif()
+
+# Must be after pybind11
+set(CMAKE_CXX_COMPILER hipcc)
 
 # GPU kernel compression related options
 option(AOTRITON_COMPRESS_KERNEL "Enable GPU kernel compression with zstd. Fail when zstd is unavailable. Only effective for AOTriton API V2" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,17 @@ set(TARGET_GPUS "MI200;MI300X;Navi31" CACHE STRING "Target Architecture (Note he
 option(AOTRITON_COMPRESS_KERNEL "Enable GPU kernel compression with zstd. Fail when zstd is unavailable. Only effective for AOTriton API V2" ON)
 # option(AOTRITON_COMPRESS_KERNEL_STATIC_ZSTD "Use static zstd library to avoid potential zstd version conflict (e.g. pytorch)" OFF)
 
+# Resolve name conflicts with suffix
+set(AOTRITON_NAME_SUFFIX "" CACHE STRING "Add suffix to namespace and library file name. This is to resovle name conflicts with PyTorch's AOTriton during testing.")
+if(AOTRITON_NAME_SUFFIX)
+  set(AOTRITON_ENABLE_SUFFIX ON)
+else()
+  set(AOTRITON_ENABLE_SUFFIX OFF)
+endif()
+configure_file(include/aotriton/config.h.in include/aotriton)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/aotriton/config.h
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/aotriton)
+
 # Note for archive library user:
 # get this property with:
 #   get_property(ZSTD_INCLUDE_DIR TARGET zstd::libzstd_shared PROPERTY INTERFACE_INCLUDE_DIRECTORIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ option(AOTRITON_ENABLE_FP32_INPUTS "Enable FP32 support." ON)
 set(AOTRITON_GPU_BUILD_TIMEOUT "8.0" CACHE STRING "GPU kernel compiler times out after X minutes. 0 for indefinite. Highly recommended if AOTRITON_BUILD_FOR_TUNING=On.")
 set(TARGET_GPUS "MI200;MI300X;Navi31" CACHE STRING "Target Architecture (Note here uses Trade names)")
 
+# Early failure for python binding
+if(NOT AOTRITON_NO_PYTHON)
+  find_package(Python3 COMPONENTS Development REQUIRED)
+endif()
+
 # GPU kernel compression related options
 option(AOTRITON_COMPRESS_KERNEL "Enable GPU kernel compression with zstd. Fail when zstd is unavailable. Only effective for AOTriton API V2" ON)
 # option(AOTRITON_COMPRESS_KERNEL_STATIC_ZSTD "Use static zstd library to avoid potential zstd version conflict (e.g. pytorch)" OFF)
@@ -117,5 +122,5 @@ add_custom_target(aotriton_venv_triton ALL DEPENDS ${AOTRITON_TRITON_EGGLINK})
 add_subdirectory(v2src)
 
 if(NOT AOTRITON_NO_PYTHON)
-    add_subdirectory(bindings) # FIXME: compile python binding
+  add_subdirectory(bindings) # FIXME: compile python binding
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,13 @@
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(AOTriton CXX C)
+set(AOTRITON_MIN_PYTHON 3.8 CACHE STRING "Minimal Python version for find_package.")
+if(AOTRITON_MIN_PYTHON VERSION_LESS "3.8")
+  message(FATAL_ERROR "Do not set AOTRITON_MIN_PYTHON lower than 3.8. The code itself does not support it.")
+endif()
 
 add_subdirectory(third_party/pybind11)
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
+find_package(Python3 ${AOTRITON_MIN_PYTHON} COMPONENTS Interpreter REQUIRED)
 
 set(CMAKE_CXX_COMPILER hipcc)
 
@@ -22,7 +26,7 @@ set(TARGET_GPUS "MI200;MI300X;Navi31" CACHE STRING "Target Architecture (Note he
 
 # Early failure for python binding
 if(NOT AOTRITON_NO_PYTHON)
-  find_package(Python3 COMPONENTS Development REQUIRED)
+  find_package(Python3 ${AOTRITON_MIN_PYTHON} COMPONENTS Development REQUIRED)
 endif()
 
 # GPU kernel compression related options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ option(AOTRITON_COMPRESS_KERNEL "Enable GPU kernel compression with zstd. Fail w
 # option(AOTRITON_COMPRESS_KERNEL_STATIC_ZSTD "Use static zstd library to avoid potential zstd version conflict (e.g. pytorch)" OFF)
 
 # Resolve name conflicts with suffix
-set(AOTRITON_NAME_SUFFIX "" CACHE STRING "Add suffix to namespace and library file name. This is to resovle name conflicts with PyTorch's AOTriton during testing.")
+set(AOTRITON_NAME_SUFFIX "" CACHE STRING "Add suffix to namespace and library file name. This is to resolve name conflicts with PyTorch's AOTriton during testing.")
 if(AOTRITON_NAME_SUFFIX)
   set(AOTRITON_ENABLE_SUFFIX ON)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(AOTRITON_NAME_SUFFIX)
 else()
   set(AOTRITON_ENABLE_SUFFIX OFF)
 endif()
-configure_file(include/aotriton/config.h.in include/aotriton)
+configure_file(include/aotriton/config.h.in include/aotriton/config.h)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/aotriton/config.h
   DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/aotriton)
 

--- a/bindings/module.cc
+++ b/bindings/module.cc
@@ -1,7 +1,7 @@
 // Copyright © 2023-2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#include <aotriton/aotriton_config.h>
+#include <aotriton/config.h>
 #include <aotriton/dtypes.h>
 #include <aotriton/flash.h>
 #include <aotriton/runtime.h>

--- a/bindings/module.cc
+++ b/bindings/module.cc
@@ -1,6 +1,7 @@
 // Copyright © 2023-2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <aotriton/aotriton_config.h>
 #include <aotriton/dtypes.h>
 #include <aotriton/flash.h>
 #include <aotriton/runtime.h>
@@ -11,6 +12,9 @@
 #include <string>
 
 namespace py = pybind11;
+#if AOTRITON_ENABLE_SUFFIX
+namespace aotriton = AOTRITON_NS;
+#endif
 
 namespace pyaotriton {
   namespace v2 {

--- a/bindings/module.cc
+++ b/bindings/module.cc
@@ -221,6 +221,17 @@ namespace pyaotriton {
       .def_property_readonly("strides", &aotriton::TensorView<0>::strides)
       .def_property_readonly("data_ptr", &aotriton::TensorView<0>::data_ptr)
       .def_property_readonly("dtype", &aotriton::TensorView<0>::dtype);
+    m.def("get_name_suffix",
+#if AOTRITON_ENABLE_SUFFIX
+#define xstr(s) str(s)
+#define str(s) #s
+          []() -> std::string { return xstr(AOTRITON_NAME_SUFFIX); }
+#undef xstr
+#undef str
+#else
+          []() -> std::string { return ""; }
+#endif
+         );
     py::module_ mod_v2api = m.def_submodule("v2", "v2 API namespace");
     v2::setup_module(mod_v2api);
   }

--- a/include/aotriton/_internal/triton_kernel.h
+++ b/include/aotriton/_internal/triton_kernel.h
@@ -9,13 +9,14 @@
        "Inconsistent definition of this macro causes ABI incompatibility."
 #endif
 
+#include <aotriton_config.h>
 #include "../runtime.h"
 #include <vector>
 #include <unordered_map>
 #include <shared_mutex>
 #include <tuple>
 
-namespace aotriton {
+namespace AOTRITON_NS {
 
 class TritonKernel {
 public:

--- a/include/aotriton/_internal/triton_kernel.h
+++ b/include/aotriton/_internal/triton_kernel.h
@@ -9,7 +9,7 @@
        "Inconsistent definition of this macro causes ABI incompatibility."
 #endif
 
-#include <aotriton_config.h>
+#include <aotriton/config.h>
 #include "../runtime.h"
 #include <vector>
 #include <unordered_map>

--- a/include/aotriton/_internal/util.h
+++ b/include/aotriton/_internal/util.h
@@ -4,7 +4,7 @@
 #ifndef AOTRITON_V2_INTERNAL_UTIL_H
 #define AOTRITON_V2_INTERNAL_UTIL_H
 
-#include <aotriton_config.h>
+#include <aotriton/config.h>
 #include <climits>
 #include <cstdint>
 

--- a/include/aotriton/_internal/util.h
+++ b/include/aotriton/_internal/util.h
@@ -4,10 +4,11 @@
 #ifndef AOTRITON_V2_INTERNAL_UTIL_H
 #define AOTRITON_V2_INTERNAL_UTIL_H
 
+#include <aotriton_config.h>
 #include <climits>
 #include <cstdint>
 
-namespace aotriton {
+namespace AOTRITON_NS {
 
 inline uint32_t bit_width(uint32_t x) {
   if (x == 0)

--- a/include/aotriton/config.h.in
+++ b/include/aotriton/config.h.in
@@ -1,0 +1,17 @@
+// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef AOTRITON_V2_CONFIG_H
+#define AOTRITON_V2_CONFIG_H
+
+#cmakedefine01 AOTRITON_ENABLE_SUFFIX
+
+#if AOTRITON_ENABLE_SUFFIX
+#cmakedefine AOTRITON_NAME_SUFFIX @AOTRITON_NAME_SUFFIX@
+#define AOTRITON_NS aotriton@AOTRITON_NAME_SUFFIX@
+#else
+#define AOTRITON_NAME_SUFFIX
+#define AOTRITON_NS aotriton
+#endif
+
+#endif

--- a/include/aotriton/cpp_tune.h
+++ b/include/aotriton/cpp_tune.h
@@ -4,7 +4,7 @@
 #ifndef AOTRITON_V2_API_CPP_TUNE_H
 #define AOTRITON_V2_API_CPP_TUNE_H
 
-#include <aotriton_config.h>
+#include <aotriton/config.h>
 
 namespace AOTRITON_NS::v2 {
 

--- a/include/aotriton/cpp_tune.h
+++ b/include/aotriton/cpp_tune.h
@@ -4,7 +4,9 @@
 #ifndef AOTRITON_V2_API_CPP_TUNE_H
 #define AOTRITON_V2_API_CPP_TUNE_H
 
-namespace aotriton::v2 {
+#include <aotriton_config.h>
+
+namespace AOTRITON_NS::v2 {
 
 struct CppTune {
 #if AOTRITON_BUILD_FOR_TUNING

--- a/include/aotriton/dtypes.h
+++ b/include/aotriton/dtypes.h
@@ -4,9 +4,10 @@
 #ifndef AOTRITON_V2_API_DTYPES_H
 #define AOTRITON_V2_API_DTYPES_H
 
+#include <aotriton_config.h>
 #include <stdint.h>
 
-namespace aotriton {
+namespace AOTRITON_NS {
 
 enum DType : int32_t {
   kUnknown = 0,

--- a/include/aotriton/dtypes.h
+++ b/include/aotriton/dtypes.h
@@ -4,7 +4,7 @@
 #ifndef AOTRITON_V2_API_DTYPES_H
 #define AOTRITON_V2_API_DTYPES_H
 
-#include <aotriton_config.h>
+#include <aotriton/config.h>
 #include <stdint.h>
 
 namespace AOTRITON_NS {

--- a/include/aotriton/flash.h
+++ b/include/aotriton/flash.h
@@ -4,11 +4,12 @@
 #ifndef AOTRITON_V2_API_FLASH_ATTN_H
 #define AOTRITON_V2_API_FLASH_ATTN_H
 
+#include <aotriton_config.h>
 #include "runtime.h"
 #include "util.h"
 #include "cpp_tune.h"
 
-namespace aotriton::v2::flash {
+namespace AOTRITON_NS::v2::flash {
 
 hipError_t
 check_gpu(aotriton::Stream stream);

--- a/include/aotriton/flash.h
+++ b/include/aotriton/flash.h
@@ -4,7 +4,7 @@
 #ifndef AOTRITON_V2_API_FLASH_ATTN_H
 #define AOTRITON_V2_API_FLASH_ATTN_H
 
-#include <aotriton_config.h>
+#include <aotriton/config.h>
 #include "runtime.h"
 #include "util.h"
 #include "cpp_tune.h"
@@ -12,12 +12,12 @@
 namespace AOTRITON_NS::v2::flash {
 
 hipError_t
-check_gpu(aotriton::Stream stream);
+check_gpu(AOTRITON_NS::Stream stream);
 
-using T4 = aotriton::TensorView<4>;
-using T2 = aotriton::TensorView<2>;
-using T1 = aotriton::TensorView<1>;
-using T0 = aotriton::TensorView<0>;
+using T4 = AOTRITON_NS::TensorView<4>;
+using T2 = AOTRITON_NS::TensorView<2>;
+using T1 = AOTRITON_NS::TensorView<1>;
+using T0 = AOTRITON_NS::TensorView<0>;
 
 struct FwdExtraArguments : public CppTune {
 };
@@ -44,7 +44,7 @@ attn_fwd(T4 q, // batch_size x num_heads x seqlen_q x head_size
          T0 philox_offset_output,
          T4 encoded_softmax,
          bool is_causal,
-         aotriton::Stream stream,
+         AOTRITON_NS::Stream stream,
          FwdExtraArguments* extargs = nullptr);
 
 hipError_t
@@ -67,7 +67,7 @@ attn_fwd_compact_varlen(T4 q, // 1 x num_heads x total_q x head_size, total_q :=
                         T0 philox_offset_output,
                         T4 encoded_softmax,
                         bool is_causal,
-                        aotriton::Stream stream,
+                        AOTRITON_NS::Stream stream,
                         FwdExtraArguments* extargs = nullptr);
 
 hipError_t
@@ -89,7 +89,7 @@ attn_bwd(T4 q, // batch_size x num_heads x seqlen_q x head_size
          T0 philox_offset1,
          int64_t philox_offset2,
          bool is_causal,
-         aotriton::Stream stream,
+         AOTRITON_NS::Stream stream,
          BwdExtraArguments* extargs = nullptr);
 
 hipError_t
@@ -115,21 +115,21 @@ attn_bwd_compact_varlen(T4 q, // 1 x num_heads x total_q x head_size, total_q :=
                         T0 philox_offset1,
                         int64_t philox_offset2,
                         bool is_causal,
-                        aotriton::Stream stream,
+                        AOTRITON_NS::Stream stream,
                         BwdExtraArguments* extargs = nullptr);
 
 hipError_t
 debug_fill_dropout_rng(T4 r,
                        uint64_t philox_seed,
                        uint64_t philox_offset,
-                       aotriton::Stream stream);
+                       AOTRITON_NS::Stream stream);
 
 hipError_t
 debug_fill_dropout_rng_tensor(T4 r,
                               T0 philox_seed,
                               T0 philox_offset,
-                              aotriton::Stream stream);
+                              AOTRITON_NS::Stream stream);
 
-} // aotriton::v2::flash
+} // AOTRITON_NS::v2::flash
 
 #endif

--- a/include/aotriton/runtime.h
+++ b/include/aotriton/runtime.h
@@ -5,7 +5,7 @@
 #define AOTRITON_V2_API_RUNTIME_H
 
 #include <hip/hip_runtime.h>
-#include <aotriton_config.h>
+#include <aotriton/config.h>
 
 namespace AOTRITON_NS {
 

--- a/include/aotriton/runtime.h
+++ b/include/aotriton/runtime.h
@@ -5,8 +5,9 @@
 #define AOTRITON_V2_API_RUNTIME_H
 
 #include <hip/hip_runtime.h>
+#include <aotriton_config.h>
 
-namespace aotriton {
+namespace AOTRITON_NS {
 
 // This is not a class for stream management (at least for now), but a way to
 // make sure AOTriton APIs can have python bindings with pybind11

--- a/include/aotriton/util.h
+++ b/include/aotriton/util.h
@@ -4,7 +4,7 @@
 #ifndef AOTRITON_V2_API_UTIL_H
 #define AOTRITON_V2_API_UTIL_H
 
-#include <aotriton_config.h>
+#include <aotriton/config.h>
 #include "dtypes.h"
 #include "runtime.h"
 #include <functional>

--- a/include/aotriton/util.h
+++ b/include/aotriton/util.h
@@ -4,13 +4,14 @@
 #ifndef AOTRITON_V2_API_UTIL_H
 #define AOTRITON_V2_API_UTIL_H
 
+#include <aotriton_config.h>
 #include "dtypes.h"
 #include "runtime.h"
 #include <functional>
 #include <stdint.h>
 #include <string_view>
 
-namespace aotriton {
+namespace AOTRITON_NS {
 
 constexpr uint64_t
 CAT(uint32_t high, uint32_t low) {
@@ -155,6 +156,6 @@ extern template class TensorView<4>;
 
 GpuArch getArchFromStream(hipStream_t);
 
-} // namespace aotriton
+} // namespace AOTRITON_NS
 
 #endif

--- a/test/aotriton_flash.py
+++ b/test/aotriton_flash.py
@@ -10,7 +10,11 @@ from pyaotriton.v2.flash import (
     FwdExtraArguments,
     BwdExtraArguments,
 )
-from pyaotriton import T1, T2, T4, DType, Stream, hipError_t
+from pyaotriton import T1, T2, T4, DType, Stream, hipError_t, get_name_suffix
+assert get_name_suffix() != "", ("To run tests, AOTriton must be compiled with suffixes "
+                                 "by passing -DAOTRITON_NAME_SUFFIX=SOME_SUFFIX to cmake. "
+                                 "Otherwise the AOTriton in-development may have conflicts with "
+                                 "AOTriton shipped with PyTorch.")
 try:
     from pyaotriton import T0
     PASS_PHILOX_AS_TENSOR = True

--- a/v2python/generate_shim.py
+++ b/v2python/generate_shim.py
@@ -51,6 +51,7 @@ def parse():
     p.add_argument("--build_dir", type=str, default='build/', help="build directory")
     p.add_argument("--archive_only", action='store_true', help='Only generate archive library instead of shared library. No linking with dependencies.')
     p.add_argument("--enable_zstd", type=str, default=None, nargs='*', help="Use zstd to compress the compiled kernel")
+    p.add_argument("--library_suffix", type=str, default='', help="Add suffix to the library name 'aotriton' to avoid symbol conflicts")
     p.add_argument("--bare_mode", action='store_true', help="Instead of generating a proper Makefile, only generate a list of source files and leave the remaining tasks to cmake.")
     p.add_argument("--build_for_tuning", action='store_true', help="Include all GPU kernels in the dispatcher for performance tuning.")
     p.add_argument("--verbose", action='store_true', help="Print debugging messages")
@@ -354,7 +355,8 @@ class AutotuneCodeGenerator(MakefileSegmentGenerator):
         self.verbose('AutotuneCodeGenerator')
         # Write the code to file
         try:
-            self._ofn = self._lut.write_lut_source(self._outdir,
+            self._ofn = self._lut.write_lut_source(self._args.library_suffix,
+                                                   self._outdir,
                                                    compressed=self._args.enable_zstd is not None,
                                                    bare_mode=self.is_bare)
         except MissingLutEntry as e:

--- a/v2python/tuning_lut.py
+++ b/v2python/tuning_lut.py
@@ -167,7 +167,7 @@ class KernelTuningEntryForFunctionalOnGPU(object):
         ALIGN = ',\n' + 4 * ' '
         return ALIGN.join(kernel_image_perfs)
 
-    def write_lut_source(self, outdir : 'pathlib.Path', compressed, bare_mode):
+    def write_lut_source(self, library_suffix : str, outdir : 'pathlib.Path', compressed, bare_mode):
         gpu_kernel_image_dir = outdir.parent / f'gpu_kernel_image.{self._kdesc.SHIM_KERNEL_NAME}'
         lut_tensor, sigs = self.get_lut()
         try:
@@ -188,6 +188,7 @@ class KernelTuningEntryForFunctionalOnGPU(object):
             old_content = ''
         mf = io.StringIO()  # Memory File
         d = {
+            'library_suffix'        : library_suffix,
             'incbin_kernel_images'  : self.codegen_incbin_code(gpu_kernel_image_dir, compressed=compressed),
             'incbin_kernel_names'   : self.codegen_incbin_names(gpu_kernel_image_dir, compressed=compressed),
             'kernel_psels'          : self.codegen_kernel_psels(gpu_kernel_image_dir, compressed=compressed),

--- a/v2src/CMakeLists.txt
+++ b/v2src/CMakeLists.txt
@@ -178,7 +178,7 @@ else(AOTRITON_COMPRESS_KERNEL)
   target_compile_definitions(aotriton_v2 PRIVATE -DAOTRITON_USE_ZSTD=0)
 endif(AOTRITON_COMPRESS_KERNEL)
 target_include_directories(aotriton_v2 PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../include)
-target_include_directories(aotriton_v2 PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include/aotriton)
+target_include_directories(aotriton_v2 PUBLIC ${CMAKE_BINARY_DIR}/include)  # for <buid>/include/aotriton/config.h. Code should use <aotriton/config.h>
 target_include_directories(aotriton_v2 PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(aotriton_v2 PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../third_party/incbin)
 target_compile_options(aotriton_v2 PRIVATE -fPIC --no-offload-arch=all)
@@ -214,8 +214,10 @@ install(FILES "${AOTRITON_V2_BUILD_DIR}/${AOTRITON_LIBRARY_FILE}" DESTINATION ${
 
 # Python binding only available for AOTriton V2 API
 add_library(aotriton INTERFACE)
-add_dependencies(aotriton aotriton_v2)
+# add_dependencies(aotriton aotriton_v2)
 # target_link_libraries(aotriton INTERFACE ${CMAKE_INSTALL_PREFIX}/lib/libaotriton_v2.a)
 # target_include_directories(aotriton INTERFACE ${CMAKE_INSTALL_PREFIX}/include)
-target_link_libraries(aotriton INTERFACE ${AOTRITON_V2_BUILD_DIR}/${AOTRITON_LIBRARY_FILE})
-target_include_directories(aotriton INTERFACE ${CMAKE_CURRENT_SOURCE_PARENT_DIR}/include)
+# target_link_libraries(aotriton INTERFACE ${AOTRITON_V2_BUILD_DIR}/${AOTRITON_LIBRARY_FILE})
+# target_include_directories(aotriton INTERFACE ${CMAKE_CURRENT_SOURCE_PARENT_DIR}/include)
+# target_include_directories(aotriton INTERFACE ${CMAKE_CURRENT_SOURCE_PARENT_DIR}/include)
+target_link_libraries(aotriton INTERFACE aotriton_v2)

--- a/v2src/CMakeLists.txt
+++ b/v2src/CMakeLists.txt
@@ -139,6 +139,7 @@ execute_process(
   -E env VIRTUAL_ENV=${VENV_DIR}
   AOTRITON_ENABLE_FP32=${AOTRITON_ENABLE_FP32}
   "${VENV_DIR}/bin/python" -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} --bare_mode ${GENERATE_OPTION}
+  --library_suffix "${AOTRITON_NAME_SUFFIX}"
   COMMAND_ECHO STDOUT
   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/.."
   COMMAND_ERROR_IS_FATAL ANY
@@ -152,6 +153,7 @@ add_custom_target(aotriton_v2_gen_shim
   -E env VIRTUAL_ENV=${VENV_DIR}
   AOTRITON_ENABLE_FP32=${AOTRITON_ENABLE_FP32}
   "${VENV_DIR}/bin/python" -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} ${AOTRITON_SHIM_FLAGS} ${GENERATE_OPTION}
+  --library_suffix "${AOTRITON_NAME_SUFFIX}"
   BYPRODUCTS ${SHIM_CC_FILES}  # Essential, otherwise add_library complains
   COMMAND_EXPAND_LISTS
   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/.."
@@ -160,12 +162,15 @@ add_dependencies(aotriton_v2_gen_shim aotriton_v2_compile)
 
 if(AOTRITON_NO_SHARED)
   add_library(aotriton_v2 STATIC ${SHIM_CC_FILES})
-  set(AOTRITON_LIBRARY_FILE libaotriton_v2.a)
+  set(AOTRITON_LIBRARY_FILE libaotriton${AOTRITON_NAME_SUFFIX}_v2.a)
 else(AOTRITON_NO_SHARED)
   add_library(aotriton_v2 SHARED ${SHIM_CC_FILES})
-  set(AOTRITON_LIBRARY_FILE libaotriton_v2.so)
+  set(AOTRITON_LIBRARY_FILE libaotriton${AOTRITON_NAME_SUFFIX}_v2.so)
 endif(AOTRITON_NO_SHARED)
 add_dependencies(aotriton_v2 aotriton_v2_gen_shim)
+if(AOTRITON_ENABLE_SUFFIX)
+  set_target_properties(aotriton_v2 PROPERTIES OUTPUT_NAME "aotriton${AOTRITON_NAME_SUFFIX}_v2")
+endif()
 
 if(AOTRITON_COMPRESS_KERNEL)
   target_compile_definitions(aotriton_v2 PRIVATE -DAOTRITON_USE_ZSTD=1)
@@ -173,6 +178,7 @@ else(AOTRITON_COMPRESS_KERNEL)
   target_compile_definitions(aotriton_v2 PRIVATE -DAOTRITON_USE_ZSTD=0)
 endif(AOTRITON_COMPRESS_KERNEL)
 target_include_directories(aotriton_v2 PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../include)
+target_include_directories(aotriton_v2 PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include/aotriton)
 target_include_directories(aotriton_v2 PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(aotriton_v2 PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../third_party/incbin)
 target_compile_options(aotriton_v2 PRIVATE -fPIC --no-offload-arch=all)
@@ -196,7 +202,9 @@ endif(AOTRITON_COMPRESS_KERNEL)
 
 include(GNUInstallDirs)
 message("CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}")
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_PARENT_DIR}/include/aotriton" DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_PARENT_DIR}/include/aotriton"
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN "*.h")
 # A few considerations
 # 1. .so file is used for sanity check to ensure all symbols are resolved,
 #    but it will not be installed because .a is what you should use to avoid setting

--- a/v2src/CMakeLists.txt
+++ b/v2src/CMakeLists.txt
@@ -131,6 +131,9 @@ endif(AOTRITON_NO_SHARED)
 if(AOTRITON_COMPRESS_KERNEL)
     list(APPEND AOTRITON_SHIM_FLAGS "--enable_zstd" "${AOTRITON_ZSTD_INCLUDE}")
 endif()
+if(AOTRITON_NAME_SUFFIX)
+  list(APPEND AOTRITON_SHIM_FLAGS "--library_suffix" "${AOTRITON_NAME_SUFFIX}")
+endif()
 message(STATUS "AOTRITON_ZSTD_INCLUDE ${AOTRITON_ZSTD_INCLUDE}")
 message(STATUS "AOTRITON_SHIM_FLAGS ${AOTRITON_SHIM_FLAGS}")
 
@@ -139,7 +142,6 @@ execute_process(
   -E env VIRTUAL_ENV=${VENV_DIR}
   AOTRITON_ENABLE_FP32=${AOTRITON_ENABLE_FP32}
   "${VENV_DIR}/bin/python" -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} --bare_mode ${GENERATE_OPTION}
-  --library_suffix "${AOTRITON_NAME_SUFFIX}"
   COMMAND_ECHO STDOUT
   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/.."
   COMMAND_ERROR_IS_FATAL ANY
@@ -153,7 +155,6 @@ add_custom_target(aotriton_v2_gen_shim
   -E env VIRTUAL_ENV=${VENV_DIR}
   AOTRITON_ENABLE_FP32=${AOTRITON_ENABLE_FP32}
   "${VENV_DIR}/bin/python" -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} ${AOTRITON_SHIM_FLAGS} ${GENERATE_OPTION}
-  --library_suffix "${AOTRITON_NAME_SUFFIX}"
   BYPRODUCTS ${SHIM_CC_FILES}  # Essential, otherwise add_library complains
   COMMAND_EXPAND_LISTS
   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/.."

--- a/v2src/flash/attn_bwd.cc
+++ b/v2src/flash/attn_bwd.cc
@@ -1,6 +1,7 @@
 // Copyright © 2023-2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <aotriton/config.h>
 #include <aotriton/_internal/util.h>
 #include <aotriton/flash.h>
 #include <aotriton/util.h>
@@ -10,16 +11,16 @@
 #include <flash/shim.bwd_preprocess_varlen.h>
 #include <iostream>
 
-namespace aotriton::v2::flash {
+namespace AOTRITON_NS::v2::flash {
 
 hipError_t
-bwd_preprocess(T4 out, T4 dout, T2 delta, aotriton::Stream stream_wrap) {
+bwd_preprocess(T4 out, T4 dout, T2 delta, AOTRITON_NS::Stream stream_wrap) {
   hipError_t err;
   auto stream = stream_wrap.native();
   auto arch = getArchFromStream(stream);
   auto grid_calculator = [](const BwdPreprocessParams& params) -> dim3 {
     dim3 grid {
-      aotriton::cdiv<uint32_t>(params.Out->size(2), params.BLOCK_M),
+      AOTRITON_NS::cdiv<uint32_t>(params.Out->size(2), params.BLOCK_M),
       uint32_t(params.Out->size(1)),
       uint32_t(params.Out->size(0)),
     };
@@ -57,13 +58,13 @@ bwd_preprocess_varlen(T4 out,
                       T2 delta,
                       T1 cu_seqlens_q,
                       int32_t max_seqlen_q,
-                      aotriton::Stream stream_wrap) {
+                      AOTRITON_NS::Stream stream_wrap) {
   hipError_t err;
   auto stream = stream_wrap.native();
   auto arch = getArchFromStream(stream);
   auto grid_calculator = [](const BwdPreprocessVarlenParams& params) -> dim3 {
     dim3 grid {
-      aotriton::cdiv<uint32_t>(params.Out->size(2), params.BLOCK_M),
+      AOTRITON_NS::cdiv<uint32_t>(params.Out->size(2), params.BLOCK_M),
       uint32_t(params.Out->size(1)),
       uint32_t(params.cu_seqlens_q->size(0) - 1),
     };
@@ -118,14 +119,14 @@ bwd_kernel_dk_dv(T4 q,
                  T0 philox_offset1,
                  int64_t philox_offset2,
                  bool is_causal,
-                 aotriton::Stream stream_wrap,
+                 AOTRITON_NS::Stream stream_wrap,
                  BwdExtraArguments* extargs) {
   hipError_t err;
   auto stream = stream_wrap.native();
   auto arch = getArchFromStream(stream);
   auto grid_calculator = [max_seqlen_k](const BwdKernelDkDvParams& params) -> dim3 {
     dim3 grid {
-      aotriton::cdiv<uint32_t>(max_seqlen_k, params.BLOCK_N),
+      AOTRITON_NS::cdiv<uint32_t>(max_seqlen_k, params.BLOCK_N),
       uint32_t(params.Q->size(1)),
       params.num_seqlens == 0 ? uint32_t(params.Q->size(0)) : params.num_seqlens,
     };
@@ -215,14 +216,14 @@ bwd_kernel_dq(T4 q,
               T0 philox_offset1,
               int64_t philox_offset2,
               bool is_causal,
-              aotriton::Stream stream_wrap,
+              AOTRITON_NS::Stream stream_wrap,
               BwdExtraArguments* extargs) {
   hipError_t err;
   auto stream = stream_wrap.native();
   auto arch = getArchFromStream(stream);
   auto grid_calculator = [num_seqlens, max_seqlen_q](const BwdKernelDqParams& params) -> dim3 {
     dim3 grid {
-      aotriton::cdiv<uint32_t>(max_seqlen_q, params.BLOCK_M),
+      AOTRITON_NS::cdiv<uint32_t>(max_seqlen_q, params.BLOCK_M),
       uint32_t(params.Q->size(1)),
       params.num_seqlens == 0 ? uint32_t(params.Q->size(0)) : params.num_seqlens,
     };
@@ -315,7 +316,7 @@ _attn_bwd_common(T4 q,
                  T0 philox_offset1,
                  int64_t philox_offset2,
                  bool is_causal,
-                 aotriton::Stream stream,
+                 AOTRITON_NS::Stream stream,
                  BwdExtraArguments* extargs) {
   hipError_t ret;
   if (num_seqlens == 0)
@@ -395,7 +396,7 @@ attn_bwd(T4 q,
          T0 philox_offset1,
          int64_t philox_offset2,
          bool is_causal,
-         aotriton::Stream stream,
+         AOTRITON_NS::Stream stream,
          BwdExtraArguments* extargs) {
   auto null_t1 = T1::get_null_tensor(DType::kInt32);
   return _attn_bwd_common(q,
@@ -448,7 +449,7 @@ attn_bwd_compact_varlen(T4 q,            // 1 x num_heads x total_q x head_size,
                         T0 philox_offset1,
                         int64_t philox_offset2,
                         bool is_causal,
-                        aotriton::Stream stream,
+                        AOTRITON_NS::Stream stream,
                         BwdExtraArguments* extargs) {
   return _attn_bwd_common(q,
                           k,

--- a/v2src/flash/attn_check.cc
+++ b/v2src/flash/attn_check.cc
@@ -1,6 +1,7 @@
 // Copyright © 2023-2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <aotriton/config.h>
 #include <aotriton/flash.h>
 #include <aotriton/runtime.h>
 #include <aotriton/util.h>
@@ -10,10 +11,10 @@
 #include <flash/shim.bwd_preprocess.h>
 #include <iostream>
 
-namespace aotriton::v2::flash {
+namespace AOTRITON_NS::v2::flash {
 
 hipError_t
-check_gpu(aotriton::Stream stream_wrap) {
+check_gpu(AOTRITON_NS::Stream stream_wrap) {
   auto stream = stream_wrap.native();
   auto arch = getArchFromStream(stream);
   if (AttnFwdContext::get_arch_number(arch) < 0 || BwdPreprocessContext::get_arch_number(arch) < 0 ||

--- a/v2src/flash/attn_debug.cc
+++ b/v2src/flash/attn_debug.cc
@@ -1,22 +1,23 @@
 // Copyright © 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <aotriton/config.h>
 #include <aotriton/_internal/util.h>
 #include <aotriton/flash.h>
 #include <aotriton/util.h>
 #include <flash/shim.debug_fill_dropout_rng.h>
 #include <flash/shim.debug_fill_dropout_rng_tensor.h>
 
-namespace aotriton::v2::flash {
+namespace AOTRITON_NS::v2::flash {
 
 hipError_t
-debug_fill_dropout_rng_tensor(T4 r, T0 philox_seed, T0 philox_offset, aotriton::Stream stream_wrap) {
+debug_fill_dropout_rng_tensor(T4 r, T0 philox_seed, T0 philox_offset, AOTRITON_NS::Stream stream_wrap) {
   hipError_t err;
   auto stream = stream_wrap.native();
   auto arch = getArchFromStream(stream);
   auto grid_calculator = [](const DebugFillDropoutRngTensorParams& params) -> dim3 {
     dim3 grid {
-      aotriton::cdiv<uint32_t>(params.R->size(2), params.BLOCK_M),
+      AOTRITON_NS::cdiv<uint32_t>(params.R->size(2), params.BLOCK_M),
       uint32_t(params.R->size(1)),
       uint32_t(params.R->size(0)),
     };
@@ -43,13 +44,13 @@ debug_fill_dropout_rng_tensor(T4 r, T0 philox_seed, T0 philox_offset, aotriton::
 }
 
 hipError_t
-debug_fill_dropout_rng(T4 r, uint64_t philox_seed, uint64_t philox_offset, aotriton::Stream stream_wrap) {
+debug_fill_dropout_rng(T4 r, uint64_t philox_seed, uint64_t philox_offset, AOTRITON_NS::Stream stream_wrap) {
   hipError_t err;
   auto stream = stream_wrap.native();
   auto arch = getArchFromStream(stream);
   auto grid_calculator = [](const DebugFillDropoutRngParams& params) -> dim3 {
     dim3 grid {
-      aotriton::cdiv<uint32_t>(params.R->size(2), params.BLOCK_M),
+      AOTRITON_NS::cdiv<uint32_t>(params.R->size(2), params.BLOCK_M),
       uint32_t(params.R->size(1)),
       uint32_t(params.R->size(0)),
     };

--- a/v2src/flash/attn_fwd.cc
+++ b/v2src/flash/attn_fwd.cc
@@ -1,6 +1,7 @@
 // Copyright © 2023-2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include <aotriton/config.h>
 #include <aotriton/_internal/util.h>
 #include <aotriton/flash.h>
 #include <aotriton/util.h>
@@ -13,7 +14,7 @@
 #define AOTRITON_VERBOSE 1
 #endif
 
-namespace aotriton::v2::flash {
+namespace AOTRITON_NS::v2::flash {
 
 hipError_t
 _attn_fwd_common(T4 q,
@@ -36,7 +37,7 @@ _attn_fwd_common(T4 q,
                  T0 philox_offset_output,
                  T4 encoded_softmax,
                  bool is_causal,
-                 aotriton::Stream stream_wrap,
+                 AOTRITON_NS::Stream stream_wrap,
                  FwdExtraArguments* extargs) {
   hipError_t err;
   auto stream = stream_wrap.native();
@@ -48,7 +49,7 @@ _attn_fwd_common(T4 q,
               << " pre_load_v = " << params.pre_load_v << std::endl;
 #endif
     dim3 grid {
-      aotriton::cdiv<uint32_t>(params.max_seqlen_q, params.BLOCK_M),
+      AOTRITON_NS::cdiv<uint32_t>(params.max_seqlen_q, params.BLOCK_M),
       uint32_t(params.Q->size(1)),
       params.num_seqlens == 0 ? uint32_t(params.Q->size(0)) : params.num_seqlens,
     };
@@ -60,7 +61,7 @@ _attn_fwd_common(T4 q,
   int head_size = q.size(3);
   int num_head_q = q.size(1);
   int num_head_k = k.size(1);
-  int head_dim_rounded = std::max<int>(16, aotriton::bit_ceil(head_size));
+  int head_dim_rounded = std::max<int>(16, AOTRITON_NS::bit_ceil(head_size));
   int bias_type = 0;
   if (b) {
     bias_type = 1;
@@ -137,7 +138,7 @@ attn_fwd(T4 q,
          T0 philox_offset_output,
          T4 encoded_softmax,
          bool is_causal,
-         aotriton::Stream stream_wrap,
+         AOTRITON_NS::Stream stream_wrap,
          FwdExtraArguments* extargs) {
   auto null_t1 = T1::get_null_tensor(DType::kInt32);
   return _attn_fwd_common(q,
@@ -184,7 +185,7 @@ attn_fwd_compact_varlen(T4 q,            // 1 x num_heads x total_q x head_size,
                         T0 philox_offset_output,
                         T4 encoded_softmax,
                         bool is_causal,
-                        aotriton::Stream stream_wrap,
+                        AOTRITON_NS::Stream stream_wrap,
                         FwdExtraArguments* extargs) {
   return _attn_fwd_common(q,
                           k,

--- a/v2src/template/autotune_table_entry.cc
+++ b/v2src/template/autotune_table_entry.cc
@@ -5,8 +5,8 @@
 #define INCBIN_PREFIX g_aotriton_FAMILY_[[kernel_family_name]]_KERNEL_[[shim_kernel_name]]_GPU_[[gpu]]_
 #define INCBIN_STYLE INCBIN_STYLE_SNAKE
 
-#define mangle(x) g_aotriton_FAMILY_[[kernel_family_name]]_KERNEL_[[shim_kernel_name]]_GPU_[[gpu]]_ ## x ## _data
-#define smangle(x) g_aotriton_FAMILY_[[kernel_family_name]]_KERNEL_[[shim_kernel_name]]_GPU_[[gpu]]_ ## x ## _size
+#define mangle(x) g_aotriton[[library_suffix]]_FAMILY_[[kernel_family_name]]_KERNEL_[[shim_kernel_name]]_GPU_[[gpu]]_ ## x ## _data
+#define smangle(x) g_aotriton[[library_suffix]]_FAMILY_[[kernel_family_name]]_KERNEL_[[shim_kernel_name]]_GPU_[[gpu]]_ ## x ## _size
 
 #include "../shim.[[shim_kernel_name]].h"
 #include <aotriton/_internal/triton_kernel.h>
@@ -45,7 +45,7 @@ PerfFields image_perf_list [] = {
     [[kernel_image_perfs]]
 };
 
-aotriton::TritonKernel image_list [] = {
+AOTRITON_NS::TritonKernel image_list [] = {
     [[kernel_image_objects]]
 };
 
@@ -53,9 +53,9 @@ aotriton::TritonKernel image_list [] = {
 
 }; // End of anonymous namespace
 
-namespace aotriton::v2::[[kernel_family_name]]::autotune {
+namespace AOTRITON_NS::v2::[[kernel_family_name]]::autotune {
 
-// using aotriton::v2::[[kernel_family_name]]::[[param_class_name]];
+// using AOTRITON_NS::v2::[[kernel_family_name]]::[[param_class_name]];
 
 void CURRENT_ENTRY_PUBLIC::operator()([[param_class_name]]& params) {
 #if AOTRITON_BUILD_FOR_TUNING

--- a/v2src/template/autotune_table_entry.cc
+++ b/v2src/template/autotune_table_entry.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // clang-format off
-#define INCBIN_PREFIX g_aotriton_FAMILY_[[kernel_family_name]]_KERNEL_[[shim_kernel_name]]_GPU_[[gpu]]_
+#define INCBIN_PREFIX g_aotriton[[library_suffix]]_FAMILY_[[kernel_family_name]]_KERNEL_[[shim_kernel_name]]_GPU_[[gpu]]_
 #define INCBIN_STYLE INCBIN_STYLE_SNAKE
 
 #define mangle(x) g_aotriton[[library_suffix]]_FAMILY_[[kernel_family_name]]_KERNEL_[[shim_kernel_name]]_GPU_[[gpu]]_ ## x ## _data

--- a/v2src/template/shim.cc
+++ b/v2src/template/shim.cc
@@ -5,7 +5,7 @@
 #include "shim.[[shim_kernel_name]].h"
 #include <aotriton/util.h>
 
-namespace aotriton::v2::[[kernel_family_name]] {
+namespace AOTRITON_NS::v2::[[kernel_family_name]] {
 
 int64_t [[param_class_name]]::godel_number() const
 {

--- a/v2src/template/shim.h
+++ b/v2src/template/shim.h
@@ -3,6 +3,8 @@
 
 // clang-format off
 #pragma once
+
+#include <aotriton/config.h>
 #include <aotriton/_internal/triton_kernel.h>
 #include <aotriton/dtypes.h>
 #include <aotriton/flash.h>
@@ -10,7 +12,7 @@
 #include <functional>
 #include <string>
 
-namespace aotriton::v2::[[kernel_family_name]] {
+namespace AOTRITON_NS::v2::[[kernel_family_name]] {
 
 struct [[param_class_name]] {
     // Function related arguments
@@ -47,7 +49,7 @@ private:
 
 namespace autotune {
 
-using aotriton::v2::[[kernel_family_name]]::[[param_class_name]];
+using AOTRITON_NS::v2::[[kernel_family_name]]::[[param_class_name]];
 
 [[kernel_table_entry_declares]]
 

--- a/v2src/triton_kernel.cc
+++ b/v2src/triton_kernel.cc
@@ -23,7 +23,7 @@
       throw std::runtime_error("FAILURE at Line " INCBIN_STRINGIZE(__LINE__));                               \
   } while (0)
 
-namespace aotriton {
+namespace AOTRITON_NS {
 
 TritonKernel::DeviceFunction::DeviceFunction(int device_id_, hipModule_t mod_, hipFunction_t func_)
   : device_id(device_id_)

--- a/v2src/util.cc
+++ b/v2src/util.cc
@@ -5,7 +5,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace aotriton {
+namespace AOTRITON_NS {
 
 struct LazyArch {
   LazyArch(hipDevice_t dev)
@@ -51,4 +51,4 @@ template class TensorView<2>;
 template class TensorView<3>;
 template class TensorView<4>;
 
-} // namespace aotriton
+} // namespace AOTRITON_NS


### PR DESCRIPTION
This adds suffix to namespace `aotriton` and the library file prefix `libaotriton`. For example, build with `-DAOTRITON_NAME_SUFFIX=123` will generate the library with `namespace aotrition123` and `libaotriton123_v2.so`.

This is to address potential name conflicts with PyTorch since PyTorch will bundle AOTriton shared library starting 2.4+