### PR TITLE
libaotriton_v2.so: Fix 'argument list too long" error

### DIFF
--- a/v2python/generate_shim.py
+++ b/v2python/generate_shim.py
@@ -229,7 +229,7 @@ class ShimMakefileGenerator(MakefileGenerator):
                 print('\t', '${AR} -r ', fn, '@ar.txt', file=f)
                 print(all_object_files, file=self._arf)
             if s == '.so':
-                print('\t', COMPILER, ' -g -shared -fPIC -o ', fn, all_object_files, file=f)
+                print('\t', COMPILER, ' -g -shared -fPIC -o ', fn, ' @ar.txt', file=f)
             print('\n\n', file=f)
 
     '''


### PR DESCRIPTION
This error is output when building the libaotriton_v2.so:

make: /bin/sh: Argument list too long
make: *** [Makefile.shim:7976: libaotriton_v2.so] Error 127
make: *** Waiting for unfinished jobs....

This can be resolved by using the ar.txt file that contains a list of the object files instead of adding them individually as arguments.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>