### PR TITLE
Restore the support of causal=True and seqlen_q != seqlen_k

### DIFF
--- a/test/mptune/flash/tuner.py
+++ b/test/mptune/flash/tuner.py
@@ -85,8 +85,6 @@ class TunerService(BaseTunerService):
                 raise PEE(request.make_skip(self.monad, 'Navi kernels triggers "MES failed to response msg=" kernel error when handling large inputs.'))
         if seqlen_q > 4096 and seqlen_k > 4096:
             N_HEADS = 1
-        if causal and seqlen_q != seqlen_k:
-            raise PEE(request.make_skip(self.monad, 'FA does not support accept casual=True when seqlen_q != seqlen_k.'))
         if causal and bias_type != 0:
             raise PEE(request.make_skip(self.monad, 'FA does not support accept casual=True when bias_type != 0.'))
         if a.dry_run:

--- a/test/test_backward.py
+++ b/test/test_backward.py
@@ -44,8 +44,6 @@ but in PyTorch API it does not present at all
 '''
 
 def _do_test_op_bwd(BATCH, N_HEADS, D_HEAD, seqlen_q, seqlen_k, causal, sm_scale, dropout_p, dtype, storage_flip, bias_type):
-    if causal and seqlen_q != seqlen_k:
-        pytest.skip("PyTorch's Flash V2 does not accept casual=True when seqlen_q != seqlen_k. Skipping")
     if causal and bias_type is not None:
         pytest.skip("_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True")
     # if BATCH > 1 and seqlen_q >= 1024 and seqlen_k >= 1024:

--- a/test/test_forward.py
+++ b/test/test_forward.py
@@ -30,8 +30,6 @@ but in PyTorch API it does not present at all
 '''
 
 def _do_test_op_fwd(BATCH, N_HEADS, D_HEAD, seqlen_q, seqlen_k, causal, sm_scale, dropout_p, dtype, storage_flip, bias_type):
-    if causal and seqlen_q != seqlen_k:
-        pytest.skip("PyTorch's Flash V2 does not accept casual=True when seqlen_q != seqlen_k. Skipping")
     if causal and bias_type is not None:
         pytest.skip("_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True")
     # if BATCH > 1 and seqlen_q >= 1024 and seqlen_k >= 1024:

--- a/test/test_varlen.py
+++ b/test/test_varlen.py
@@ -26,8 +26,6 @@ def rng_seqlens(n_seqlen):
 
 def _do_test_varlen(N_HEADS, D_HEAD, seqlens_q, seqlens_k, causal, sm_scale, dropout_p, dtype):
     import numpy as np
-    if causal and not np.allclose(seqlens_q, seqlens_k):
-        pytest.skip("PyTorch's Flash V2 does not accept casual=True when seqlen_q != seqlen_k. Skipping")
     # Data creation
     SKIP_DK_DV = False
     SKIP_DQ = False

--- a/tritonsrc/_common_backward.py
+++ b/tritonsrc/_common_backward.py
@@ -41,14 +41,20 @@ def _do_test_op_bwd(BATCH, N_HEADS, D_HEAD, seqlen_q, seqlen_k, causal, sm_scale
     q, k, v, b = ctx.dev_tensors
     # autotune = True
     # # triton implementation
-    ext = AttentionExtraArgs(return_encoded_softmax=dropout_p > 0.0,
+    ext = AttentionExtraArgs(return_encoded_softmax=True, #dropout_p > 0.0,
                              autotune=False,
                              return_autotune=False,
                              fillnan=True)
     tri_out, encoded_softmax, _ = attention(q, k, v, b, causal, sm_scale, dropout_p, ext)
+    print(f'{encoded_softmax=}')
+    print(f'{encoded_softmax.shape=}')
+    print(f'{v=}')
+    print(f'{v.shape=}')
+    print(f'{tri_out.shape=}')
     dropout_mask = encoded_softmax >= 0 if dropout_p > 0.0 else None
     sdpa_params = SdpaParams(causal=causal, sm_scale=sm_scale, dropout_p=dropout_p, dropout_mask=dropout_mask)
     ref_out, _ = ctx.compute_ref_forward(sdpa_params)
+    print(f'{ref_out.shape=}')
     dout = torch.rand_like(tri_out)
     ctx.compute_backward(tri_out, dout)
     is_allclose, adiff, grads_allclose, grads_adiff = ctx.validate_with_reference(tri_out, ctx.dout_tensors)

--- a/tritonsrc/_common_backward.py
+++ b/tritonsrc/_common_backward.py
@@ -23,8 +23,6 @@ but in PyTorch API it does not present at all
 '''
 
 def _do_test_op_bwd(BATCH, N_HEADS, D_HEAD, seqlen_q, seqlen_k, causal, sm_scale, dropout_p, dtype, storage_flip, bias_type):
-    if causal and seqlen_q != seqlen_k:
-        pytest.skip("PyTorch's Flash V2 does not accept casual=True when seqlen_q != seqlen_k. Skipping")
     if causal and bias_type is not None:
         pytest.skip("_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True")
     SKIP_DK_DV = False

--- a/tritonsrc/bwd_kernel_dk_dv.py
+++ b/tritonsrc/bwd_kernel_dk_dv.py
@@ -99,12 +99,6 @@ def bwd_kernel_dk_dv(
         cu_seqlens_k_start = 0
         batch_index = off_z
 
-    # Still need early exit in GPU kernel to support varlen
-    if CAUSAL:
-        # TODO: bottom right causal and windowed
-        if start_k > seqlen_q:
-            return
-
     # Initialize pointers to Q, K, V
     # Q is consumed depending on block ID. Every block uses
     # previous block offset by BLOCK_M x D_HEAD.

--- a/tritonsrc/bwd_kernel_dq.py
+++ b/tritonsrc/bwd_kernel_dq.py
@@ -201,7 +201,7 @@ def bwd_kernel_dq(
     else:
         tl.static_assert(False, f'Unsupported BIAS_TYPE {BIAS_TYPE}')
 
-    k_lo = 0
+    k_lo = 0  # reserved for windowed attention
     k_hi = min(start_q + BLOCK_M, seqlen_k) if CAUSAL else seqlen_k
     real_seqlen_k = k_hi - k_lo  # seqlen_q after considering causal (and windowed in the future)
     n_blocks = tl.cdiv(k_hi - k_lo, BLOCK_N)
@@ -211,6 +211,7 @@ def bwd_kernel_dq(
     elif real_seqlen_k % BLOCK_N:
         n_extra_tokens = real_seqlen_k % BLOCK_N
     is_irregular_k = n_extra_tokens != 0
+    n_full_blocks = (k_hi - k_lo) // BLOCK_N
     leading_masked_blocks = 0  # TODO: Windowed attention
     trailing_masked_blocks = 0
     # For causal masks, actually it is easier to calculate the full blocks and
@@ -218,11 +219,11 @@ def bwd_kernel_dq(
     # windowed masks. Therefore we still derive n_full_blocks from
     # trailing_masked_blocks for long term stability.
     if CAUSAL:
-        mask_top_edge = start_q
-        # For DQ, each CU compute along K/V direction
-        # Thus no leading masked blocks while trailing masked blocks comes from
-        # the diagnoal cutting line from causal masks
-        trailing_masked_blocks = tl.cdiv(k_hi - mask_top_edge // BLOCK_N * BLOCK_N, BLOCK_N)
+        # TODO: Botton right variant
+        # Top left variant
+        mask_top_edge = min(start_q, seqlen_k)
+        n_full_blocks = (mask_top_edge - k_lo) // BLOCK_N
+        trailing_masked_blocks = n_blocks - n_full_blocks
     else:
         trailing_masked_blocks = 1 if is_irregular_k else 0
 
@@ -233,7 +234,6 @@ def bwd_kernel_dq(
     l_i = tl.load(l_ptrs + offs_q, mask=d_lse_ptrs_mask, other=0.0)
 
     dq = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
-    n_full_blocks = n_blocks - leading_masked_blocks - trailing_masked_blocks
     if n_full_blocks > 0:
         lo = 0
         hi = n_full_blocks * BLOCK_N

--- a/tritonsrc/bwd_kernel_dq.py
+++ b/tritonsrc/bwd_kernel_dq.py
@@ -99,12 +99,6 @@ def bwd_kernel_dq(
         cu_seqlens_k_start = 0
         batch_index = off_z
 
-    # Still need early exit in GPU kernel to support varlen
-    if CAUSAL:
-        # TODO: bottom right causal and windowed
-        if start_q > seqlen_k:
-            return
-
     # Initialize pointers to Q, K, V
     q_offset = off_h_q * stride_qh + batch_index * stride_qz + cu_seqlens_q_start * stride_qm
     Q += q_offset

--- a/tritonsrc/fwd_kernel.py
+++ b/tritonsrc/fwd_kernel.py
@@ -307,6 +307,7 @@ def attn_fwd(
             out_ptrs_mask = mask_m_offsets[:, None] >= out_mask_boundary[None, :]
             z = 0.0
             acc = tl.where(out_ptrs_mask, acc, z.to(acc.type.element_ty))
+    tl.device_print('outer acc after CAUSAL: ', acc)
     # FIXME: MQA/GQA L tensor
     # TODO: make writing of L optional
     # write back LSE

--- a/tritonsrc/fwd_kernel_inner.py
+++ b/tritonsrc/fwd_kernel_inner.py
@@ -117,7 +117,10 @@ def attn_fwd_inner(
                 # tl.store(encoded_sm_ptrs, tl.where(keep, p, -p).to(q.type.element_ty))
             p = tl.where(keep, p, 0.0)
         elif RETURN_ENCODED_SOFTMAX:
+            causal_boundary = start_n + offs_n_causal
+            causal_mask = offs_m[:, None] >= causal_boundary[None, :]
             mstore2d(p.to(q.type.element_ty),
+                     # causal_mask.to(q.type.element_ty),
                      BLOCK_M,
                      BLOCK_N,
                      o_base=encoded_sm_base,
@@ -130,13 +133,20 @@ def attn_fwd_inner(
             # tl.store(encoded_sm_ptrs, p.to(q.type.element_ty))
         # -- update output accumulator --
         alpha = tl.math.exp2(m_i - m_ij)
+        # tl.device_print('alpha: ', alpha)
         acc = acc * alpha[:, None]
+        # tl.debug_barrier()
+        # tl.device_print('acc: ', acc)
         if not PRE_LOAD_V:
             v = load_fn(v_ptrs, k_offs_n, k_offs_d, seqlen_k, head_dim)
         # -- update m_i and l_i
         l_i = l_i * alpha + l_ij
         # update m_i and l_i
         m_i = m_ij
+        # tl.device_print('v: ', v)
+        # tl.debug_barrier()
+        # delta = tl.dot(p.to(v.type.element_ty), v)
+        # tl.device_print('delta: ', delta)
         acc += tl.dot(p.to(v.type.element_ty), v)
         k_ptrs += BLOCK_N * stride_kn
         v_ptrs += BLOCK_N * stride_vk
@@ -144,4 +154,5 @@ def attn_fwd_inner(
             bias_ptrs += BLOCK_N * stride_bn
         # if RETURN_ENCODED_SOFTMAX:
         #     encoded_sm_ptrs += BLOCK_N
+        # tl.device_print('inner acc: ', acc)
     return acc, l_i, m_i

--- a/tritonsrc/test_backward.py
+++ b/tritonsrc/test_backward.py
@@ -175,14 +175,14 @@ def main():
 
 def main_nsq_causal():
     BATCH = 1
-    D_HEAD = 1
+    N_HEADS = 1
+    D_HEAD = 8
     '''
     N_HEADS = 2
     seqlens_q = 6432
     seqlens_k = 6432
     '''
-    N_HEADS = 1
-    seqlen_q = 2
+    seqlen_q = 8
     seqlen_k = 4
     causal = True
     sm_scale = 1.2

--- a/tritonsrc/test_backward.py
+++ b/tritonsrc/test_backward.py
@@ -173,6 +173,25 @@ def main():
     dtype = torch.bfloat16
     _do_test_op_bwd(BATCH, N_HEADS, D_HEAD, seqlen_q, seqlen_k, causal, sm_scale, dropout_p, dtype, storage_flip, bias_type)
 
+def main_nsq_causal():
+    BATCH = 1
+    D_HEAD = 1
+    '''
+    N_HEADS = 2
+    seqlens_q = 6432
+    seqlens_k = 6432
+    '''
+    N_HEADS = 1
+    seqlen_q = 2
+    seqlen_k = 4
+    causal = True
+    sm_scale = 1.2
+    dropout_p = 0.0
+    dtype = torch.float16
+    storage_flip = False
+    bias_type = None
+    _do_test_op_bwd(BATCH, N_HEADS, D_HEAD, seqlen_q, seqlen_k, causal, sm_scale, dropout_p, dtype, storage_flip, bias_type)
+
 if __name__ == '__main__':
-    # main3()
-    main_npz()
+    main_nsq_causal()
+    # main_npz()

--- a/tritonsrc/test_backward.py
+++ b/tritonsrc/test_backward.py
@@ -175,14 +175,14 @@ def main():
 
 def main_nsq_causal():
     BATCH = 1
-    N_HEADS = 1
-    D_HEAD = 8
+    D_HEAD = 1
     '''
     N_HEADS = 2
     seqlens_q = 6432
     seqlens_k = 6432
     '''
-    seqlen_q = 8
+    N_HEADS = 1
+    seqlen_q = 2
     seqlen_k = 4
     causal = True
     sm_scale = 1.2

--- a/tritonsrc/test_forward.py
+++ b/tritonsrc/test_forward.py
@@ -71,8 +71,6 @@ class FwdTester(object):
         self.use_fill_rng_for_dropout = False
 
     def do_test_op_fwd(self, BATCH, N_HEADS, D_HEAD, seqlen_q, seqlen_k, causal, sm_scale, dropout_p, dtype, storage_flip, bias_type):
-        if causal and seqlen_q != seqlen_k:
-            pytest.skip("PyTorch's Flash V2 does not accept casual=True when seqlen_q != seqlen_k. Skipping")
         if causal and bias_type is not None:
             pytest.skip("_scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True")
         torch.manual_seed(20)

--- a/tritonsrc/test_varlen.py
+++ b/tritonsrc/test_varlen.py
@@ -26,8 +26,6 @@ def rng_seqlens(n_seqlen):
 
 def _do_test_varlen(N_HEADS, D_HEAD, seqlens_q, seqlens_k, causal, sm_scale, dropout_p, dtype):
     import numpy as np
-    if causal and not np.allclose(seqlens_q, seqlens_k):
-        pytest.skip("PyTorch's Flash V2 does not accept casual=True when seqlen_q != seqlen_k. Skipping")
     # Data creation
     SKIP_DK_DV = False
     SKIP_DQ = False

--- a/v2python/generate_shim.py
+++ b/v2python/generate_shim.py
@@ -347,6 +347,7 @@ class AutotuneCodeGenerator(MakefileSegmentGenerator):
 
     def write_body(self):
         self.verbose('AutotuneCodeGenerator')
+        do_raise = None
         # Write the code to file
         try:
             self._ofn = self._lut.write_lut_source(self._args.library_suffix,
@@ -354,9 +355,10 @@ class AutotuneCodeGenerator(MakefileSegmentGenerator):
                                                    bare_mode=self.is_bare,
                                                    noimage_mode=self._args.noimage_mode)
         except MissingLutEntry as e:
+            do_raise = e
+            self._ofn = e.ofn
             print(e)
             self._args._sanity_check_exceptions.append(e)
-            return
         self.verbose(f'\t lut = {self._fsels}')
         self.verbose(f'\t ofn = {self._ofn}')
         self._obj_fn = self._ofn.with_suffix('.o')
@@ -369,6 +371,8 @@ class AutotuneCodeGenerator(MakefileSegmentGenerator):
             print(self._makefile_target, ':', self._ofn.relative_to(self._build_dir), file=self._out)
             cmd  = self._cc_cmd + f' {self._ofn.absolute()} -o {self._obj_fn.absolute()} -c'
             print('\t', cmd, '\n', file=self._out)
+        if do_raise:
+            raise do_raise
 
     @property
     def list_of_self_object_files(self) -> 'list[Path]':

--- a/v2python/rules/flash/_common.py
+++ b/v2python/rules/flash/_common.py
@@ -16,9 +16,10 @@ class FlashKernel(KernelDescription):
                 if fsel.repr_name == repr_name:
                     return fsel.argument_value
         is_causal = check_value('CAUSAL')
+        bias_type = check_value('BIAS_TYPE')
         if lut_tensor.size == 1:
             to_check = lut_tensor
-        elif is_causal:
+        elif is_causal and bias_type:
             to_check = lut_tensor.diagonal()
         else:
             to_check = lut_tensor

--- a/v2python/tuning_lut.py
+++ b/v2python/tuning_lut.py
@@ -184,8 +184,9 @@ class KernelTuningEntryForFunctionalOnGPU(object):
             raise e
         godel_number = first_sig.godel_number
         ofn = outdir / f'{first_sig.functional_signature}_{first_sig.target_gpu}.cc'
+        raise_lut_entry = False
         if not self._kdesc.sancheck_lut_tensor(lut_tensor, self._fsels):
-            raise MissingLutEntry(ofn, self._fsels, lut_tensor)
+            raise_lut_entry = True
         if bare_mode:
             return ofn
         if ofn.exists():
@@ -223,6 +224,8 @@ class KernelTuningEntryForFunctionalOnGPU(object):
             mf.seek(0)
             with open(ofn, 'w') as of:
                 shutil.copyfileobj(mf, of)
+        if raise_lut_entry:
+            raise MissingLutEntry(ofn, self._fsels, lut_tensor)
         return ofn
 
     @property


### PR DESCRIPTION
## Major changes

1. Fix the Triton kernel to support causal=True and seqlen_q != seqlen_k
    + This matches efficient attention behavior (align to top left corner)
2. Re-Enable the related tests
3. Re-Enable the related tuning (also fixes OOM on long seqlen_q/k)
4. Add the missing entries to tuning database for causal=True and seqlen_q != seqlen_k

## Known Problems

No tuning entries for MI300X/Navi31 since we are going to re-run the tuning script for all cases no later than next week.