### PR TITLE
Fix missing batch_index when calculating bias pointer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(AOTriton CXX C)
 # Version numbers
 set(AOTRITON_VERSION_MAJOR_INT 0)
 set(AOTRITON_VERSION_MINOR_INT 8)
-set(AOTRITON_VERSION_PATCH_INT 1)
+set(AOTRITON_VERSION_PATCH_INT 2)
 # Must have integer-suffix, other 0 generates
 # /* #undef AOTRITON_VERSION_MAJOR */
 # in config.h

--- a/tritonsrc/fwd_kernel.py
+++ b/tritonsrc/fwd_kernel.py
@@ -176,9 +176,8 @@ def attn_fwd(
     if BIAS_TYPE == 0:
         bias_ptrs = None
     elif BIAS_TYPE == 1:
-        # Note: this might get large enough to overflow on some configs
-        bias_offset = off_h_q * stride_bh
-        bias_ptrs = B + bias_offset + offs_m[:, None] * stride_bm + offs_n[None, :] * stride_bn
+        bias_offset = B + batch_index * stride_bz + off_h_q * stride_bh
+        bias_ptrs = bias_offset + offs_m[:, None] * stride_bm + offs_n[None, :] * stride_bn
     else:
         tl.static_assert(False, f'Unsupported BIAS_TYPE {BIAS_TYPE}')
 


### PR DESCRIPTION
This will be AOTriton 0.8.2b due to its emergency. We received reports this causes NaN during fine-tuning llama3.2-11b vision model 