### PR TITLE
Add "AOTriton <major>.<minor>.<patch>" string to .comment section of libaotriton_v2.so

### DIFF
--- a/v2python/ld_script.py
+++ b/v2python/ld_script.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import argparse
+from pathlib import Path
+
+def parse():
+    p = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    p.add_argument('-o', help="Output", type=Path, required=True)
+    p.add_argument('major')
+    p.add_argument('minor')
+    p.add_argument('patch')
+    args = p.parse_args()
+    return args
+
+def write_linker_script(args):
+    string = f"AOTriton {args.major}.{args.minor}.{args.patch}"
+    string = string.encode('ascii')
+    with open(args.o, 'w') as f:
+        print("""SECTIONS
+{
+  .comment : {
+    KEEP(*(.comment))
+    BYTE(0)""", file=f)
+        for c in string:
+            print(f"    BYTE(0x{c:02x})", file=f)
+        print("""    BYTE(0)
+  }
+}""", file=f)
+
+def main():
+    args = parse()
+    write_linker_script(args)
+
+if __name__ == "__main__":
+    main()

--- a/v2src/CMakeLists.txt
+++ b/v2src/CMakeLists.txt
@@ -180,6 +180,20 @@ target_link_libraries(aotriton_v2 PUBLIC hip::host hip::amdhip64)
 set_target_properties(aotriton_v2 PROPERTIES VERSION
   ${AOTRITON_VERSION_MAJOR_INT}.${AOTRITON_VERSION_MINOR_INT}.${AOTRITON_VERSION_PATCH_INT})
 
+execute_process(
+  COMMAND ${CMAKE_COMMAND}
+  -E env VIRTUAL_ENV=${VENV_DIR}
+  "${VENV_DIR}/bin/python" -m v2python.ld_script
+  -o "${AOTRITON_V2_BUILD_DIR}/set_aotriton_version.ld"
+  ${AOTRITON_VERSION_MAJOR_INT}
+  ${AOTRITON_VERSION_MINOR_INT}
+  ${AOTRITON_VERSION_PATCH_INT}
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_PARENT_DIR}"
+  COMMAND_ERROR_IS_FATAL ANY
+)
+target_link_options(aotriton_v2 PRIVATE
+                    -T "${AOTRITON_V2_BUILD_DIR}/set_aotriton_version.ld")
+
 include(GNUInstallDirs)
 message("CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_PARENT_DIR}/include/aotriton"


### PR DESCRIPTION
Effect:

```
$ readelf -p .comment libaotriton_v2.so.0.9.0

String dump of section '.comment':
  [     0]  GCC: (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
  [    2c]  AOTriton 0.9.0

```