### PR TITLE
build: Fix the linker script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(AOTriton CXX C)
 # Version numbers
 set(AOTRITON_VERSION_MAJOR_INT 0)
 set(AOTRITON_VERSION_MINOR_INT 9)
-set(AOTRITON_VERSION_PATCH_INT 0)
+set(AOTRITON_VERSION_PATCH_INT 2)
 # Must have integer-suffix, other 0 generates
 # /* #undef AOTRITON_VERSION_MAJOR */
 # in config.h

--- a/v2python/ld_script.py
+++ b/v2python/ld_script.py
@@ -25,7 +25,9 @@ def write_linker_script(args):
             print(f"    BYTE(0x{c:02x})", file=f)
         print("""    BYTE(0)
   }
-}""", file=f)
+}
+INSERT AFTER .comment;
+""", file=f)
 
 def main():
     args = parse()


### PR DESCRIPTION
Use "INSERT AFTER .comment;" to keep the default linker script.