### PR TITLE
Cut final binary size

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ cd build
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${CONDA_PREFIX}/lib/pkgconfig"
 cmake .. -DCMAKE_INSTALL_PREFIX=./install_dir -DCMAKE_BUILD_TYPE=Release -DAOTRITON_GPU_BUILD_TIMEOUT=0 -G Ninja
 # Use ccmake to tweak options
-ninja install
+ninja install/strip  # Use `ninja install` to keep symbols
 ```
 
 The library and the header file can be found under `build/install_dir` afterwards.

--- a/include/aotriton/_internal/kernel_cluster.h
+++ b/include/aotriton/_internal/kernel_cluster.h
@@ -1,0 +1,32 @@
+// Copyright © 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef AOTRITON_V2_API_KERNEL_CLUSTER_H
+#define AOTRITON_V2_API_KERNEL_CLUSTER_H
+
+#include <aotriton/config.h>
+#include <aotriton/_internal/triton_kernel.h>
+
+namespace AOTRITON_NS {
+
+template<int N>
+class TritonKernelCluster {
+public:
+  TritonKernelCluster(TritonKernelCompactMeta* meta_list,
+                      const char* packed_string) {
+    for (int i = 0; i < N; i++) {
+      const auto& meta = meta_list[i];
+      cluster_[i].delayed_init(meta.blake2b_hi,
+                               meta.blake2b_lo,
+                               packed_string + meta.psel_offset,
+                               packed_string + meta.copt_offset);
+    }
+  }
+  TritonKernel* get(int index) { return &cluster_[index]; }
+public:
+  TritonKernel cluster_[N];
+};
+
+}
+
+#endif

--- a/include/aotriton/_internal/kernel_cluster.h
+++ b/include/aotriton/_internal/kernel_cluster.h
@@ -23,7 +23,7 @@ public:
     }
   }
   TritonKernel* get(int index) { return &cluster_[index]; }
-public:
+private:
   TritonKernel cluster_[N];
 };
 

--- a/include/aotriton/_internal/packed_kernel.h
+++ b/include/aotriton/_internal/packed_kernel.h
@@ -1,4 +1,4 @@
-// Copyright © 2024 Advanced Micro Devices, Inc.
+// Copyright © 2024-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #ifndef AOTRITON_V2_API_PACKED_KERNEL_H

--- a/include/aotriton/_internal/packed_kernel.h
+++ b/include/aotriton/_internal/packed_kernel.h
@@ -21,14 +21,14 @@ struct AKS2_Metadata;
 
 class PackedKernel {
 public:
-  static PackedKernelPtr open(const char* package_path);
+  static PackedKernelPtr open(std::string_view package_path);
   PackedKernel(int fd);
   ~PackedKernel();
   hipError_t status() const {
     return final_status_;
   }
 
-  TritonKernel::Essentials filter(const char* stem_name) const;
+  TritonKernel::Essentials filter(std::string_view stem_name) const;
 
 private:
   static std::shared_mutex registry_mutex_;

--- a/include/aotriton/_internal/triton_kernel.h
+++ b/include/aotriton/_internal/triton_kernel.h
@@ -55,7 +55,9 @@ struct TritonKernelCompactMeta {
 //                          KERNEL NAME STORAGE SCHEME
 //  kernel_name: stored in shim.<kernel_name>.cc
 //  package_path, func_name, arch_name: stored in autotune_table_entry
-//  psel_name, copt_name: stored in each TritonKernel object
+//  psel_name, copt_name: consolated and stored in packed_string object.
+//                        Their offsets are stored in TritonKernelCompactMeta
+//                        objects.
 //
 
 class PackedKernel;

--- a/include/aotriton/_internal/triton_kernel.h
+++ b/include/aotriton/_internal/triton_kernel.h
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// Copyright © 2023-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #ifndef AOTRITON_V2_API_TRITON_KERNEL_H

--- a/include/aotriton/_internal/triton_kernel.h
+++ b/include/aotriton/_internal/triton_kernel.h
@@ -15,6 +15,13 @@
 
 namespace AOTRITON_NS {
 
+struct TritonKernelCompactMeta {
+  uint32_t blake2b_hi;
+  uint32_t blake2b_lo;
+  int16_t psel_offset;
+  int16_t copt_offset;
+};
+
 // To reduce the size of compiled shared library, we decompose the kernel image
 // name into a few components and only store one copy for components shared by
 // multiple kernels.
@@ -62,7 +69,13 @@ public:
     dim3 block { 0, 0, 0 };
   };
 
-  TritonKernel(uint64_t blake2b, std::string_view psel, std::string_view copt);
+  TritonKernel() {
+  }
+
+  void delayed_init(uint32_t blake2b_hi,
+                    uint32_t blake2b_lo,
+                    const char* psel,
+                    const char* copt);
 
   hipError_t invoke(std::string_view kernel_name,
                     std::string_view package_path,
@@ -92,7 +105,6 @@ private:
   uint64_t blake2b_; // TODO: sanity check of assemblied stem name
   std::string_view ksig_psel_; // psel_name component
   std::string_view ksig_copt_; // copt_name component
-  size_t image_size_ = 0;
   struct DeviceFunction {
     DeviceFunction(int device_id_, hipModule_t mod_, hipFunction_t func_);
     ~DeviceFunction();

--- a/include/aotriton/_internal/triton_kernel.h
+++ b/include/aotriton/_internal/triton_kernel.h
@@ -7,12 +7,49 @@
 #include "../runtime.h"
 #include <aotriton/config.h>
 #include <memory>
+#include <string_view>
 #include <shared_mutex>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
 
 namespace AOTRITON_NS {
+
+// To reduce the size of compiled shared library, we decompose the kernel image
+// name into a few components and only store one copy for components shared by
+// multiple kernels.
+//
+// CAVEAT: Due to the multi-source storage scheme, it is not feasible to create
+//         a unified struct to keep all information together
+//
+//                              KERNEL NAME COMPONENTS
+//
+// With
+//   amd-gfx942/flash/attn_fwd/FONLY__^fp16@16,80,True,False,0,0___MI300X.aks2
+//   attn_fwd-Sig-F__^fp16@16_80_True_False_0_0__P__0_2_64_64_True__CO__wave0_warp4_stg1-Gpu-MI300X.hsaco
+// As an example
+//   package_path: amd-gfx942/flash/attn_fwd/FONLY__^fp16@16,80,True,False,0,0___MI300X
+//   kernel_name:  attn_fwd
+//              (JOIN WITH -Sig-)
+//              (PREFIX F__)
+//   func_name:    ^fp16@16_80_True_False_0_0
+//              (JOIN WITH __)
+//              (PREFIX P__)
+//   psel_name:    0_2_64_64_True
+//              (JOIN WITH __)
+//              (PREFIX CO__)
+//   copt_name:    wave0_warp4_stg1
+//              (JOIN WITH -Gpu-)
+//   arch_name:    MI300X
+// Note:
+//   arch_name should be "GPU name" since we are using MI300X etc. right now.
+//   But it will be gfx942 etc after dispatcher v3 refactor
+//
+//                          KERNEL NAME STORAGE SCHEME
+//  kernel_name: stored in shim.<kernel_name>.cc
+//  package_path, func_name, arch_name: stored in autotune_table_entry
+//  psel_name, copt_name: stored in each TritonKernel object
+//
 
 class PackedKernel;
 
@@ -25,9 +62,12 @@ public:
     dim3 block { 0, 0, 0 };
   };
 
-  TritonKernel(const char* package_path, const char* stem_name);
+  TritonKernel(uint64_t blake2b, std::string_view psel, std::string_view copt);
 
-  hipError_t invoke(const char* kernel_name,
+  hipError_t invoke(std::string_view kernel_name,
+                    std::string_view package_path,
+                    std::string_view func_name,
+                    std::string_view arch_name,
                     dim3 grid,
                     std::vector<void*>& args,
 #if AOTRITON_BUILD_FOR_TUNING
@@ -42,11 +82,16 @@ public:
   Essentials get_image_info_iff_decompressed() const;
 #endif
 private:
-  std::tuple<hipFunction_t, hipError_t> load_for_device(int device_id, const char* kernel_name);
+  std::tuple<hipFunction_t, hipError_t> load_for_device(int device_id,
+                                                        std::string_view kernel_name,
+                                                        std::string_view package_path,
+                                                        std::string_view func_name,
+                                                        std::string_view arch_name);
   hipFunction_t cfind_function(int device_id) const;
 
-  const char* package_path_ = nullptr;
-  const char* stem_name_ = nullptr;
+  uint64_t blake2b_; // TODO: sanity check of assemblied stem name
+  std::string_view ksig_psel_; // psel_name component
+  std::string_view ksig_copt_; // copt_name component
   size_t image_size_ = 0;
   struct DeviceFunction {
     DeviceFunction(int device_id_, hipModule_t mod_, hipFunction_t func_);
@@ -60,7 +105,8 @@ private:
 
   Essentials essentials_;
   bool kernel_loaded_ = false;
-  void decompress_kernel();
+  void decompress_kernel(std::string_view package_path,
+                         const std::string stem_name);
   std::shared_ptr<PackedKernel> packed_kernel_ = nullptr;
   std::shared_mutex packedkernel_mutex_;
 };

--- a/include/aotriton/config.h.in
+++ b/include/aotriton/config.h.in
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// Copyright © 2023-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #ifndef AOTRITON_V2_CONFIG_H

--- a/include/aotriton/config.h.in
+++ b/include/aotriton/config.h.in
@@ -19,4 +19,6 @@
 #cmakedefine AOTRITON_VERSION_PATCH @AOTRITON_VERSION_PATCH@
 #cmakedefine AOTRITON_GIT_SHA1 @AOTRITON_GIT_SHA1@
 
+#define AOTRITON_API __attribute__ ((visibility ("default")))
+
 #endif

--- a/include/aotriton/cpp_tune.h
+++ b/include/aotriton/cpp_tune.h
@@ -8,7 +8,7 @@
 
 namespace AOTRITON_NS::v2 {
 
-struct CppTune {
+struct AOTRITON_API CppTune {
 #if AOTRITON_BUILD_FOR_TUNING
   // TODO: Move them into a base class since they are common to all kernels
   int force_kernel_index = -1;
@@ -22,7 +22,7 @@ struct CppTune {
 #endif
 };
 
-enum CppTuneSpecialKernelIndex : int {
+enum AOTRITON_API CppTuneSpecialKernelIndex : int {
   kDefault = -1,
   kSkipGPUCall = -2,
 };

--- a/include/aotriton/cpp_tune.h
+++ b/include/aotriton/cpp_tune.h
@@ -1,4 +1,4 @@
-// Copyright © 2024 Advanced Micro Devices, Inc.
+// Copyright © 2024-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #ifndef AOTRITON_V2_API_CPP_TUNE_H

--- a/include/aotriton/dtypes.h
+++ b/include/aotriton/dtypes.h
@@ -9,7 +9,7 @@
 
 namespace AOTRITON_NS {
 
-enum DType : int32_t {
+enum AOTRITON_API DType : int32_t {
   kUnknown = 0,
   kFloat32 = 1,
   kFloat16 = 2,

--- a/include/aotriton/dtypes.h
+++ b/include/aotriton/dtypes.h
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// Copyright © 2023-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #ifndef AOTRITON_V2_API_DTYPES_H

--- a/include/aotriton/flash.h
+++ b/include/aotriton/flash.h
@@ -11,7 +11,7 @@
 
 namespace AOTRITON_NS::v2::flash {
 
-hipError_t
+hipError_t AOTRITON_API
 check_gpu(AOTRITON_NS::Stream stream);
 
 using T4 = AOTRITON_NS::TensorView<4>;
@@ -19,19 +19,19 @@ using T2 = AOTRITON_NS::TensorView<2>;
 using T1 = AOTRITON_NS::TensorView<1>;
 using T0 = AOTRITON_NS::TensorView<0>;
 
-struct FwdExtraArguments : public CppTune {
+struct AOTRITON_API FwdExtraArguments : public CppTune {
 };
 
-struct BwdExtraArguments {
+struct AOTRITON_API BwdExtraArguments {
 #if AOTRITON_BUILD_FOR_TUNING
   FwdExtraArguments dkdv, dqdb;
 #endif
 };
 
-struct FusedBwdExtraArguments : public CppTune {
+struct AOTRITON_API FusedBwdExtraArguments : public CppTune {
 };
 
-hipError_t
+hipError_t AOTRITON_API
 attn_fwd(T4 q, // batch_size x num_heads x seqlen_q x head_size
          T4 k, // batch_size x num_heads x seqlen_k x head_size
          T4 v, // batch_size x num_heads x seqlen_k x head_size
@@ -51,7 +51,7 @@ attn_fwd(T4 q, // batch_size x num_heads x seqlen_q x head_size
          AOTRITON_NS::Stream stream,
          FwdExtraArguments* extargs = nullptr);
 
-hipError_t
+hipError_t AOTRITON_API
 attn_fwd_compact_varlen(T4 q, // 1 x num_heads x total_q x head_size, total_q := \sum_{i=0}^{b} s_i
                         T4 k, // 1 x num_heads x total_k x head_size, total_k := \sum_{i=0}^{b} s_i
                         T4 v, // 1 x num_heads x total_v x head_size, total_, := \sum_{i=0}^{b} s_i
@@ -75,7 +75,7 @@ attn_fwd_compact_varlen(T4 q, // 1 x num_heads x total_q x head_size, total_q :=
                         AOTRITON_NS::Stream stream,
                         FwdExtraArguments* extargs = nullptr);
 
-hipError_t
+hipError_t AOTRITON_API
 attn_bwd(T4 q, // batch_size x num_heads x seqlen_q x head_size
          T4 k, // batch_size x num_heads x seqlen_k x head_size
          T4 v, // batch_size x num_heads x seqlen_k x head_size
@@ -97,7 +97,7 @@ attn_bwd(T4 q, // batch_size x num_heads x seqlen_q x head_size
          AOTRITON_NS::Stream stream,
          BwdExtraArguments* extargs = nullptr);
 
-hipError_t
+hipError_t AOTRITON_API
 attn_bwd_fused(T4 q, // batch_size x num_heads x seqlen_q x head_size
                T4 k, // batch_size x num_heads x seqlen_k x head_size
                T4 v, // batch_size x num_heads x seqlen_k x head_size
@@ -118,7 +118,7 @@ attn_bwd_fused(T4 q, // batch_size x num_heads x seqlen_q x head_size
                AOTRITON_NS::Stream stream,
                FusedBwdExtraArguments* extargs = nullptr);
 
-hipError_t
+hipError_t AOTRITON_API
 attn_bwd_compact_varlen(T4 q, // 1 x num_heads x total_q x head_size, total_q := \sum_{i=0}^{b}
                         T4 k, // 1 x num_heads x total_k x head_size, total_k := \sum_{i=0}^{b}
                         T4 v, // 1 x num_heads x total_v x head_size, total_, := \sum_{i=0}^{b}
@@ -144,20 +144,20 @@ attn_bwd_compact_varlen(T4 q, // 1 x num_heads x total_q x head_size, total_q :=
                         AOTRITON_NS::Stream stream,
                         BwdExtraArguments* extargs = nullptr);
 
-hipError_t
+hipError_t AOTRITON_API
 debug_fill_dropout_rng(T4 r,
                        uint64_t philox_seed,
                        uint64_t philox_offset,
                        AOTRITON_NS::Stream stream);
 
-hipError_t
+hipError_t AOTRITON_API
 debug_fill_dropout_rng_tensor(T4 r,
                               T0 philox_seed,
                               T0 philox_offset,
                               AOTRITON_NS::Stream stream);
 
 // varlen should use len(cu_seqlens_q) - 1 for the batch size
-hipError_t
+hipError_t AOTRITON_API
 debug_simulate_encoded_softmax(T4 r,  // batch_size x num_heads x max_seqlen_q x max_seqlen_k
                                float dropout_p,
                                T0 philox_seed,

--- a/include/aotriton/runtime.h
+++ b/include/aotriton/runtime.h
@@ -12,7 +12,7 @@ namespace AOTRITON_NS {
 // This is not a class for stream management (at least for now), but a way to
 // make sure AOTriton APIs can have python bindings with pybind11
 template<typename DeviceStreamType>
-class StreamTemplate {
+class AOTRITON_API StreamTemplate {
 public:
   StreamTemplate()
     : stream_(nullptr) {

--- a/include/aotriton/runtime.h
+++ b/include/aotriton/runtime.h
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// Copyright © 2023-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #ifndef AOTRITON_V2_API_RUNTIME_H

--- a/include/aotriton/util.h
+++ b/include/aotriton/util.h
@@ -21,20 +21,20 @@ CAT(uint32_t high, uint32_t low) {
 }
 
 template<typename T>
-T
+T AOTRITON_API
 cdiv(T numerator, T denominator) {
   return (numerator + (denominator - 1)) / denominator;
 }
 
 // Use PCI IDs to avoid allocating numbers by ourselves
-enum GpuVendor : uint32_t {
+enum AOTRITON_API GpuVendor : uint32_t {
   kAMD = 0x1002,
   kNVIDIA = 0x10de,
   kINTEL = 0x8086,
 };
 
 // More bits for potential non-PCI architectures
-enum GpuArch : uint64_t {
+enum AOTRITON_API GpuArch : uint64_t {
   GPU_ARCH_UNKNOWN = 0,
   GPU_ARCH_AMD_GFX90A = CAT(GpuVendor::kAMD, 0x90a),
   GPU_ARCH_AMD_GFX942 = CAT(GpuVendor::kAMD, 0x942),
@@ -45,7 +45,7 @@ enum GpuArch : uint64_t {
 };
 
 template<int Rank>
-class TensorView {
+class AOTRITON_API TensorView {
 public:
   TensorView() {
   }
@@ -110,7 +110,7 @@ private:
 };
 
 template<>
-class TensorView<0> {
+class AOTRITON_API TensorView<0> {
 public:
   TensorView(intptr_t base, DType dtype)
     : base_(reinterpret_cast<void*>(base))
@@ -159,9 +159,9 @@ extern template class TensorView<2>;
 extern template class TensorView<3>;
 extern template class TensorView<4>;
 
-GpuArch getArchFromStream(hipStream_t);
-bool isArchExperimentallySupported(hipStream_t);
-int getMultiProcessorCount(hipStream_t stream);
+GpuArch AOTRITON_API getArchFromStream(hipStream_t);
+bool AOTRITON_API isArchExperimentallySupported(hipStream_t);
+int AOTRITON_API getMultiProcessorCount(hipStream_t stream);
 
 } // namespace AOTRITON_NS
 

--- a/include/aotriton/util.h
+++ b/include/aotriton/util.h
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// Copyright © 2023-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #ifndef AOTRITON_V2_API_UTIL_H

--- a/v2python/kernel_desc.py
+++ b/v2python/kernel_desc.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Advanced Micro Devices, Inc.
+# Copyright © 2023-2025 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
 import itertools

--- a/v2python/kernel_desc.py
+++ b/v2python/kernel_desc.py
@@ -390,9 +390,7 @@ class KernelDescription(object):
             godel_numbers = sorted(list(set([o.godel_number for o in object_files if o.target_gpu == target_gpu])))
             for godel_number in godel_numbers:
                 struct_name = self.get_autotune_struct_name(arch_number, godel_number)
-                decls.append(f'struct {struct_name} {{')
-                decls.append(f'    void operator()({self.param_class_name}& params);')
-                decls.append(f'}};')
+                decls.append(f'void {struct_name}({self.param_class_name}& params);')
         return '\n'.join(decls)
 
     def codegen_kernel_table_entries(self, object_files):
@@ -403,9 +401,9 @@ class KernelDescription(object):
             for godel_number in range(self._godel_number):
                 struct_name = self.get_autotune_struct_name(arch_number, godel_number)
                 if godel_number in godel_numbers:
-                    lets.append(8 * ' ' + f'autotune::{struct_name}(),')
+                    lets.append(8 * ' ' + f'&autotune::{struct_name},')
                 else:
-                    lets.append(8 * ' ' + f'[]({self.param_class_name}&) {{}},')
+                    lets.append(8 * ' ' + f'nullptr,')
             lets.append(4 * ' ' + '},')
         return '\n'.join(lets)
 

--- a/v2python/kernel_desc.py
+++ b/v2python/kernel_desc.py
@@ -120,7 +120,9 @@ class KernelDescription(object):
         self._godel_number = self._func_meta[0].godel_number * self._func_meta[0].nchoices
         for m in self._perf_meta:
             m.sort_arguments(self.ARGUMENTS)
-        self._perf_meta = sorted(self._perf_meta, key=lambda m: m.first_apperance)
+        # self._perf_meta = sorted(self._perf_meta, key=lambda m: m.first_apperance)
+        # Note: Re-order with byte sizes can reduce the C-struct size in autotune files.
+        self._perf_meta = sorted(self._perf_meta, key=lambda m : m.param_cc_size, reverse=True)
         # Performance arguments do not need godel numbers, they will be handled in a different way
         # ArgumentMetadata.assign_godel_number(self._perf_meta)
         self._func_selections = [m.spawn_all_selections() for m in self._func_meta]

--- a/v2python/kernel_desc.py
+++ b/v2python/kernel_desc.py
@@ -227,16 +227,7 @@ class KernelDescription(object):
                     break
 
     def build_object_file_description(self, outpath, sig, sancheck_fileexists=False):
-        # print(f"{gpu=} {fsels=} {psels=} {compiler_options=}")
-        # sig = KernelSignature(self, fsels, psels, compiler_options, gpu)
-        # fn = file_name_prefix + '-Kernel-' if file_name_prefix else ''
-        # kernel_name =  if kernel_name is None else kernel_name
-        fn = self.SHIM_KERNEL_NAME
-        # print(f'{sig.compact_signature=}')
-        fn += '-Sig-' + sig.compact_signature
-        fn += '-Gpu-' + sig.target_gpu
-        fn += '.hsaco'
-        return ObjectFileDescription(self, sig, outpath / fn, sancheck_fileexists=sancheck_fileexists)
+        return ObjectFileDescription(self, sig, outpath, sancheck_fileexists=sancheck_fileexists)
 
     def gen_tuned_kernel_lut(self, tuned_db : 'KernelTuningDatabase') -> 'Iterator[KernelTuningLutForGPU]':
         for gpu, fsels in itertools.product(self._target_gpus,

--- a/v2python/kernel_signature.py
+++ b/v2python/kernel_signature.py
@@ -3,7 +3,6 @@
 
 from .gpu_targets import AOTRITON_GPU_ARCH_TUNING_STRING
 import json
-import hashlib
 from .kernel_argument import ArgumentSelection
 
 class KernelSignature(object):
@@ -119,9 +118,3 @@ class KernelSignature(object):
 
     def is_functional_disabled(self):
         return self._kdesc.is_functional_disabled_on_gpu(self._gpu, self._func_selections)
-
-    @property
-    def blake2b_compact_signature(self):
-        s = self.compact_signature
-        h = hashlib.blake2b(s.encode('utf-8'), digest_size=8)
-        return h.hexdigest()

--- a/v2python/kernel_signature.py
+++ b/v2python/kernel_signature.py
@@ -3,6 +3,7 @@
 
 from .gpu_targets import AOTRITON_GPU_ARCH_TUNING_STRING
 import json
+import hashlib
 from .kernel_argument import ArgumentSelection
 
 class KernelSignature(object):
@@ -42,15 +43,15 @@ class KernelSignature(object):
         lf = [s.compact_signature for s in self._func_selections]
         lp = [s.compact_signature for s in self._perf_selections]
         lc = [f'{self.get_compact_compiler_option_name(k)}{v}' for k, v in self._compiler_options.items() if k != '_debug']
-        func = '_'.join([x for x in lf if x is not None])
-        perf = '_'.join([x for x in lp if x is not None])
+        fsel = '_'.join([x for x in lf if x is not None])
+        psel = '_'.join([x for x in lp if x is not None])
         copts = '_'.join([x for x in lc if x is not None])
-        return func, perf, copts
+        return fsel, psel, copts
 
     @property
     def compact_signature(self):
-        func, perf, copts = self.get_compact_signature_components()
-        return 'F__' + sf + '__P__' + sp + '__CO__' + co
+        fsel, psel, copts = self.get_compact_signature_components()
+        return 'F__' + fsel + '__P__' + psel + '__CO__' + copts
 
     @property
     def human_readable_signature(self):
@@ -119,3 +120,8 @@ class KernelSignature(object):
     def is_functional_disabled(self):
         return self._kdesc.is_functional_disabled_on_gpu(self._gpu, self._func_selections)
 
+    @property
+    def blake2b_compact_signature(self):
+        s = self.compact_signature
+        h = hashlib.blake2b(s.encode('utf-8'), digest_size=8)
+        return h.hexdigest()

--- a/v2python/kernel_signature.py
+++ b/v2python/kernel_signature.py
@@ -38,14 +38,18 @@ class KernelSignature(object):
     def godel_number(self):
         return sum([s.godel_number for s in self._func_selections])
 
-    @property
-    def compact_signature(self):
+    def get_compact_signature_components(self):
         lf = [s.compact_signature for s in self._func_selections]
         lp = [s.compact_signature for s in self._perf_selections]
         lc = [f'{self.get_compact_compiler_option_name(k)}{v}' for k, v in self._compiler_options.items() if k != '_debug']
-        sf = '_'.join([x for x in lf if x is not None])
-        sp = '_'.join([x for x in lp if x is not None])
-        co = '_'.join([x for x in lc if x is not None])
+        func = '_'.join([x for x in lf if x is not None])
+        perf = '_'.join([x for x in lp if x is not None])
+        copts = '_'.join([x for x in lc if x is not None])
+        return func, perf, copts
+
+    @property
+    def compact_signature(self):
+        func, perf, copts = self.get_compact_signature_components()
         return 'F__' + sf + '__P__' + sp + '__CO__' + co
 
     @property

--- a/v2python/kernel_signature.py
+++ b/v2python/kernel_signature.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from .gpu_targets import AOTRITON_GPU_ARCH_TUNING_STRING
+import numpy
 import json
 from .kernel_argument import ArgumentSelection
 
@@ -109,6 +110,9 @@ class KernelSignature(object):
         d = {}
         for ps in self._perf_selections:
             value = ps.argument_value
+            if isinstance(value, numpy.number):
+                # Cast to python native for json dump
+                value = value.item()
             for aname in ps.argument_names:
                 d[aname] = value
         return json.dumps(d)

--- a/v2python/kernel_signature.py
+++ b/v2python/kernel_signature.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Advanced Micro Devices, Inc.
+# Copyright © 2023-2025 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
 from .gpu_targets import AOTRITON_GPU_ARCH_TUNING_STRING

--- a/v2python/object_desc.py
+++ b/v2python/object_desc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright © 2023-2024 Advanced Micro Devices, Inc.
+# Copyright © 2023-2025 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path

--- a/v2python/object_desc.py
+++ b/v2python/object_desc.py
@@ -25,7 +25,7 @@ class ObjectFileDescription(object):
     DEFAULT_NUM_STAGES = 1
     DEFAULT_WAVES_PER_EU = 1
 
-    def build_kernel_filename(self, signature: 'KernelSignature'):
+    def build_kernel_filename(self, sig: 'KernelSignature'):
         # print(f"{gpu=} {fsels=} {psels=} {compiler_options=}")
         # sig = KernelSignature(self, fsels, psels, compiler_options, gpu)
         # fn = file_name_prefix + '-Kernel-' if file_name_prefix else ''
@@ -79,11 +79,15 @@ class ObjectFileDescription(object):
 
     @property
     def compact_signature_components(self):
-        return self._signature.get_compact_filename_components()
+        return self._signature.get_compact_signature_components()
 
     @property
     def human_readable_signature(self):
         return self._signature.human_readable_signature
+
+    @property
+    def blake2b_compact_signature(self):
+        return self._signature.blake2b_compact_signature
 
     @property
     def c_identifier_signature(self):

--- a/v2python/object_desc.py
+++ b/v2python/object_desc.py
@@ -25,16 +25,28 @@ class ObjectFileDescription(object):
     DEFAULT_NUM_STAGES = 1
     DEFAULT_WAVES_PER_EU = 1
 
+    def build_kernel_filename(self, signature: 'KernelSignature'):
+        # print(f"{gpu=} {fsels=} {psels=} {compiler_options=}")
+        # sig = KernelSignature(self, fsels, psels, compiler_options, gpu)
+        # fn = file_name_prefix + '-Kernel-' if file_name_prefix else ''
+        # kernel_name =  if kernel_name is None else kernel_name
+        fn = self.SHIM_KERNEL_NAME
+        # print(f'{sig.compact_signature=}')
+        fn += '-Sig-' + sig.compact_signature
+        fn += '-Gpu-' + sig.target_gpu
+        fn += '.hsaco'
+        return fn
+
     def __init__(self,
                  triton_kernel_desc : 'KernelDescription',
                  signature: 'KernelSignature',
-                 hsaco_kernel_path : Path,
+                 hsaco_outpath : Path,
                  sancheck_fileexists = False):
         self._triton_kernel_desc = triton_kernel_desc
         self.KERNEL_FAMILY = self._triton_kernel_desc.KERNEL_FAMILY
         self.SHIM_KERNEL_NAME = self._triton_kernel_desc.SHIM_KERNEL_NAME
         self._signature = signature
-        self._hsaco_kernel_path = Path(hsaco_kernel_path)
+        self._hsaco_kernel_path = hsaco_outpath / self.build_kernel_filename(signature)
         # self._hsaco_metatdata_path = Path() if triton_metadata_path is None else self._triton_file_path.with_suffix('.json')
         self._hsaco_metatdata_path = self._hsaco_kernel_path.with_suffix('.json')
         if self.compiled_files_exist:
@@ -64,6 +76,10 @@ class ObjectFileDescription(object):
     @property
     def compact_signature(self):
         return self._signature.compact_signature
+
+    @property
+    def compact_signature_components(self):
+        return self._signature.get_compact_filename_components()
 
     @property
     def human_readable_signature(self):

--- a/v2python/object_desc.py
+++ b/v2python/object_desc.py
@@ -4,6 +4,7 @@
 
 from pathlib import Path
 import json
+import hashlib
 
 SOURCE_PATH = Path(__file__).resolve()
 
@@ -85,9 +86,13 @@ class ObjectFileDescription(object):
     def human_readable_signature(self):
         return self._signature.human_readable_signature
 
-    @property
-    def blake2b_compact_signature(self):
-        return self._signature.blake2b_compact_signature
+    def blake2b_hash(self, package_path):
+        raw = package_path.encode('utf-8')
+        _, psel, copts = self.compact_signature_components
+        s = '__P__' + psel + '__CO__' + copts + '-Gpu-' + self._signature.target_gpu
+        raw += s.encode('utf-8')
+        h = hashlib.blake2b(raw, digest_size=8)
+        return h.hexdigest(), raw
 
     @property
     def c_identifier_signature(self):

--- a/v2python/object_desc.py
+++ b/v2python/object_desc.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
+import numpy as np
 import json
 import hashlib
 
@@ -10,14 +11,41 @@ SOURCE_PATH = Path(__file__).resolve()
 
 class ObjectFileDescription(object):
     SIGNATURE_TO_C = {
-        'fp32'  : 'float',
-        '*fp32' : 'const float*',
-        '*fp16' : 'const __fp16*',
-        '*bf16' : 'const __bf16*',
-        'i32'   : 'int32_t',
-        'i64'   : 'int64_t',
-        'u32'   : 'uint32_t',
-        'u64'   : 'uint64_t',
+        'fp32'    : 'float',
+        '*fp32'   : 'const float*',
+        '*fp16'   : 'const __fp16*',
+        '*bf16'   : 'const __bf16*',
+        'i8'      : 'int8_t',
+        'i16'     : 'int16_t',
+        'i32'     : 'int32_t',
+        'i64'     : 'int64_t',
+        'u8'      : 'uint8_t',
+        'u16'     : 'uint16_t',
+        'u32'     : 'uint32_t',
+        'u64'     : 'uint64_t',
+        np.int8   : 'int8_t',
+        np.int16  : 'int16_t',
+        np.int32  : 'int32_t',
+        np.int64  : 'int64_t',
+        np.uint8  : 'uint8_t',
+        np.uint16 : 'uint16_t',
+        np.uint32 : 'uint32_t',
+        np.uint64 : 'uint64_t',
+    }
+    C_SIZE = {
+        'bool'              : 1,
+        'const __bf16*'     : 8,
+        'const __fp16*'     : 8,
+        'const float*'      : 8,
+        'float'             : 4,
+        'int8_t'            : 1,
+        'int16_t'           : 2,
+        'int32_t'           : 4,
+        'int64_t'           : 8,
+        'uint8_t'           : 1,
+        'uint16_t'          : 2,
+        'uint32_t'          : 4,
+        'uint64_t'          : 8,
     }
     def is_tensor_type(t):
         return t.startswith('*')

--- a/v2python/rules/flash/attn_fwd.py
+++ b/v2python/rules/flash/attn_fwd.py
@@ -3,6 +3,7 @@
 
 import itertools
 import os
+import numpy as np
 from ._common import FlashKernel, select_pattern, BinningLessOrEqual, BinningExact, Config
 
 AOTRITON_FLASH_BLOCK_DMODEL = os.getenv('AOTRITON_FLASH_BLOCK_DMODEL', default='16, 32, 48, 64, 80, 96, 128, 160, 192, 224, 256, 512')
@@ -99,13 +100,13 @@ class attn_fwd(FlashKernel):
         frozenset(['USE_ALIBI']) : [False],
         frozenset(['INT8', 'INT8_KV', 'USE_P_SCALE']) : [False],  # INT8 for the future
     }
-    def PERSISTENT_TYPE(gpu, fsel_dict) -> int:  # NOTE: Return type annotation is REQUIRED
+    def PERSISTENT_TYPE(gpu, fsel_dict) -> 'i8':  # NOTE: Return type annotation is REQUIRED
         return 2 if fsel_dict['CAUSAL_TYPE'] else 0
     PERF_CHOICES = {
         frozenset(['PERSISTENT_TYPE']) : [PERSISTENT_TYPE],
-        frozenset(['GRID_CU_MULTIP']) : [2],
-        frozenset(['BLOCK_M']) : [16],
-        frozenset(['BLOCK_N']) : [16],
+        frozenset(['GRID_CU_MULTIP']) : np.array([2], dtype=np.int8),  # NOTE: use np.array with dtype to reduce size of the generate tuning infomation struct
+        frozenset(['BLOCK_M']) : np.array([16], dtype=np.int16),
+        frozenset(['BLOCK_N']) : np.array([16], dtype=np.int16),
         frozenset(['PRE_LOAD_V']) : [False], # [False, True],
     }
     TENSOR_RANKS = {

--- a/v2python/tuning_lut.py
+++ b/v2python/tuning_lut.py
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Advanced Micro Devices, Inc.
+# Copyright © 2023-2025 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
 from .kernel_signature import KernelSignature

--- a/v2src/CMakeLists.txt
+++ b/v2src/CMakeLists.txt
@@ -202,6 +202,9 @@ execute_process(
 )
 target_link_options(aotriton_v2 PRIVATE
                     -T "${AOTRITON_V2_BUILD_DIR}/set_aotriton_version.ld")
+# Otherwise the binary size blows up
+# FIXME: Properly export symbols
+set_target_properties(aotriton_v2 PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
 include(GNUInstallDirs)
 message("CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}")

--- a/v2src/CMakeLists.txt
+++ b/v2src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright © 2023-2024 Advanced Micro Devices, Inc.
+# Copyright © 2023-2025 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
 message("CMAKE_SOURCE_DIR ${CMAKE_SOURCE_DIR}")

--- a/v2src/packed_kernel.cc
+++ b/v2src/packed_kernel.cc
@@ -1,4 +1,4 @@
-// Copyright © 2024 Advanced Micro Devices, Inc.
+// Copyright © 2024-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #include <aotriton/_internal/packed_kernel.h>

--- a/v2src/packed_kernel.cc
+++ b/v2src/packed_kernel.cc
@@ -48,20 +48,19 @@ std::shared_mutex PackedKernel::registry_mutex_;
 std::unordered_map<std::string_view, PackedKernelPtr> PackedKernel::registry_;
 
 PackedKernelPtr
-PackedKernel::open(const char* package_path) {
-  std::string_view path_view(package_path);
+PackedKernel::open(std::string_view package_path) {
   {
     // Fast path
     std::shared_lock lock(registry_mutex_);
     if (registry_.contains(package_path))
-      return registry_[path_view];
+      return registry_[package_path];
   }
 
   // Slow path, registry doesn't contain this kernel
   std::unique_lock lock(registry_mutex_);
   // Prevent TOCTTOU b/w two locks
   if (registry_.contains(package_path))
-    return registry_[path_view];
+    return registry_[package_path];
   const auto& storage_base = locate_aotriton_images();
 #if AOTRITON_KERNEL_VERBOSE
   std::cerr << "open dir " << storage_base << std::endl;
@@ -84,7 +83,7 @@ PackedKernel::open(const char* package_path) {
   close(aks2fd);
   close(dirfd);
   if (ret->status() == hipSuccess) {
-    registry_.emplace(path_view, ret);
+    registry_.emplace(package_path, ret);
     return ret;
   }
 #if AOTRITON_KERNEL_VERBOSE
@@ -202,12 +201,11 @@ PackedKernel::~PackedKernel() {
 }
 
 TritonKernel::Essentials
-PackedKernel::filter(const char* stem_name) const {
+PackedKernel::filter(std::string_view stem_name) const {
   if (status() != hipSuccess) {
     return { nullptr, 0, 0, dim3 { 0, 0, 0 } };
   }
-  std::string_view filename(stem_name);
-  auto iter = directory_.find(filename);
+  auto iter = directory_.find(stem_name);
   if (iter == directory_.end())
     return { nullptr, 0, 0, dim3 { 0, 1, 1 } };
   auto meta = iter->second;

--- a/v2src/template/autotune_table_entry.cc
+++ b/v2src/template/autotune_table_entry.cc
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// Copyright © 2023-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #include "../shim.[[shim_kernel_name]].h"

--- a/v2src/template/autotune_table_entry.cc
+++ b/v2src/template/autotune_table_entry.cc
@@ -4,7 +4,6 @@
 #include "../shim.[[shim_kernel_name]].h"
 #include <aotriton/_internal/triton_kernel.h>
 #include <aotriton/cpp_tune.h>
-#include <iostream>
 
 // [[human_readable_signature]]
 #define CURRENT_ENTRY_PUBLIC Autotune_[[shim_kernel_name]]__A[[arch_number]]__F[[godel_number]]

--- a/v2src/template/autotune_table_entry.cc
+++ b/v2src/template/autotune_table_entry.cc
@@ -26,7 +26,7 @@ struct PerfFields {
   [[perf_fields]];
 };
 
-PerfFields image_perf_list [] = {
+static PerfFields image_perf_list [] = {
     [[kernel_image_perfs]]
 };
 
@@ -34,18 +34,18 @@ constexpr std::string_view PACKAGE_PATH { R"xyzw([[package_path]])xyzw" };
 constexpr std::string_view FUNC_NAME { R"xyzw([[func_name]])xyzw" };
 constexpr std::string_view ARCH_NAME { R"xyzw([[arch_name]])xyzw" };
 
-const char packed_string[] =
+static const char packed_string[] =
 [[packed_string]];
 
-AOTRITON_NS::TritonKernelCompactMeta meta_list[] = {
+static AOTRITON_NS::TritonKernelCompactMeta meta_list[] = {
     [[meta_objects]]
 };
 
 static constexpr int kTotalNumKernels = ARRAY_SIZE(meta_list);
 
-AOTRITON_NS::TritonKernelCluster<kTotalNumKernels> kernel_cluster(meta_list, packed_string);
+static AOTRITON_NS::TritonKernelCluster<kTotalNumKernels> kernel_cluster(meta_list, packed_string);
 
-[[lut_dtype]] lut[[lut_shape]] = [[lut_data]];
+static [[lut_dtype]] lut[[lut_shape]] = [[lut_data]];
 
 }; // End of anonymous namespace
 

--- a/v2src/template/autotune_table_entry.cc
+++ b/v2src/template/autotune_table_entry.cc
@@ -27,14 +27,16 @@ PerfFields image_perf_list [] = {
     [[kernel_image_perfs]]
 };
 
-const char* PACKAGE_PATH = [[package_path]];
+constexpr std::string_view PACKAGE_PATH { R"xyzw([[package_path]])xyzw" };
+constexpr std::string_view FUNC_NAME { R"xyzw([[func_name]])xyzw" };
+constexpr std::string_view ARCH_NAME { R"xyzw([[arch_name]])xyzw" };
 
-AOTRITON_NS::TritonKernel image_list [] = {
+AOTRITON_NS::TritonKernel kernel_list[] = {
     [[kernel_image_objects]]
 };
 
 #if AOTRITON_BUILD_FOR_TUNING
-static constexpr int total_num_kernels = ARRAY_SIZE(image_list);
+static constexpr int total_num_kernels = ARRAY_SIZE(kernel_list);
 #endif
 
 [[lut_dtype]] lut[[lut_shape]] = [[lut_data]];
@@ -52,7 +54,7 @@ void CURRENT_ENTRY_PUBLIC::operator()([[param_class_name]]& params) {
     if (preferred_index != -1) {
         if (preferred_index >= total_num_kernels)
             return ;
-        params.selected_kernel = &image_list[preferred_index];
+        params.selected_kernel = &kernel_list[preferred_index];
         params._preferred_kernel_psels = kernel_psels[preferred_index];
         params._preferred_kernel_copts = kernel_copts[preferred_index];
         const auto& perf = image_perf_list[preferred_index];
@@ -65,7 +67,10 @@ void CURRENT_ENTRY_PUBLIC::operator()([[param_class_name]]& params) {
     if (kernel_index < 0) {
       return ;
     }
-    params.selected_kernel = &image_list[kernel_index];
+    params.kernel_on_device = &kernel_list[kernel_index];
+    params.package_path = PACKAGE_PATH;
+    params.func_name = FUNC_NAME;
+    params.arch_name = ARCH_NAME;
 #ifndef NDEBUG
     std::cerr << __FILE__ << " kernel_index = " << int(kernel_index) << std::endl;
 #endif

--- a/v2src/template/autotune_table_entry.cc
+++ b/v2src/template/autotune_table_entry.cc
@@ -61,8 +61,7 @@ void CURRENT_ENTRY_PUBLIC::operator()([[param_class_name]]& params) {
         return ;
     }
 #endif
-    [[binning_autotune_keys]]
-    auto kernel_index = lut[[binned_indices]];
+    auto kernel_index = [[deduplicated_lut_function]](params, lut);
     if (kernel_index < 0) {
       return ;
     }

--- a/v2src/template/autotune_table_entry.cc
+++ b/v2src/template/autotune_table_entry.cc
@@ -46,7 +46,7 @@ namespace AOTRITON_NS::v2::[[kernel_family_name]]::autotune {
 
 // using AOTRITON_NS::v2::[[kernel_family_name]]::[[param_class_name]];
 
-void CURRENT_ENTRY_PUBLIC::operator()([[param_class_name]]& params) {
+void CURRENT_ENTRY_PUBLIC([[param_class_name]]& params) {
 #if AOTRITON_BUILD_FOR_TUNING
     int preferred_index = params._has_preferred_kernel;
     params._total_number_of_kernels = total_num_kernels;

--- a/v2src/template/shim.cc
+++ b/v2src/template/shim.cc
@@ -22,6 +22,8 @@ hipError_t
     }
     params.kernel_on_device = nullptr;
     auto tune_func = autotune_table[arch_number][params.godel_number()];
+    if (!tune_func)
+        return hipErrorProfilerNotInitialized;
     tune_func(params);
     if (!params.kernel_on_device)
         return hipErrorSharedObjectSymbolNotFound;

--- a/v2src/template/shim.cc
+++ b/v2src/template/shim.cc
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// Copyright © 2023-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 // clang-format off

--- a/v2src/template/shim.cc
+++ b/v2src/template/shim.cc
@@ -66,6 +66,12 @@ int64_t
 
 [[define_compiled_in_features]]
 
+namespace autotune {
+
+[[list_of_deduplicated_lut_functions]]
+
+} // namespace autotune
+
 [[context_class_name]]::AutoTuneTableEntry
 [[context_class_name]]::autotune_table[][ [[number_of_functionals]] ] = {
 [[kernel_table_entries]]

--- a/v2src/template/shim.h
+++ b/v2src/template/shim.h
@@ -21,7 +21,11 @@ struct [[param_class_name]] {
     // Performance related arguments for current selection
     [[perf_fields]];
 
-    TritonKernel* selected_kernel = nullptr;
+    TritonKernel* kernel_on_device = nullptr;
+    std::string_view package_path;
+    std::string_view func_name;
+    std::string_view arch_name;
+    // Note to save ELF space, this object is constructed on the fly.
     const char* _debug_kernel_name = nullptr;
 #if AOTRITON_BUILD_FOR_TUNING
     int _has_preferred_kernel = -1; // For C++ based autotune database generation

--- a/v2src/template/shim.h
+++ b/v2src/template/shim.h
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// Copyright © 2023-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 // clang-format off

--- a/v2src/template/shim.h
+++ b/v2src/template/shim.h
@@ -51,7 +51,7 @@ public:
 private:
     GpuArch kernel_arch = GPU_ARCH_UNKNOWN;
 
-    using AutoTuneTableEntry = std::function<void([[param_class_name]]& params)>;
+    typedef void (*AutoTuneTableEntry)([[param_class_name]]& params);
     static AutoTuneTableEntry autotune_table[][ [[number_of_functionals]] ];
 };
 

--- a/v2src/template/shim.h
+++ b/v2src/template/shim.h
@@ -64,6 +64,8 @@ namespace autotune {
 
 using AOTRITON_NS::v2::[[kernel_family_name]]::[[param_class_name]];
 
+[[declare_list_of_deduplicated_lut_functions]]
+
 [[kernel_table_entry_declares]]
 
 }

--- a/v2src/triton_kernel.cc
+++ b/v2src/triton_kernel.cc
@@ -1,4 +1,4 @@
-// Copyright © 2023-2024 Advanced Micro Devices, Inc.
+// Copyright © 2023-2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
 #include <aotriton/_internal/packed_kernel.h>

--- a/v2src/triton_kernel.cc
+++ b/v2src/triton_kernel.cc
@@ -5,6 +5,7 @@
 #include <aotriton/_internal/triton_kernel.h>
 #include <aotriton/runtime.h>
 #include <iostream>
+#include <string>
 #include <mutex>
 
 #ifdef NDEBUG
@@ -25,6 +26,38 @@
 
 namespace AOTRITON_NS {
 
+constexpr std::string_view INTER_KERNEL_FUNC { "-Sig-F__" };
+constexpr std::string_view INTER_FUNC_PSEL { "__P__" };
+constexpr std::string_view INTER_PSEL_COPT { "__CO__" };
+constexpr std::string_view INTER_COPT_ARCH { "-Gpu-" };
+
+std::string construct_stem_name(std::string_view kernel_name,
+                                std::string_view func_name,
+                                std::string_view psel_name,
+                                std::string_view copt_name,
+                                std::string_view arch_name) {
+  std::string ret;
+  ret.reserve(kernel_name.size() +
+              INTER_KERNEL_FUNC.size() +
+              func_name.size() +
+              INTER_FUNC_PSEL.size() +
+              psel_name.size() +
+              INTER_PSEL_COPT.size() +
+              copt_name.size() +
+              INTER_COPT_ARCH.size() +
+              arch_name.size());
+  ret += kernel_name;
+  ret += INTER_KERNEL_FUNC;
+  ret += func_name;
+  ret += INTER_FUNC_PSEL;
+  ret += psel_name;
+  ret += INTER_PSEL_COPT;
+  ret += copt_name;
+  ret += INTER_COPT_ARCH;
+  ret += arch_name;
+  return ret;
+}
+
 TritonKernel::DeviceFunction::DeviceFunction(int device_id_, hipModule_t mod_, hipFunction_t func_)
   : device_id(device_id_)
   , mod(mod_)
@@ -37,13 +70,17 @@ TritonKernel::DeviceFunction::~DeviceFunction() {
   }
 }
 
-TritonKernel::TritonKernel(const char* package_path, const char* stem_name)
-  : package_path_(package_path)
-  , stem_name_(stem_name) {
+TritonKernel::TritonKernel(uint64_t blake2b, std::string_view psel, std::string_view copt)
+  : blake2b_(blake2b)
+  , ksig_psel_(psel)
+  , ksig_copt_(copt) {
 }
 
 hipError_t
-TritonKernel::invoke(const char* kernel_name,
+TritonKernel::invoke(std::string_view kernel_name,
+                     std::string_view package_path,
+                     std::string_view func_name,
+                     std::string_view arch_name,
                      dim3 grid,
                      std::vector<void*>& args,
 #if AOTRITON_BUILD_FOR_TUNING
@@ -70,7 +107,11 @@ TritonKernel::invoke(const char* kernel_name,
     func = cfind_function(device_id);
     if (!func) {
       hipError_t err;
-      std::tie(func, err) = load_for_device(device_id, kernel_name);
+      std::tie(func, err) = load_for_device(device_id,
+                                            kernel_name,
+                                            package_path,
+                                            func_name,
+                                            arch_name);
     }
   }
 #if AOTRITON_BUILD_FOR_TUNING
@@ -99,7 +140,11 @@ TritonKernel::cfind_function(int device_id) const {
 }
 
 std::tuple<hipFunction_t, hipError_t>
-TritonKernel::load_for_device(int device_id, const char* kernel_name) {
+TritonKernel::load_for_device(int device_id,
+                              std::string_view kernel_name,
+                              std::string_view package_path,
+                              std::string_view func_name,
+                              std::string_view arch_name) {
   hipJitOption opt[] = { hipJitOptionErrorLogBufferSizeBytes,
                          hipJitOptionErrorLogBuffer,
                          hipJitOptionInfoLogBufferSizeBytes,
@@ -114,11 +159,12 @@ TritonKernel::load_for_device(int device_id, const char* kernel_name) {
                      (void*)(uintptr_t)log.size(),
                      log.data(),
                      (void*)(uintptr_t)1 };
+  std::string stem_name = construct_stem_name(kernel_name, func_name, ksig_psel_, ksig_copt_, arch_name);
 
 #if AOTRITON_KERNEL_VERBOSE
-  std::cerr << "Trying to decompress kernel " << package_path_ << " " << stem_name_ << std::endl;
+  std::cerr << "Trying to decompress kernel " << package_path << " " << stem_name << std::endl;
 #endif
-  decompress_kernel();
+  decompress_kernel(package_path, stem_name);
 #if AOTRITON_KERNEL_VERBOSE
   std::cerr << "Decompress kernel to " << essentials_.image << std::endl;
 #endif
@@ -128,7 +174,7 @@ TritonKernel::load_for_device(int device_id, const char* kernel_name) {
   hipModule_t mod;
   hipFunction_t func;
   AOTRITON_HIP_CHECK_RETURN(hipModuleLoadDataEx(&mod, essentials_.image, 5, opt, optval));
-  AOTRITON_HIP_CHECK_RETURN(hipModuleGetFunction(&func, mod, kernel_name));
+  AOTRITON_HIP_CHECK_RETURN(hipModuleGetFunction(&func, mod, kernel_name.data()));
   funcache_.emplace(std::piecewise_construct,
                     std::forward_as_tuple(device_id),
                     std::forward_as_tuple(device_id, mod, func));
@@ -153,7 +199,8 @@ TritonKernel::get_image_info_iff_decompressed() const {
 // tell if a kernel is loaded, or the kernel image failed to compile and thus
 // does not exists from beginning by testing essentials_.image == nullptr
 void
-TritonKernel::decompress_kernel() {
+TritonKernel::decompress_kernel(std::string_view package_path,
+                                const std::string stem_name) {
   if (kernel_loaded_) {
     return ;
   }
@@ -165,14 +212,14 @@ TritonKernel::decompress_kernel() {
     return ;
   }
   if (!packed_kernel_) {
-    packed_kernel_ = PackedKernel::open(package_path_);
+    packed_kernel_ = PackedKernel::open(package_path);
   }
   if (packed_kernel_) { // open may fail
 #if AOTRITON_KERNEL_VERBOSE
     std::cerr << "PackedKernel::open returns " << packed_kernel_.get()
               << " status: " << packed_kernel_->status() << std::endl;
 #endif
-    essentials_ = packed_kernel_->filter(stem_name_);
+    essentials_ = packed_kernel_->filter(stem_name);
   }
   // FIXME: There should be a memory barrier here for non-X86 CPUs.
   kernel_loaded_ = true;

--- a/v2src/triton_kernel.cc
+++ b/v2src/triton_kernel.cc
@@ -70,10 +70,13 @@ TritonKernel::DeviceFunction::~DeviceFunction() {
   }
 }
 
-TritonKernel::TritonKernel(uint64_t blake2b, std::string_view psel, std::string_view copt)
-  : blake2b_(blake2b)
-  , ksig_psel_(psel)
-  , ksig_copt_(copt) {
+void TritonKernel::delayed_init(uint32_t blake2b_lo,
+                                uint32_t blake2b_hi,
+                                const char* psel,
+                                const char* copt) {
+  blake2b_ = (uint64_t) blake2b_hi << 32 | blake2b_lo;
+  ksig_psel_ = psel;
+  ksig_copt_ = copt;
 }
 
 hipError_t


### PR DESCRIPTION
## Summary

This PR reduces the `libaotriton_v2.so` from 49 MiB to 9.6 MiB (Release build, all default arches in 0.9b).

## Major Changes

* [shim] share common substring of TritonKernel's stem_name
* [shim] remove `#include <iostream>`
* [build] change default visibility to "hidden"
* [shim] deduplicate the binning lambda functions
* [shim] replace std::function with function pointers
* [shim] Store autotune strings compactly and re-write the TritonKernel initialization with loop
* [shim] re-order the perf fields with sizes.

## Minor Changes

* [v2python] move build_object_file_description to ObjectFileDescription
* [doc] update the build instruction to use `ninja install/strip`
* LICENSE: Update Copyright years