### PR TITLE
dockerfile: build script for 0.10b

### DIFF
--- a/dockerfile/build.sh
+++ b/dockerfile/build.sh
@@ -39,8 +39,14 @@ if [ -z ${TRITON_LLVM_HASH+x} ]; then
     0.8b)
       TRITON_LLVM_HASH="bd9145c8"
       ;;
+    0.8.*b)
+      TRITON_LLVM_HASH="bd9145c8"
+      ;;
+    0.9b)
+      TRITON_LLVM_HASH="86b69c31"
+      ;;
     *)
-      echo "Only 0.7b, 0.7.xb and 0.8b are supported right now"
+      echo "Unknown AOTRITON_GIT_NAME ${AOTRITON_GIT_NAME}. Please set TRITON_LLVM_HASH explicitly."
       exit
       ;;
   esac

--- a/dockerfile/build.sh
+++ b/dockerfile/build.sh
@@ -50,15 +50,26 @@ if [ -z ${NOIMAGE_MODE+x} ]; then
   NOIMAGE_MODE="OFF"
 fi
 
-DOCKER_IMAGE=aotriton:manylinux_2_28-buildenv-tiny
+if [ -z ${DOCKER_IMAGE+x} ]; then
+  DOCKER_IMAGE=aotriton:manylinux_2_28-buildenv-tiny
+fi
 
 if [ -z "$(docker images -q ${DOCKER_IMAGE} 2> /dev/null)" ]; then
   if [ -z ${AMDGPU_INSTALLER+x} ]; then
-    build_options="--build-arg amdgpu_installer=${AMDGPU_INSTALLER}"
-  else
     build_options=""
+  else
+    build_options="--build-arg amdgpu_installer=${AMDGPU_INSTALLER}"
   fi
-  docker build ${build_options} -t ${DOCKER_IMAGE} -f manylinux_2_28.Dockerfile .
+  if [ -z ${AMDGPU_INSTALLER_SELECT_VERSION+x} ]; then
+    version_selection="true"
+  else
+    version_selection="${AMDGPU_INSTALLER_SELECT_VERSION}"
+  fi
+  echo "docker build ${build_options} ${version_selection} -t ${DOCKER_IMAGE} -f manylinux_2_28.Dockerfile ."
+  docker build ${build_options} \
+    --build-arg amdgpu_installer_select_version="${version_selection}" \
+    -t ${DOCKER_IMAGE} \
+    -f manylinux_2_28.Dockerfile .
 fi
 
 if [ "$WORKSPACE" == "tmpfs" ]; then

--- a/dockerfile/input/install.sh
+++ b/dockerfile/input/install.sh
@@ -2,12 +2,17 @@
 
 TRITON_LLVM_HASH=$1
 AOTRITON_GIT_NAME="$2"
-AOTRITON_TARGET_GPUS="$3"
+AOTRITON_TARGET_ARCH="$3"
 NOIMAGE_MODE="$4"
+
+if [[ -z "${AOTRITON_GIT_NAME}" ]]; then
+  echo 'Must define AOTRITON_GIT_NAME environment variable'
+  exit 1
+fi
 
 if [ "$NOIMAGE_MODE" = "OFF" ]; then
   echo /input/install_triton.sh ${TRITON_LLVM_HASH}
   bash /input/install_triton.sh ${TRITON_LLVM_HASH}
 fi
-echo /input/install_aotriton.sh ${AOTRITON_GIT_NAME} "${AOTRITON_TARGET_GPUS}" "${NOIMAGE_MODE}"
-bash /input/install_aotriton.sh ${AOTRITON_GIT_NAME} "${AOTRITON_TARGET_GPUS}" "${NOIMAGE_MODE}"
+echo /input/install_aotriton.sh ${AOTRITON_GIT_NAME} "${AOTRITON_TARGET_ARCH}" "${NOIMAGE_MODE}"
+bash /input/install_aotriton.sh ${AOTRITON_GIT_NAME} "${AOTRITON_TARGET_ARCH}" "${NOIMAGE_MODE}"

--- a/dockerfile/input/install_aotriton.sh
+++ b/dockerfile/input/install_aotriton.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 AOTRITON_GIT_NAME="$1"
-AOTRITON_TARGET_GPUS="$2"
+AOTRITON_TARGET_ARCH="$2"
 NOIMAGE_MODE="$3"
 
 cd /root/build
 (
-  git clone --recursive https://github.com/ROCm/aotriton.git
+  git clone --recursive ${AOTRITON_GIT_URL}
   cd aotriton
   git checkout ${AOTRITON_GIT_NAME}
   git submodule sync
@@ -27,6 +27,11 @@ if [ "$NOIMAGE_MODE" = "OFF" ]; then
 else
   scl enable gcc-toolset-13 "cd aotriton; python -m pip install -r requirements.txt"
 fi
-scl enable gcc-toolset-13 "mkdir -p aotriton/build; cd aotriton/build; cmake .. -DCMAKE_PREFIX_PATH=/opt/rocm -DPYTHON_EXECUTABLE=/usr/bin/python3.11 -DCMAKE_INSTALL_PREFIX=installed_dir/aotriton -DCMAKE_BUILD_TYPE=Release -DAOTRITON_GPU_BUILD_TIMEOUT=0 \"-DTARGET_GPUS=${AOTRITON_TARGET_GPUS}\" -DAOTRITON_NO_PYTHON=ON -DAOTRITON_NOIMAGE_MODE=${NOIMAGE_MODE} -G Ninja && ninja install"
+scl enable gcc-toolset-13 "mkdir -p aotriton/build; cd aotriton/build; cmake .. -DCMAKE_PREFIX_PATH=/opt/rocm -DPYTHON_EXECUTABLE=/usr/bin/python3.11 -DCMAKE_INSTALL_PREFIX=installed_dir/aotriton -DCMAKE_BUILD_TYPE=Release -DAOTRITON_GPU_BUILD_TIMEOUT=0 \"-DAOTRITON_TARGET_ARCH=${AOTRITON_TARGET_ARCH}\" -DAOTRITON_NO_PYTHON=ON -DAOTRITON_NOIMAGE_MODE=${NOIMAGE_MODE} -G Ninja && ninja install/strip"
 rocmver=$(scl enable gcc-toolset-13 "cpp -I/opt/rocm/include /input/print_rocm_version.h"|tail -n 1|sed 's/ //g')
-cd /root/build/aotriton/build/installed_dir && tar cz aotriton > /output/aotriton-${AOTRITON_GIT_NAME}-manylinux_2_28_x86_64-rocm${rocmver}-shared.tar.gz
+if [ -z ${AOTRITON_TARBALL_SHARD} ]; then
+  tarfile=aotriton-${AOTRITON_GIT_NAME}-manylinux_2_28_x86_64-rocm${rocmver}-shared.tar.gz
+else
+  tarfile=aotriton-${AOTRITON_GIT_NAME}-manylinux_2_28_x86_64-rocm${rocmver}-shared.shard${AOTRITON_TARBALL_SHARD}.tar.gz
+fi
+cd /root/build/aotriton/build/installed_dir && tar cz aotriton > /output/${tarfile}

--- a/dockerfile/manylinux_2_28.Dockerfile
+++ b/dockerfile/manylinux_2_28.Dockerfile
@@ -1,7 +1,7 @@
 FROM almalinux:8 AS buildenv
 
 RUN dnf install -y gcc-toolset-13 python3.11 python3.11-devel \
-    zstd libzstd-devel xz-devel zlib-devel git which vim && \
+    zstd libzstd-devel xz-devel zlib-devel git which vim wget && \
     update-alternatives --set python /usr/bin/python3.11 && \
     update-alternatives --set python3 /usr/bin/python3.11 && \
     python -m ensurepip && \
@@ -9,4 +9,5 @@ RUN dnf install -y gcc-toolset-13 python3.11 python3.11-devel \
 RUN mkdir /root/build
 
 ARG amdgpu_installer="https://repo.radeon.com/amdgpu-install/6.2.2/el/8.10/amdgpu-install-6.2.60202-1.el8.noarch.rpm"
-RUN yum install -y "${amdgpu_installer}" && amdgpu-install --usecase=hip --no-dkms --no-32 -y && dnf install -y hipcc rocm-device-libs
+ARG amdgpu_installer_select_version="true"
+RUN yum install -y "${amdgpu_installer}" && bash -c "${amdgpu_installer_select_version}" && amdgpu-install --usecase=hip --no-dkms --no-32 -y && dnf install -y hipcc rocm-device-libs hip-devel


### PR DESCRIPTION
## Changes

* Support `AMDGPU_INSTALLER` and `AMDGPU_INSTALLER_SELECT_VERSION` to select/set ROCM installer package.
* Add TRITON_LLVM_HASH for 0.8b/0.9b/0.10b
* Support build from forked repo with env var `AOTRITON_GIT_URL`
* Allow delete docker container after complete by setting env var `DELETE_ONCE_COMPLETE_OPTION='--rm'`
* Allow add `.shard{N}` to file name with env var `AOTRITON_TARBALL_SHARD=N`
* Use `ninja install/strip` instead