### PR TITLE
Add gfx1101 target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(AOTRITON_BUILD_FOR_TUNING_BUT_SKIP_KERNEL "" CACHE STRING "Use tuning databa
 option(AOTRITON_ENABLE_FP32_INPUTS "Enable FP32 support." ON)
 option(AOTRITON_NOIMAGE_MODE "Only build C++ Shim part. Kernel image builds are disabled" OFF)
 set(AOTRITON_GPU_BUILD_TIMEOUT "8.0" CACHE STRING "GPU kernel compiler times out after X minutes. 0 for indefinite. Highly recommended if AOTRITON_BUILD_FOR_TUNING=On.")
-set(AOTRITON_TARGET_ARCH "gfx90a;gfx942;gfx950;gfx1100;gfx1151;gfx1150;gfx1201;gfx1200" CACHE STRING "Target GPU Architecture. Select all GPUs within the given list")
+set(AOTRITON_TARGET_ARCH "gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1151;gfx1150;gfx1201;gfx1200" CACHE STRING "Target GPU Architecture. Select all GPUs within the given list")
 set(TARGET_GPUS "OBSOLETE" CACHE STRING "OBSOLETE. To select only one GPU, use AOTRITON_TARGET_ARCH or AOTRITON_OVERRIDE_TARGET_GPUS.")
 set(AOTRITON_OVERRIDE_TARGET_GPUS "" CACHE STRING "Override AOTRITON_TARGET_ARCH, and only build for GPUs within this list.")
 

--- a/v3python/gpu_targets.py
+++ b/v3python/gpu_targets.py
@@ -10,6 +10,7 @@ AOTRITON_SUPPORTED_GPUS = (
     # 'gfx942_mod2',
     'gfx950_mod0',
     'gfx1100_mod0',
+    'gfx1101_mod0',
     'gfx1151_mod0',
     'gfx1150_mod0',
     'gfx1201_mod0',
@@ -20,6 +21,7 @@ AOTRITON_SUPPORTED_GPUS = (
 # TODO: AOTRITON_TUNING_DATABASE_REUSE -> AOTRITON_TUNING_DATABASE_FALLBACK
 # Load fallback entries first, and override with "patching" entries from real GPU
 AOTRITON_TUNING_DATABASE_REUSE = {
+    'gfx1101_mod0' : 'gfx1100_mod0',
     'gfx1200_mod0' : 'gfx1201_mod0',
     'gfx1151_mod0' : 'gfx1100_mod0',
     'gfx1150_mod0' : 'gfx1100_mod0',
@@ -48,6 +50,7 @@ AOTRITON_ARCH_WARPSIZE = {
     'gfx942'     : 64,
     'gfx950'     : 64,
     'gfx1100'    : 32,
+    'gfx1101'    : 32,
     'gfx1151'    : 32,
     'gfx1150'    : 32,
     'gfx1201'    : 32,
@@ -60,6 +63,7 @@ AOTRITON_ARCH_PRODUCTION_LINE = {
     'gfx942'     : 'CDNA',
     'gfx950'     : 'CDNA',
     'gfx1100'    : 'RDNA',
+    'gfx1101'    : 'RDNA',
     'gfx1151'    : 'RDNA',
     'gfx1150'    : 'RDNA',
     'gfx1201'    : 'RDNA',


### PR DESCRIPTION
## Motivation

This PR adds the gfx1101 CMake and v3 target.

## Technical Details

Adding the target enables the use of experimental support for Memory Efficient Attention.

## Test Plan

Ran a DLM vLLM test with both TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL set to 0 and to 1.

## Test Result

With experimental features enabled the test showed significantly lower memory utilization by PyTorch.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
