### PR TITLE
Xinyazhang/mold ci

### DIFF
--- a/.ci/build-shim.sh
+++ b/.ci/build-shim.sh
@@ -13,7 +13,8 @@ fi
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 . "${SCRIPT_DIR}/common-build.sh"
 
-common_build "$1" "test" \
+common_build "$1" "shim" \
+  -DAOTRITON_NOIMAGE_MODE=ON \
   -DAOTRITON_GPU_BUILD_TIMEOUT=0 \
   -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold" \
   -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"

--- a/.ci/common-build.sh
+++ b/.ci/common-build.sh
@@ -4,34 +4,37 @@ SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 . "${SCRIPT_DIR}/common-vars.sh"
 
 function _common_build() {
-  target_arch="$1"
-  build_type="$2"
-  cmake_option0="$3"
-  bdir="build-${aotriton_major}.${aotriton_minor}-${build_type}-${target_arch}"
+  build_type="$1"
+  suffix="$2"
+  target_arch="$3"
+  build_for="$4"
+  shift 4
+  bdir="build-${aotriton_major}.${aotriton_minor}-${build_for}-${target_arch}"
   mkdir -p ${SCRIPT_DIR}/../${bdir}
   (
     cd ${SCRIPT_DIR}/../${bdir};
     cmake .. -DCMAKE_INSTALL_PREFIX=./install_dir \
-      -DCMAKE_BUILD_TYPE=$4 \
+      -DCMAKE_BUILD_TYPE=${build_type} \
       -DAOTRITON_TARGET_ARCH=${target_arch} \
-      ${cmake_option0} \
-      -DAOTRITON_NAME_SUFFIX=123 -G Ninja;
+      -DAOTRITON_NAME_SUFFIX=${suffix} \
+      "$@" \
+      -G Ninja;
     ninja install/strip
   )
 }
 
 function common_build() {
-  if [ "$#" -ne 3 ]; then
-    echo 'common_build expects 3 arguments: <target arch> <build type> <cmake option>' >&2
+  if [ "$#" -lt 2 ]; then
+    echo 'common_build expects at least 2 arguments: <target arch> <build for> [cmake options...]' >&2
     exit 1
   fi
-  _common_build "$@" Release
+  _common_build Release "123" "$@"
 }
 
 function debug_build() {
-  if [ "$#" -ne 3 ]; then
-    echo 'common_build expects 3 arguments: <target arch> <build type> <cmake option>' >&2
+  if [ "$#" -lt 2 ]; then
+    echo 'common_build expects at least 2 arguments: <target arch> <build for> [cmake options..]' >&2
     exit 1
   fi
-  _common_build "$@" Debug
+  _common_build Debug "123" "$@"
 }

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -18,7 +18,7 @@ test_level="$2"
 backend="$3"
 bdir="build-${aotriton_major}.${aotriton_minor}-test-${native_arch}"
 
-small_vram=$(amd-smi static -g 0 -v --json| python -c 'import json, sys; j = json.load(sys.stdin); print(int(j["gpu_data"][0]["vram"]["size"]["value"] / 1024.0 < 60))')
+small_vram=$(amd-smi static -g 0 -v --json|grep -v '^WARNING:'| python -c 'import json, sys; j = json.load(sys.stdin); print(int(j["gpu_data"][0]["vram"]["size"]["value"] / 1024.0 < 60))')
 
 (
   ulimit -c 0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
-project(AOTriton CXX C)
+project(AOTriton CXX C ASM)
 
 # Version numbers
 set(AOTRITON_VERSION_MAJOR_INT 0)

--- a/v3python/comment_only_asm.py
+++ b/v3python/comment_only_asm.py
@@ -14,26 +14,17 @@ def parse():
     args = p.parse_args()
     return args
 
-def write_linker_script(args):
+def write_assembly(args):
     string = f"AOTriton {args.major}.{args.minor}.{args.patch}"
-    string = string.encode('ascii')
     with open(args.o, 'w') as f:
-        print("""SECTIONS
-{
-  .comment : {
-    KEEP(*(.comment))
-    BYTE(0)""", file=f)
-        for c in string:
-            print(f"    BYTE(0x{c:02x})", file=f)
-        print("""    BYTE(0)
-  }
-}
-INSERT AFTER .comment;
-""", file=f)
+        print(f""".section .comment
+msg: .ascii "{string}\\0"
+len = . - msg""", file=f)
+
 
 def main():
     args = parse()
-    write_linker_script(args)
+    write_assembly(args)
 
 if __name__ == "__main__":
     main()

--- a/v3src/CMakeLists.txt
+++ b/v3src/CMakeLists.txt
@@ -255,20 +255,21 @@ if(NOT WIN32)
   execute_process(
     COMMAND ${CMAKE_COMMAND}
     -E env VIRTUAL_ENV=${VENV_DIR}
-    "${VENV_BIN_PYTHON}" -m v3python.ld_script
-    -o "${AOTRITON_V2_BUILD_DIR}/set_aotriton_version.ld"
+    "${VENV_BIN_PYTHON}" -m v3python.comment_only_asm
+    -o "${AOTRITON_V2_BUILD_DIR}/set_aotriton_version.s"
     ${AOTRITON_VERSION_MAJOR_INT}
     ${AOTRITON_VERSION_MINOR_INT}
     ${AOTRITON_VERSION_PATCH_INT}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_PARENT_DIR}"
     COMMAND_ERROR_IS_FATAL ANY
   )
-  target_link_options(aotriton_v2 PRIVATE
-                      -T "${AOTRITON_V2_BUILD_DIR}/set_aotriton_version.ld")
+  target_sources(aotriton_v2 PRIVATE "${AOTRITON_V2_BUILD_DIR}/set_aotriton_version.s")
+else()
+  # FIXME: Add version string to Windows binaries.
 endif()
-  # Otherwise the binary size blows up
-  # FIXME: Properly export symbols
-  set_target_properties(aotriton_v2 PROPERTIES CXX_VISIBILITY_PRESET hidden)
+# Otherwise the binary size blows up
+# FIXME: Properly export symbols
+set_target_properties(aotriton_v2 PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
 include(GNUInstallDirs)
 message("CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}")


### PR DESCRIPTION
# Overview

This PR switches to [MOLD linker](https://github.com/rui314/mold) in `build-test.sh` and `build-shim.sh` for better linking time.

## Major Changes

* [build] Replace the linker script with assembly code to generate `.comment` section
* [ci] use mold instead of the default linker in `build-test.sh` and `build-shim.sh`

## Known Problems

* `mold` does not merge `.comment` sections from multiple object files while GNU ld does
* The ASM code generate does not work on Windows. However, Windows has its own way to embed version numbers to .DLLs