### PR TITLE
Fix warning 'missing .note.GNU-stack section implies executable stack'

### DIFF
--- a/v3python/comment_only_asm.py
+++ b/v3python/comment_only_asm.py
@@ -17,7 +17,8 @@ def parse():
 def write_assembly(args):
     string = f"AOTriton {args.major}.{args.minor}.{args.patch}"
     with open(args.o, 'w') as f:
-        print(f""".section .comment
+        print(f""".section .note.GNU-stack,"",@progbits
+.section .comment
 msg: .ascii "{string}\\0"
 len = . - msg""", file=f)
 


### PR DESCRIPTION
## Overview

Assembly code needs `.section .note.GNU-stack`, otherwise linker warns.
