### PR TITLE
Remove stray line in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,4 +272,3 @@ add_subdirectory(v3src)
 if(NOT AOTRITON_NO_PYTHON)
   add_subdirectory(bindings) # FIXME: compile python binding
 endif()
-pick cb6a160 # aiter: change pin


### PR DESCRIPTION
Removed a stray line that found its way into CMakeLists.txt and was breaking the build.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
