### PR TITLE
Use SHA-256 file names

### DIFF
--- a/.ci/build-release.sh
+++ b/.ci/build-release.sh
@@ -48,7 +48,7 @@ if [ "${target_arch}" = "ALL" ]; then
   target_arch="${default_target_arch}"
 fi
 
-source_dir="${SCRIPT_DIR}/.."
+source_dir=$(realpath ${SCRIPT_DIR}/..)
 if [ -n "${AOTRITON_BUILD_PATH}" ]; then
   bdir="${AOTRITON_BUILD_PATH}"
 else

--- a/.claude/agents/codegen.md
+++ b/.claude/agents/codegen.md
@@ -74,6 +74,27 @@ Kernel specs in `v3python/rules/` define:
 - `FEAT_CHOICES` — dict of feature flag → list of bool/int values
 - `AUTOTUNE_KEYS` — which input dimensions drive the LUT binning (e.g., seqlen_q, seqlen_k)
 
+### Implied change relationships
+
+Some changes in the codegen pipeline are **implied** by a higher-level change
+and easy to miss when writing PR descriptions. Key examples:
+
+- **HSACO entry name format change → `autotune.py` `func_name`**: The C++
+  runtime (in `v3src/triton_kernel.cc`) reconstructs the AKS2 entry name from
+  section strings embedded in the generated autotune `.cc` files. When
+  `hsaco_inaks2_name`/`hsaco_entry_name` format changes, `autotune.py` must
+  embed the same format via `func_name` (now `unified_signature` instead of
+  `signature_in_func_name`) so the reconstructed name matches the AKS2 archive
+  key. This is a required consistency constraint, not an independent change.
+
+- **`unified_signature` → `tunecc_signature`**: When `unified_signature` format
+  changes, `tunecc_signature` (which builds on it) changes too, affecting the
+  SHA-256 of autotune `.cc` filenames.
+
+When asked to identify implied changes for a PR, trace the data flow:
+entry name construction (Python) → embedded strings in generated `.cc` →
+C++ runtime reconstruction → AKS2 lookup. Any break in this chain is a bug.
+
 ### What this agent can help with
 
 - Adding a new kernel or operator to `v3python/rules/`

--- a/.claude/agents/prwriter.md
+++ b/.claude/agents/prwriter.md
@@ -1,0 +1,249 @@
+---
+name: prwriter
+description: Use this agent to draft PR descriptions for AOTriton pull requests. It knows the house style: section structure, component tagging, tone, and how to present known issues. Invoke with a summary of what changed and it will produce a ready-to-post PR description.
+---
+
+You are a PR description writer for the AOTriton project. Your task is to produce PR descriptions that match the established house style exactly.
+
+## Document Structure
+
+Every PR description follows this skeleton (omit sections that don't apply):
+
+```
+# Overview
+
+<1–4 sentences. State the purpose of the PR. Include concrete metrics if
+performance is involved. Reference the command used to measure if relevant.>
+
+## Major Changes   ← significant behaviour or API changes
+## Minor Changes   ← small fixes, cleanup, refactors
+## Known Issues    ← (also acceptable: "Known Problems", "Known Limitations")
+## CAVEAT          ← user-facing gotchas that must not be missed
+## Note            ← design rationale worth preserving in the record
+## Lessons         ← post-mortems or decisions validated by this PR
+## Usage           ← setup/invocation steps for new infrastructure
+## Documents       ← new classes, APIs, or concepts that need explanation
+```
+
+Use `## Changes` (a single flat list) when the PR is a cleanup or removal with no meaningful major/minor split (see PR174 style).
+
+## Bullet Format
+
+Top-level bullets use `*`, nested points use `+`:
+
+```
+* [component] One sentence describing the change.
+  + Sub-detail, elaboration, or nested impact.
+  + Another sub-point.
+* [component] Next change.
+```
+
+Every substantive bullet starts with a `[component]` tag. Common tags:
+
+| Tag | Meaning |
+|---|---|
+| `[kernel]` / `[tritonsrc]` | Triton kernel source changes |
+| `[rules]` | Kernel/operator rule definitions (`v3python/rules/`) |
+| `[codegen]` | Code generator (`v3python/codegen/`) |
+| `[shim]` | Generated shim headers/sources |
+| `[gen]` | Generator invocation or build integration |
+| `[db]` | Tuning database schema or content |
+| `[tune]` | Tuning infrastructure |
+| `[pq]` | PostgreSQL queue package |
+| `[localq]` | Unix-socket local queue |
+| `[worker]` | GPU tuning worker |
+| `[webui]` | Web UI |
+| `[api]` | Public C++ API |
+| `[binding]` | Python bindings |
+| `[build]` | CMake / build system |
+| `[ci]` | CI scripts |
+| `[test]` | Test suite |
+| `[doc]` | Documentation |
+| `[release]` | Release scripts or version bumps |
+| `[signature]` | Kernel signature / hsaco naming |
+| `[aks2]` | AKS2 archive / image packaging |
+| `[flash]` / `[flash_op]` | Flash attention kernel or operator specifically |
+
+Add a new tag if no existing one fits; keep it lowercase and short.
+
+## Tone and Style Rules
+
+- **Active voice, imperative verbs**: "Add", "Fix", "Replace", "Remove", "Bump" — not "was added", "has been fixed"
+- **Technical and precise**: use domain terms (HSACO, functional, backend, metro kernel, optune, autotune) without defining them
+- **No filler**: every sentence carries information; no motivational prose about why the project matters
+- **Assume expert readers**: reviewers know the codebase; skip obvious context
+- **Concrete over vague**: include file paths, class names, column names, TFLOPS numbers, timing deltas
+- **Unapologetic about known issues**: state them plainly; do not soften or promise future fixes unless a fix is actually planned
+- **Cross-reference** related PRs and commits: "introduced in PR #96", "deprecated in PR #164"
+- Use backticks for inline code, class names, argument names, file paths: `` `tunecc_signature` ``, `` `v3python/codegen/` ``
+
+## Content Practices
+
+- **Show real examples for format changes** — when a data format changes, include actual values in sub-bullets, not just abstract schemas. Readers need to see what the data looks like:
+  ```
+  + `hsaco_inaks2_name` now uses human-readable format, e.g.:
+    - `#F;Q='*bf16:16';BLOCK_DMODEL=160;PADDED_HEAD=False;...`
+    - `#P;PERSISTENT_TYPE=0;BLOCK_M=32;...`
+  ```
+
+- **Explain *why* the old approach was wrong** when replacing it — don't just state what changed; one clause on the motivation makes the PR self-documenting:
+  ```
+  Replace the old `-Sig-F__...__P__` scheme, which required a UTF-8 char to avoid `*`
+  ```
+
+- **Expand non-obvious acronyms on first use** in a sub-bullet:
+  ```
+  + `.nsv` manifest maps `abs_path\x00entry_name`
+    - `nsv` is for "null-separated variables"
+  ```
+
+- **Consolidate to the dominant subsystem tag** — don't split one cohesive change across `[signature]`, `[shim]`, and `[gen]` when `[codegen]` covers the theme. Over-tagging fragments the narrative.
+
+- **Three-level bullets** (`*` / `+` / `-`) are acceptable for sub-sub-details; use sparingly.
+
+- **Collapse structural scaffolding** into the bullet that motivated it — e.g. a new class attribute that exists solely to support a feature goes as a sub-bullet of that feature, not as its own top-level bullet.
+
+- **Old format details belong in sub-bullets** of the bullet describing the replacement, not as separate entries.
+
+- **Omit design rationale already in `CLAUDE.md`** — the `## Note` section is for rationale not captured elsewhere; don't repeat what's already documented.
+
+## Performance Metrics
+
+When performance numbers are relevant, include them in the Overview with the measurement command:
+
+```
+This update delivers 904 TFLOPS on MI355X, improved from 753 TFLOPS without pipelining.
+
+Measured with:
+```
+TRITON_PRINT_AUTOTUNING=1 USE_CAUSAL=0 N_CTX=14 D_HEAD=128 N_HEADS=64 python tritonsrc/performance_forward.py
+```
+```
+
+## Known Issues Section
+
+Be specific: what is broken, why it was not fixed in this PR, and whether a workaround exists:
+
+```
+# Known Issues
+
+* [tritonsrc] autotune is still broken for gfx90a under GQA n_heads=(16,8),
+  dtype=fp16, hdim=128, seqlen=2048 — unidentified compiler issue.
+* [db] Tuning database not updated to reflect new kernel arguments; re-tuning required.
+```
+
+## CAVEAT Section
+
+Use `# CAVEAT` (H1, not H2) for user-facing gotchas that are easy to miss:
+
+```
+# CAVEAT
+
+Empty tensors must be passed as `None`, not as zero-sized tensors, when
+calling `op_attn_fwd`. Passing a zero-sized tensor will silently produce
+wrong results on gfx90a.
+```
+
+## Implied Changes
+
+Some changes are implied by a major feature rather than being independent —
+the downstream code *must* change to maintain a consistency invariant, but it
+is not obvious from the diff alone. Always check for these before finalising
+the description.
+
+For PRs touching the codegen pipeline (`v3python/codegen/`, `v3python/base/`,
+`v3src/`), consult the **codegen agent** to identify implied changes. Ask it:
+"Given that [major change X] was made, what downstream changes in the codegen
+pipeline are implied and required for correctness?"
+
+When listing implied changes in the PR description, place `**implied**` before
+the `[tag]` so the author can spot and verify them easily before posting:
+
+```
+* **implied** [codegen] `autotune.py` uses `unified_signature` for `func_name`
+  to match the new `hsaco_entry_name` format embedded in generated `.cc` files
+```
+
+The author removes the `**implied**` marker after confirming the change is
+present and correctly described, or deletes the bullet if it does not apply.
+
+## Stacked PRs
+
+PRs are often stacked: `upstream/main → (PR X work) → PR X HEAD → (PR Y work) → PR Y HEAD`. In this case PR Y's diff against `main` includes all of PR X's changes, which must not appear in PR Y's description.
+
+**Before drafting, always ask:** "Is this PR based on another PR's branch rather than directly on main? If so, what is the base commit (or branch) I should diff from?"
+
+Once the user provides the base commit or branch, restrict the description to only the changes introduced on top of that base — `git log <base>..HEAD` and `git diff <base>..HEAD`. Never summarise PR X's work inside PR Y's description; reviewers will read PR X separately.
+
+If the user does not know the exact base commit, suggest running:
+```
+git log --oneline upstream/main..HEAD
+```
+and identifying the last commit that belongs to the upstream PR.
+
+## Worked Examples
+
+### Cleanup / removal PR (PR174 style — single flat `## Changes`):
+
+```
+# Overview
+
+Remove V2 API source code, the legacy Celery-based tuner, and stale files
+accumulated over and before the 0.12b cycle. The V2 API was deprecated in PR
+#164 and marked for removal after 0.12b; this PR completes that cleanup (~14 000
+lines deleted). CI level0 v3 tests pass.
+
+## Changes
+
+* Remove `v2src/`, `v2python/`, `include/aotriton/v2/`, and V2
+  implementations in `v3src/flash/`; keep a minimal `bindings/v2.cc`
+  exporting only the symbols still required by the Python bindings
+* Remove Celery-based tuner (`.celery/`) and related legacy scripts
+* [pq] Remove deprecated `complete_task()`; replace `example.py` with an
+  API reference `README.md`
+* Minor: remove empty stubs, stale `.bak` files, and fix a broken
+  `__main__` block in `test_exaid.py`
+```
+
+### Feature PR with performance data (PR162 style):
+
+```
+# Overview
+
+Enable kernel pipelining and XCD remapping for gfx950 (MI350 series).
+Pipelining overlaps memory and compute; XCD remapping distributes work across
+compute dies. Delivers 904 TFLOPS on MI355X, up from 753 TFLOPS.
+
+Measured with:
+```
+TRITON_PRINT_AUTOTUNING=1 USE_CAUSAL=0 N_CTX=14 D_HEAD=128 N_HEADS=64 \
+  python tritonsrc/performance_forward.py
+```
+
+## Major Changes
+
+* [tritonsrc] Enable pipelining for forward and backward kernels
+  + Add pipelining configs to autotune search space
+  + Pass `num_stages` to inner loop kernels when `MASK_STEPS=False`
+* [tritonsrc] Add XCD remapping for multi-die GPUs
+  + Add `NUM_XCDS` kernel argument
+  + Flip `tl.program_id` 0 and 1 for better load balancing
+
+## Minor Changes
+
+* [ci] Document that `<target arch>` accepts semicolon-separated lists
+
+# Known Issues
+
+* `num_warps=8` does not improve BWD kernel or Navi GPU performance
+* Tuning database not updated to use new kernel arguments
+```
+
+## What to Omit
+
+- No screenshots or diagrams
+- No "test plan" boilerplate
+- No contributor credits or review process notes
+- No explanation of why the project or feature is useful to end users
+- No future roadmap beyond what is strictly needed to explain a known limitation
+- **No self-corrections**: if a bug was introduced and fixed within the same PR, omit both — only the net change visible to reviewers belongs in the description

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,15 @@ If you need to perform a database operation:
 
 This keeps all database operations centralized and schema-consistent.
 
+## v3python Package Architecture
+
+The `v3python` package has a strict layering between **description** and **generation**:
+
+- `v3python/base/`, `v3python/kernel/`, `v3python/op/`, `v3python/affine/` — description layer. These serve as structured knowledge for describing kernels and operators, analogous to an AST in a compiler. They should have **minimal knowledge about the code generator**.
+- `v3python/codegen/` — generation layer. This drives the code generation process and is the only layer that should contain codegen logic.
+
+Knowledge must not flow upward: description-layer classes must not import from `codegen/` or embed generation logic. When adding a property or method to `Interface`, `KernelDescription`, `Operator`, or the affine classes, ask whether the concept belongs to the *description* of the kernel/operator (fine) or to the *generation process* (put it in `codegen/` instead).
+
 ## config.rc Usage
 
 **IMPORTANT: `<workdir>/config.rc` is for AOTriton tuning project configuration ONLY.**

--- a/v3python/affine/slim_akdesc.py
+++ b/v3python/affine/slim_akdesc.py
@@ -22,6 +22,7 @@ from ..gpu_targets import AOTRITON_ARCH_TO_PACK
 C++ dispather and does not need to generate one.
 '''
 class SlimAffineKernelDescription(Interface):
+    CODEGEN_MODULE = 'affine'
     TUNE_NAME = None
     FILE_PFX = 'affine'
     NAME = None     # Name for AOTriton shim code

--- a/v3python/aks2.py
+++ b/v3python/aks2.py
@@ -17,7 +17,8 @@ def parse():
     parser = ArgumentParser(description=desc)
     parser.add_argument("-o", help="Output AKS2 file")
     parser.add_argument("--ignore_json", help="Ignore JSON files", action='store_true')
-    parser.add_argument("hsaco_files", nargs='*', help="Input HSACO Files")
+    parser.add_argument("--hsaco_manifest", required=True,
+                        help="NSV file mapping abs HSACO path to its AKS2 entry name")
     args = parser.parse_args()
     return args
 
@@ -37,39 +38,41 @@ _AKS2_DirectoryEntry_BaseSize = (len(fields(AKS2_DirectoryEntry)) - 1) * 4
 def directory_entry_size(entry):
     return entry.filename_length + _AKS2_DirectoryEntry_BaseSize
 
-def load_hsaco(hsaco_rule : str, offset, ignore_json):
-    # Rule syntax
-    # :<aks2 filename>:<.hsaco path>
-    # aks2 filename may contain '/'
-    if hsaco_rule.startswith(':'):
-        _, filename, hsaco = hsaco_rule.split(':', 2)
-        hsaco = Path(hsaco)
-        filename = filename.encode('utf-8')
-    else:
-        hsaco = Path(hsaco_rule)
-        filename = str(hsaco.stem).encode('utf-8')
+def read_manifest(manifest_path: str) -> dict[str, str]:
+    '''Read NUL-separated manifest, return {abs_hsaco_path: aks2_entry_name}.'''
+    text = Path(manifest_path).read_text(encoding='utf-8')
+    result = {}
+    for line in text.splitlines():
+        parts = line.split('\x00')
+        if len(parts) >= 2 and parts[0]:
+            result[parts[0]] = parts[1]
+    return result
+
+def load_hsaco(hsaco_path: str, entry_name: str, offset: int, ignore_json: bool):
+    hsaco = Path(hsaco_path)
+    filename = entry_name.encode('utf-8')
     with open(hsaco, 'rb') as f:
         blob = f.read()
-        if ignore_json:
-            shared_memory_size = 0
-            block_threads = 0
-        else:
-            with open(hsaco.with_suffix('.json')) as jf:
-                j = json.load(jf)
-                if len(blob) > 0:
-                    shared_memory_size = j['shared']
-                    block_threads = j['num_warps'] * j['warp_size']
-                else:
-                    shared_memory_size = 0
-                    block_threads = 0
-                    assert j['compile_status'] != 'Complete'
-        entry = AKS2_DirectoryEntry(shared_memory_size=shared_memory_size,
-                                    block_threads=block_threads,
-                                    offset=offset,
-                                    image_size=len(blob),
-                                    filename_length=len(filename)+1,
-                                    filename=filename)
-        return entry, blob
+    if ignore_json:
+        shared_memory_size = 0
+        block_threads = 0
+    else:
+        with open(hsaco.with_suffix('.json')) as jf:
+            j = json.load(jf)
+            if len(blob) > 0:
+                shared_memory_size = j['shared']
+                block_threads = j['num_warps'] * j['warp_size']
+            else:
+                shared_memory_size = 0
+                block_threads = 0
+                assert j['compile_status'] != 'Complete'
+    entry = AKS2_DirectoryEntry(shared_memory_size=shared_memory_size,
+                                block_threads=block_threads,
+                                offset=offset,
+                                image_size=len(blob),
+                                filename_length=len(filename)+1,
+                                filename=filename)
+    return entry, blob
 
 def u32(val):
     return val.to_bytes(4, byteorder=sys.byteorder, signed=False)
@@ -97,10 +100,10 @@ class AKS2(object):
         self.hsaco_blobs = []
         self.current_offset = 0
 
-    def load(self, args):
-        self.number_of_kernels = len(args.hsaco_files)
-        for hsaco_rule in args.hsaco_files:
-            entry, blob = load_hsaco(hsaco_rule, self.current_offset, args.ignore_json)
+    def load(self, manifest: dict[str, str], ignore_json: bool):
+        self.number_of_kernels = len(manifest)
+        for hsaco_path, entry_name in manifest.items():
+            entry, blob = load_hsaco(hsaco_path, entry_name, self.current_offset, ignore_json)
             self.current_offset += len(blob)
             self.directory.append(entry)
             self.hsaco_blobs.append(blob)
@@ -121,11 +124,12 @@ class AKS2(object):
         f.write(lzc.flush())
 
 def do_create(args):
-    if not args.hsaco_files:
+    manifest = read_manifest(args.hsaco_manifest)
+    if not manifest:
         print("No input file, exit")
         return
     aks2 = AKS2()
-    aks2.load(args)
+    aks2.load(manifest, args.ignore_json)
     with open(Path(args.o).with_suffix('.aks2'), "wb") as f:
         aks2.write(f)
 

--- a/v3python/base/functional.py
+++ b/v3python/base/functional.py
@@ -157,8 +157,7 @@ class Functional(object):
     '''
     @property
     def tunecc_signature(self):
-        sf = self.signature_in_func_name
-        return 'FONLY__' + sf + f'___{self.arch}'
+        return '#F;' + self.unified_signature + f';;arch={self.arch}'
 
     '''
     Used by KSignature to construct full kernel name

--- a/v3python/base/functional.py
+++ b/v3python/base/functional.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
+from functools import cached_property
 from ..gpu_targets import (
     cluster_gpus,
     gpu2arch,
@@ -126,7 +127,7 @@ class Functional(object):
     def fallback_choices(self) -> dict:
         return self.meta_object.fallback_compact_dict(self._compact_dict)
 
-    @property
+    @cached_property
     def unified_signature(self) -> str:
         def fmt(b):
             return f'{b.name}={b.value.testrun_entry_signature}'

--- a/v3python/base/functional.py
+++ b/v3python/base/functional.py
@@ -126,6 +126,12 @@ class Functional(object):
     def fallback_choices(self) -> dict:
         return self.meta_object.fallback_compact_dict(self._compact_dict)
 
+    @property
+    def unified_signature(self) -> str:
+        def fmt(b):
+            return f'{b.name}={b.value.testrun_entry_signature}'
+        return ';'.join(fmt(b) for b in self._binds if b.show_in_compact)
+
     '''
     "core" signature
     only directly used to supply TritonKernel as HSACO name component

--- a/v3python/base/interface.py
+++ b/v3python/base/interface.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 import itertools
+from pathlib import Path
 from .parameter import (
     TemplateParameter as TP,
 )
@@ -22,6 +23,7 @@ Interface: common items b/w Operator, KernelDescription and MetroKernel
 class Interface(ABC):
     FAMILY = None               # Must be defined
     NAME = None                 # Must be defined
+    CODEGEN_MODULE = None       # Must be defined: 'op', 'triton', or 'affine'
     TUNE_NAME = None            # Must be defined autotune/optune
     FILE_PFX = 'iface'          # Op uses iface, while Triton kernel uses 'shim'
     ARGUMENTS = None            # Must be defined
@@ -39,6 +41,16 @@ class Interface(ABC):
     @property
     def UNTYPED_FULL_NAME(self):
         return f'{self.FAMILY}.{self.NAME}'
+
+    '''
+    Stable three-component identifier: FAMILY/CODEGEN_MODULE/NAME
+    (e.g. flash/triton/attn_fwd, flash/op/op_attn_fwd, flash/affine/aiter_fmha_v3_fwd).
+    Used as the --selective argument for code generator subprocesses and as the shard
+    subdirectory key under build_dir/Bare.shards/.
+    '''
+    @property
+    def unique_path(self) -> Path:
+        return Path(self.FAMILY) / self.CODEGEN_MODULE / self.NAME
 
     def _insert_tensor_strides_to_choices(self, last_is_continuous=False):
         log(lambda:f"_insert_tensor_strides_to_choices {self.NAME} {self.TENSOR_STRIDE_INPUTS=}")

--- a/v3python/base/typed_choice.py
+++ b/v3python/base/typed_choice.py
@@ -26,6 +26,11 @@ class TypedChoice(ABC):
         pass
 
     @property
+    def testrun_entry_signature(self) -> str:
+        v = self.triton_compile_signature
+        return repr(v) if isinstance(v, str) else str(v)
+
+    @property
     def sql_value(self):
         return self.triton_compile_signature
 

--- a/v3python/codegen/autotune.py
+++ b/v3python/codegen/autotune.py
@@ -15,7 +15,7 @@ from ..utils import (
 from .common import (
     codegen_struct_cfields,
     MissingLutEntry,
-    hsaco_filename,
+    hsaco_ondisk_name,
     hsaco_dir,
 )
 from .basetune import BaseTuneCodeGenerator
@@ -47,7 +47,7 @@ class AutotuneCodeGenerator(BaseTuneCodeGenerator):
                 if args.build_for_tuning_second_pass:
                     image_path = hsaco_dir(args.build_dir, kdesc)
                     def hsaco_compile_successful(ksig : KernelSignature):
-                        full = image_path / hsaco_filename(kdesc, ksig)
+                        full = image_path / hsaco_ondisk_name(kdesc, ksig)
                         if not full.exists():
                             return False
                         meta = full.with_suffix('.json')
@@ -99,7 +99,7 @@ class AutotuneCodeGenerator(BaseTuneCodeGenerator):
             'godel_number'          : f.godel_number,
             'perf_fields'           : codegen_struct_cfields(kdesc.perf_cfields, nalign=4),
             'package_path'          : package_path,
-            'func_name'             : f.signature_in_func_name,
+            'func_name'             : f.unified_signature,
             'arch_name'             : f.arch,
             'meta_hsacos'           : meta_hsacos,
             'kernel_image_perfs'    : self.codegen_kernel_image_perfs(self._sigs),
@@ -141,8 +141,8 @@ class AutotuneCodeGenerator(BaseTuneCodeGenerator):
             assert len(b2sum_u64) == 16
             b2sum_u64_hi = b2sum_u64[:8]
             b2sum_u64_lo = b2sum_u64[8:]
-            psel_offset = register_string(sig.perf_signature)
-            copt_offset = register_string(sig.copt_signature)
+            psel_offset = register_string(sig.perf_section)
+            copt_offset = register_string(sig.copt_section)
             meta_hsacos.append(f'{{ 0x{b2sum_u64_hi}u, 0x{b2sum_u64_lo}u, {psel_offset}, {copt_offset} }}, // {b2sum_u64} = b2sum -l 64 <<< {u8raw}')
         # assert string_dict[None] < 2 ** 16 - 1, f'Packed string size {string_dict[None]} exceeds uint16_t limit'
         # del string_dict[None]

--- a/v3python/codegen/basetune.py
+++ b/v3python/codegen/basetune.py
@@ -7,6 +7,7 @@ from ..base import (
     Functional,
     Interface,
 )
+from .common import tunecc_ondisk_name
 import numpy as np
 
 class BaseTuneCodeGenerator(ABC):
@@ -27,7 +28,10 @@ class BaseTuneCodeGenerator(ABC):
         iface = self._f.meta_object
         tune_dir = self._args.build_dir / iface.FAMILY / f'{iface.TUNE_NAME}.{iface.NAME}'
         tune_dir.mkdir(parents=True, exist_ok=True)
-        return tune_dir / (f.tunecc_signature + '.cc')
+        ondisk = tunecc_ondisk_name(f)
+        with open(tune_dir / 'manifest.nsv', 'a', encoding='utf-8') as mf:
+            mf.write(ondisk + '\x00' + f.tunecc_signature + '\x00\n')
+        return tune_dir / (ondisk + '.cc')
 
     @property
     def cc_file(self):

--- a/v3python/codegen/basetune.py
+++ b/v3python/codegen/basetune.py
@@ -31,7 +31,7 @@ class BaseTuneCodeGenerator(ABC):
         ondisk = tunecc_ondisk_name(f)
         with open(tune_dir / 'manifest.nsv', 'a', encoding='utf-8') as mf:
             mf.write(ondisk + '\x00' + f.tunecc_signature + '\x00\n')
-        return tune_dir / (ondisk + '.cc')
+        return tune_dir / ondisk
 
     @property
     def cc_file(self):

--- a/v3python/codegen/common.py
+++ b/v3python/codegen/common.py
@@ -17,7 +17,7 @@ def hsaco_dir(build_dir : Path, k : 'KernelDescription'):
 
 def tunecc_ondisk_name(f: 'Functional') -> str:
     digest = hashlib.sha256(f.tunecc_signature.encode()).hexdigest()
-    return f.name + digest
+    return f.name + '-' + digest + '.cc'
 
 '''
 _cfields means the data type has been translated to c types

--- a/v3python/codegen/common.py
+++ b/v3python/codegen/common.py
@@ -15,6 +15,10 @@ def hsaco_inaks2_name(kdesc: 'KernelDescription', ksig: 'KernelSignature') -> st
 def hsaco_dir(build_dir : Path, k : 'KernelDescription'):
     return build_dir / k.FAMILY / f'gpu_kernel_image.{k.NAME}'
 
+def tunecc_ondisk_name(f: 'Functional') -> str:
+    digest = hashlib.sha256(f.tunecc_signature.encode()).hexdigest()
+    return f.name + digest
+
 '''
 _cfields means the data type has been translated to c types
 '''

--- a/v3python/codegen/common.py
+++ b/v3python/codegen/common.py
@@ -1,12 +1,16 @@
 # Copyright © 2025 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+import hashlib
 from v3python.utils import log
 from pathlib import Path
 
-def hsaco_filename(kdesc : 'KernelDescription',
-                   ksig : 'KernelSignature'):
-    return kdesc.NAME + '-Sig-' + ksig.full_compact_signature + '.hsaco'
+def hsaco_ondisk_name(kdesc: 'KernelDescription', ksig: 'KernelSignature') -> str:
+    digest = hashlib.sha256(ksig.hsaco_entry_name.encode()).hexdigest()
+    return kdesc.NAME + '-' + digest + '.hsaco'
+
+def hsaco_inaks2_name(kdesc: 'KernelDescription', ksig: 'KernelSignature') -> str:
+    return ksig.hsaco_entry_name
 
 def hsaco_dir(build_dir : Path, k : 'KernelDescription'):
     return build_dir / k.FAMILY / f'gpu_kernel_image.{k.NAME}'

--- a/v3python/codegen/root.py
+++ b/v3python/codegen/root.py
@@ -90,8 +90,6 @@ class RootGenerator(object):
     def do_generate(self):
         args = self._args
         sel = args.selective  # Path or None
-        if sel is not None:
-            sel_kind, sel_family, sel_name = sel.parts
 
         hsaco_for_kernels = []
         asms_for_kernels = []
@@ -102,10 +100,8 @@ class RootGenerator(object):
         all_trivial_stats: dict[tuple, dict[str, int]] = {}
 
         ops = dispatcher_operators
-        if sel is not None and sel_kind != 'op':
-            ops = []
-        elif sel is not None:
-            ops = [op for op in ops if op.FAMILY == sel_family and op.NAME == sel_name]
+        if sel is not None:
+            ops = [op for op in ops if op.unique_path == sel]
         for op in ops:
             opg = OperatorGenerator(self._args, op, parent_repo=None)
             opg.generate()
@@ -122,10 +118,8 @@ class RootGenerator(object):
         self._print_lut_stats(all_lut_stats, all_trivial_stats)
 
         kerns = triton_kernels
-        if sel is not None and sel_kind != 'triton':
-            kerns = []
-        elif sel is not None:
-            kerns = [k for k in kerns if k.FAMILY == sel_family and k.NAME == sel_name]
+        if sel is not None:
+            kerns = [k for k in kerns if k.unique_path == sel]
         for k in kerns:
             ksg = KernelShimGenerator(self._args, k, parent_repo=None)
             ksg.generate()
@@ -137,10 +131,8 @@ class RootGenerator(object):
         # On Windows, you get "KeyError: 'validator_function'"
         # See discussion in https://discord.com/channels/1239631572886491286/1401853302139912222/1401862203845378201
         affs = affine_kernels
-        if sel is not None and sel_kind != 'affine':
-            affs = []
-        elif sel is not None:
-            affs = [ak for ak in affs if ak.FAMILY == sel_family and ak.NAME == sel_name]
+        if sel is not None:
+            affs = [ak for ak in affs if ak.unique_path == sel]
         for ak in affs:
             log(lambda : f'{ak.__class__=}')
             if isinstance(ak, SlimAffineKernelDescription):
@@ -210,9 +202,9 @@ class RootGenerator(object):
     def launch_workers(self):
         args = self._args
         items: list[Path] = []
-        items += [Path('op')     / op.FAMILY / op.NAME  for op in dispatcher_operators]
-        items += [Path('triton') / k.FAMILY  / k.NAME   for k in triton_kernels]
-        items += [Path('affine') / ak.FAMILY / ak.NAME  for ak in affine_kernels]
+        items += [op.unique_path for op in dispatcher_operators]
+        items += [k.unique_path  for k in triton_kernels]
+        items += [ak.unique_path for ak in affine_kernels]
 
         base_argv = [x for x in sys.argv[1:] if not x.startswith('--selective')]
 

--- a/v3python/codegen/root.py
+++ b/v3python/codegen/root.py
@@ -25,7 +25,8 @@ from ..utils import (
 )
 from .common import (
     hsaco_dir,
-    hsaco_filename,
+    hsaco_ondisk_name,
+    hsaco_inaks2_name,
 )
 from ..gpu_targets import AOTRITON_ARCH_TO_DIRECTORY
 import sys
@@ -133,7 +134,7 @@ class RootGenerator(object):
         # TODO: Support Cluter Functionals
         #       Implemented this in
         #       Functional.filepack_signature (used by Functional.full_filepack_path)
-        cluster_dict = defaultdict(list)
+        cluster_dict: dict[Path, dict[str, str]] = {}
         with LazyFile(args.build_dir / 'Bare.compile') as rulefile:
             for kdesc, hsacos in hsaco_for_kernels:
                 image_path = hsaco_dir(args.build_dir, kdesc)
@@ -146,11 +147,13 @@ class RootGenerator(object):
                         # functional == ksig._functional ?
                         self.write_hsaco(kdesc, image_path, functional, ksig, rulefile)
                     ffp = functional.full_filepack_path
-                    aol = [self._absobjfn(image_path, kdesc, ksig) for ksig in signatures]
-                    cluster_dict[ffp] += aol
+                    cluster_dict.setdefault(ffp, {}).update(
+                        {self._absobjfn(image_path, kdesc, ksig): hsaco_inaks2_name(kdesc, ksig)
+                         for ksig in signatures}
+                    )
         with LazyFile(args.build_dir / 'Bare.cluster') as clusterfile:
-            for ffp, aol in cluster_dict.items():
-                self.write_cluster(ffp, aol, clusterfile)
+            for ffp, aol_map in cluster_dict.items():
+                self.write_cluster(ffp, aol_map, clusterfile)
         '''
         Note: Affine kernel's functionals have residual choices, so it is not
         completely the same with Triton kernel/Interface's functionals
@@ -159,17 +162,24 @@ class RootGenerator(object):
         compute full_filepack_path, so eventually .hsaco and .co files will be
         consolated into the same .aks2 file, which is intentional.
         '''
-        affine_dict = defaultdict(list)
+        affine_dict: dict[Path, dict[str, str]] = {}
+
+        def parse_rule(asm: str) -> tuple[str, str]:
+            assert asm.startswith(':')
+            _, inaks2, ondisk = asm.split(':', 2)
+            return Path(ondisk).absolute().as_posix(), inaks2
+
         for akdesc, asm_registry in asms_for_kernels:
             for package_path, asms in asm_registry.items():
-                affine_dict[Path(package_path)] += [ self._absasmfn(asm_rule) for asm_rule in asms ]
+                ffp = Path(package_path)
+                affine_dict.setdefault(ffp, {}).update(dict(parse_rule(r) for r in asms))
         with LazyFile(args.build_dir / 'Affine.cluster') as clusterfile:
-            for ffp, aol in affine_dict.items():
-                self.write_cluster(ffp, list(set(aol)), clusterfile)
+            for ffp, aol_map in affine_dict.items():
+                self.write_cluster(ffp, aol_map, clusterfile)
 
     def _absobjfn(self, path, kdesc, ksig):
-        full = path / hsaco_filename(kdesc, ksig)
-        return str(full.absolute())
+        full = path / hsaco_ondisk_name(kdesc, ksig)
+        return full.absolute().as_posix()
 
     def write_hsaco(self, kdesc, path, functional, ksig, rulefile):
         log(lambda : f'{ksig=}')
@@ -187,16 +197,20 @@ class RootGenerator(object):
               ksig.triton_signature_string,  # Functional is not Triton-specific
               sep=';', file=rulefile)
 
-    def write_cluster(self, ffp, aol, clusterfile):
-        print(*ffp.parts, end=';', sep=';', file=clusterfile)
-        print(*aol, sep=';', file=clusterfile)
+    def write_cluster(self, ffp, aol_map, clusterfile):
+        manifest_path = (self._args.build_dir / ffp).with_suffix('.nsv')
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(manifest_path, 'w', encoding='utf-8') as mf:
+            for abs_path, entry_name in aol_map.items():
+                mf.write(abs_path + '\x00' + entry_name + '\x00\n')
+        print(*ffp.parts, *aol_map.keys(), sep=';', file=clusterfile)
 
     # TODO: deprecate this, the generator should return the full path directly
     def _absasmfn(self, asm_rule):
         if asm_rule.startswith(':'):
             return asm_rule
         full = self._args.root_dir / asm_rule
-        return str(full.absolute())
+        return full.absolute().as_posix()
 
     def _load_altwheel_config(self, d: dict):
         venvs = d.get("venvs", {})

--- a/v3python/codegen/root.py
+++ b/v3python/codegen/root.py
@@ -198,7 +198,7 @@ class RootGenerator(object):
               sep=';', file=rulefile)
 
     def write_cluster(self, ffp, aol_map, clusterfile):
-        manifest_path = (self._args.build_dir / ffp).with_suffix('.nsv')
+        manifest_path = (self._args.build_dir / 'aotriton.images' / ffp).with_suffix('.nsv')
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
         with open(manifest_path, 'w', encoding='utf-8') as mf:
             for abs_path, entry_name in aol_map.items():

--- a/v3python/codegen/root.py
+++ b/v3python/codegen/root.py
@@ -5,6 +5,8 @@
 
 from pathlib import Path, PurePath
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+import subprocess
 from ..rules import (
     kernels as triton_kernels,
     operators as dispatcher_operators,
@@ -80,7 +82,17 @@ class RootGenerator(object):
         self._load_altwheel_config(self._altrules_dict)
 
     def generate(self):
+        if self._args.selective:
+            self.do_generate()
+        else:
+            self.launch_workers()
+
+    def do_generate(self):
         args = self._args
+        sel = args.selective  # Path or None
+        if sel is not None:
+            sel_kind, sel_family, sel_name = sel.parts
+
         hsaco_for_kernels = []
         asms_for_kernels = []
         shims = []
@@ -88,7 +100,13 @@ class RootGenerator(object):
         all_lut_stats: dict[tuple, int] = {}
         # (arch, op_name) -> {'trivial': N, 'non_trivial': N}
         all_trivial_stats: dict[tuple, dict[str, int]] = {}
-        for op in dispatcher_operators:
+
+        ops = dispatcher_operators
+        if sel is not None and sel_kind != 'op':
+            ops = []
+        elif sel is not None:
+            ops = [op for op in ops if op.FAMILY == sel_family and op.NAME == sel_name]
+        for op in ops:
             opg = OperatorGenerator(self._args, op, parent_repo=None)
             opg.generate()
             shims += opg.shim_files
@@ -102,16 +120,28 @@ class RootGenerator(object):
                 d['trivial']     += ts['trivial']
                 d['non_trivial'] += ts['non_trivial']
         self._print_lut_stats(all_lut_stats, all_trivial_stats)
-        for k in triton_kernels:
+
+        kerns = triton_kernels
+        if sel is not None and sel_kind != 'triton':
+            kerns = []
+        elif sel is not None:
+            kerns = [k for k in kerns if k.FAMILY == sel_family and k.NAME == sel_name]
+        for k in kerns:
             ksg = KernelShimGenerator(self._args, k, parent_repo=None)
             ksg.generate()
             hsacos = ksg.this_repo.get_data('hsaco')
             hsaco_for_kernels.append((k, hsacos))
             shims += ksg.shim_files
+
         # TODO: Fix this for Windows
         # On Windows, you get "KeyError: 'validator_function'"
         # See discussion in https://discord.com/channels/1239631572886491286/1401853302139912222/1401862203845378201
-        for ak in affine_kernels:
+        affs = affine_kernels
+        if sel is not None and sel_kind != 'affine':
+            affs = []
+        elif sel is not None:
+            affs = [ak for ak in affs if ak.FAMILY == sel_family and ak.NAME == sel_name]
+        for ak in affs:
             log(lambda : f'{ak.__class__=}')
             if isinstance(ak, SlimAffineKernelDescription):
                 aksg = SlimAffineGenerator(self._args, ak, parent_repo=None)
@@ -126,34 +156,34 @@ class RootGenerator(object):
         if args.build_for_tuning_second_pass:
             return
 
-        with LazyFile(args.build_dir / 'Bare.shim') as shimfile:
+        out_dir = args.build_dir / 'Bare.shards' / sel if sel is not None else args.build_dir
+        if sel is not None:
+            out_dir.mkdir(parents=True, exist_ok=True)
+
+        with LazyFile(out_dir / 'Bare.shim') as shimfile:
             for shim in shims:
                 print(shim.absolute().as_posix(), file=shimfile)
         if args.noimage_mode:
             return
-        # TODO: Support Cluter Functionals
-        #       Implemented this in
-        #       Functional.filepack_signature (used by Functional.full_filepack_path)
+
         cluster_dict: dict[Path, dict[str, str]] = {}
-        with LazyFile(args.build_dir / 'Bare.compile') as rulefile:
+        with LazyFile(out_dir / 'Bare.compile') as rulefile:
             for kdesc, hsacos in hsaco_for_kernels:
                 image_path = hsaco_dir(args.build_dir, kdesc)
                 image_path.mkdir(parents=True, exist_ok=True)
                 for functional, signatures in hsacos.items():
                     log(lambda : f'{signatures=}')
                     for ksig in signatures:
-                        # TODO: Add sanity check to ensure
-                        # k == functional.meta_object and
-                        # functional == ksig._functional ?
                         self.write_hsaco(kdesc, image_path, functional, ksig, rulefile)
                     ffp = functional.full_filepack_path
                     cluster_dict.setdefault(ffp, {}).update(
                         {self._absobjfn(image_path, kdesc, ksig): hsaco_inaks2_name(kdesc, ksig)
                          for ksig in signatures}
                     )
-        with LazyFile(args.build_dir / 'Bare.cluster') as clusterfile:
+        with LazyFile(out_dir / 'Bare.cluster') as clusterfile:
             for ffp, aol_map in cluster_dict.items():
                 self.write_cluster(ffp, aol_map, clusterfile)
+
         '''
         Note: Affine kernel's functionals have residual choices, so it is not
         completely the same with Triton kernel/Interface's functionals
@@ -173,9 +203,43 @@ class RootGenerator(object):
             for package_path, asms in asm_registry.items():
                 ffp = Path(package_path)
                 affine_dict.setdefault(ffp, {}).update(dict(parse_rule(r) for r in asms))
-        with LazyFile(args.build_dir / 'Affine.cluster') as clusterfile:
+        with LazyFile(out_dir / 'Affine.cluster') as clusterfile:
             for ffp, aol_map in affine_dict.items():
                 self.write_cluster(ffp, aol_map, clusterfile)
+
+    def launch_workers(self):
+        args = self._args
+        items: list[Path] = []
+        items += [Path('op')     / op.FAMILY / op.NAME  for op in dispatcher_operators]
+        items += [Path('triton') / k.FAMILY  / k.NAME   for k in triton_kernels]
+        items += [Path('affine') / ak.FAMILY / ak.NAME  for ak in affine_kernels]
+
+        base_argv = [x for x in sys.argv[1:] if not x.startswith('--selective')]
+
+        def run_one(item: Path):
+            cmd = [sys.executable, '-m', 'v3python.generate',
+                   '--selective', item.as_posix()] + base_argv
+            result = subprocess.run(cmd, capture_output=False)
+            if result.returncode != 0:
+                raise RuntimeError(f'Worker failed for {item}: exit {result.returncode}')
+
+        with ThreadPoolExecutor() as pool:
+            futures = [pool.submit(run_one, item) for item in items]
+        for f in futures:
+            f.result()  # re-raise any worker exception
+
+        shard_names = ['Bare.shim', 'Bare.compile', 'Bare.cluster', 'Affine.cluster']
+        out_files = {name: args.build_dir / name for name in shard_names}
+        # Truncate output files before appending
+        for path in out_files.values():
+            path.unlink(missing_ok=True)
+        for item in items:
+            shard_dir = args.build_dir / 'Bare.shards' / item
+            for name, out_path in out_files.items():
+                shard_file = shard_dir / name
+                if shard_file.exists():
+                    with open(out_path, 'ab') as out, open(shard_file, 'rb') as src:
+                        out.write(src.read())
 
     def _absobjfn(self, path, kdesc, ksig):
         full = path / hsaco_ondisk_name(kdesc, ksig)

--- a/v3python/database/sqlite.py
+++ b/v3python/database/sqlite.py
@@ -40,32 +40,15 @@ class Factory(object):
         'op': 'database/op_database.sqlite3',
     }
 
-    @staticmethod
-    def _load_into_memory(disk_path, uri_name):
-        '''Back up a disk SQLite file into a named shared-cache in-memory database.
-        The URI file:uri_name?mode=memory&cache=shared can be ATTACHed by any
-        connection in the same process.'''
-        disk = sqlite3.connect(disk_path)
-        mem = sqlite3.connect(f'file:{uri_name}?mode=memory&cache=shared', uri=True)
-        disk.backup(mem)
-        disk.close()
-        return mem
-
     def __init__(self, path):
-        log(lambda : f'sqlite3.connect({path / self.SIGNATURE_FILE}) -> :memory:')
-        # Keep references alive so the shared-cache in-memory dbs are not freed.
-        self._mem_conns = []
-        self._mem_conns.append(self._load_into_memory(path / self.SIGNATURE_FILE, 'primary'))
-        self._conn = sqlite3.connect('file:primary?mode=memory&cache=shared', uri=True)
+        log(lambda : f'sqlite3.connect({path / self.SIGNATURE_FILE})')
+        self._conn = sqlite3.connect(path / self.SIGNATURE_FILE)
         self._conn.set_trace_callback(log) # Debug
         for schema, bn in self.SECONDARY_DATABASES.items():
             fn = path / bn
             if fn.is_file():
-                log(lambda : f"Loading {fn} into :memory: as schema '{schema}'")
-                self._mem_conns.append(self._load_into_memory(fn, schema))
-                self._conn.execute(
-                    f"ATTACH DATABASE 'file:{schema}?mode=memory&cache=shared' AS {schema};"
-                )
+                log(lambda : f"ATTACH DATABASE '{fn.as_posix()}' AS {schema};")
+                self._conn.execute(f"ATTACH DATABASE '{fn.as_posix()}' AS {schema};")
             else:
                 assert False, f'{fn} is not a file, {path}'
 

--- a/v3python/database/sqlite.py
+++ b/v3python/database/sqlite.py
@@ -40,15 +40,32 @@ class Factory(object):
         'op': 'database/op_database.sqlite3',
     }
 
+    @staticmethod
+    def _load_into_memory(disk_path, uri_name):
+        '''Back up a disk SQLite file into a named shared-cache in-memory database.
+        The URI file:uri_name?mode=memory&cache=shared can be ATTACHed by any
+        connection in the same process.'''
+        disk = sqlite3.connect(disk_path)
+        mem = sqlite3.connect(f'file:{uri_name}?mode=memory&cache=shared', uri=True)
+        disk.backup(mem)
+        disk.close()
+        return mem
+
     def __init__(self, path):
-        log(lambda : f'sqlite3.connect({path / self.SIGNATURE_FILE})')
-        self._conn = sqlite3.connect(path / self.SIGNATURE_FILE)
+        log(lambda : f'sqlite3.connect({path / self.SIGNATURE_FILE}) -> :memory:')
+        # Keep references alive so the shared-cache in-memory dbs are not freed.
+        self._mem_conns = []
+        self._mem_conns.append(self._load_into_memory(path / self.SIGNATURE_FILE, 'primary'))
+        self._conn = sqlite3.connect('file:primary?mode=memory&cache=shared', uri=True)
         self._conn.set_trace_callback(log) # Debug
         for schema, bn in self.SECONDARY_DATABASES.items():
             fn = path / bn
             if fn.is_file():
-                log(lambda : f"ATTACH DATABASE '{fn.as_posix()}' AS {schema};")
-                self._conn.execute(f"ATTACH DATABASE '{fn.as_posix()}' AS {schema};")
+                log(lambda : f"Loading {fn} into :memory: as schema '{schema}'")
+                self._mem_conns.append(self._load_into_memory(fn, schema))
+                self._conn.execute(
+                    f"ATTACH DATABASE 'file:{schema}?mode=memory&cache=shared' AS {schema};"
+                )
             else:
                 assert False, f'{fn} is not a file, {path}'
 

--- a/v3python/generate.py
+++ b/v3python/generate.py
@@ -43,7 +43,7 @@ def parse():
     # Always True
     # p.add_argument("--generate_cluster_info", action='store_true', help="Generate Bare.functionals for clustering.")
     p.add_argument("--selective", type=Path, default=None,
-                   help="Only generate one item, e.g. op/flash/op_attn_fwd, triton/flash/attn_fwd, affine/flash/aiter_fmha_v3_fwd")
+                   help="Only generate one item, e.g. flash/op/op_attn_fwd, flash/triton/attn_fwd, flash/affine/aiter_fmha_v3_fwd")
     p.add_argument("--verbose", action='store_true', help="Print debugging messages")
     p.add_argument("--lut_sanity_check", action='store_true', help="By default, an exception will ba raised when any the look up table (LUT) is broken. With this option the exception is not raised, and diagnose information is printed for developers to re-run the tuning script in order to fix the database.")
     p.add_argument("--sanity_check_only", action='store_true', help="Run --lut_sanity_check but suppress all code generation. No files are written. Implies --lut_sanity_check.")

--- a/v3python/generate.py
+++ b/v3python/generate.py
@@ -42,6 +42,8 @@ def parse():
                    help="Excluse certain GPU kernels for performance tuning when --build_for_tuning=True.")
     # Always True
     # p.add_argument("--generate_cluster_info", action='store_true', help="Generate Bare.functionals for clustering.")
+    p.add_argument("--selective", type=Path, default=None,
+                   help="Only generate one item, e.g. op/flash/op_attn_fwd, triton/flash/attn_fwd, affine/flash/aiter_fmha_v3_fwd")
     p.add_argument("--verbose", action='store_true', help="Print debugging messages")
     p.add_argument("--lut_sanity_check", action='store_true', help="By default, an exception will ba raised when any the look up table (LUT) is broken. With this option the exception is not raised, and diagnose information is printed for developers to re-run the tuning script in order to fix the database.")
     p.add_argument("--sanity_check_only", action='store_true', help="Run --lut_sanity_check but suppress all code generation. No files are written. Implies --lut_sanity_check.")

--- a/v3python/kernel/kdesc.py
+++ b/v3python/kernel/kdesc.py
@@ -49,6 +49,7 @@ def select_pattern(arguments, prefix, trim_left=None, trim_right=None, delete_wh
     return (ret[trim_left:trim_right], delete_when)
 
 class KernelDescription(Interface):
+    CODEGEN_MODULE = 'triton'
     TUNE_NAME = 'autotune'
     FILE_PFX = 'shim'
     ARGUMENTS = []

--- a/v3python/kernel/ksignature.py
+++ b/v3python/kernel/ksignature.py
@@ -3,6 +3,7 @@
 
 from ..base import Functional
 from ..utils import log
+from functools import cached_property
 import hashlib
 
 # Move to a dedicated file
@@ -59,18 +60,18 @@ class KernelSignature(object):
         lc = [f"{COMPACT_COMPILER_OPTIONS[oname]}{v}" for oname, v in self.copt_dict.items()]
         return '_'.join(lc)
 
-    @property
+    @cached_property
     def perf_section(self) -> str:
         parts = []
         for bind in self._perfs:
             parts.append(f'{bind.name}={bind.value.testrun_entry_signature}')
         return ';'.join(parts)
 
-    @property
+    @cached_property
     def copt_section(self) -> str:
         return ';'.join(f'{k}={v}' for k, v in self.copt_dict.items())
 
-    @property
+    @cached_property
     def hsaco_entry_name(self) -> str:
         return (
             f';;#F;{self._functional.unified_signature}'

--- a/v3python/kernel/ksignature.py
+++ b/v3python/kernel/ksignature.py
@@ -60,6 +60,26 @@ class KernelSignature(object):
         return '_'.join(lc)
 
     @property
+    def perf_section(self) -> str:
+        parts = []
+        for bind in self._perfs:
+            parts.append(f'{bind.name}={bind.value.testrun_entry_signature}')
+        return ';'.join(parts)
+
+    @property
+    def copt_section(self) -> str:
+        return ';'.join(f'{k}={v}' for k, v in self.copt_dict.items())
+
+    @property
+    def hsaco_entry_name(self) -> str:
+        return (
+            f';;#F;{self._functional.unified_signature}'
+            f';;#P;{self.perf_section}'
+            f';;#CO;{self.copt_section}'
+            f';;arch={self._functional.arch}'
+        )
+
+    @property
     def both_signature(self):
         perf = self.perf_signature
         copt = self.copt_signature
@@ -70,9 +90,8 @@ class KernelSignature(object):
         return self._functional.compact_signature_noarch + self.both_signature + '--Arch_' + self._functional.arch
 
     def blake2b_hash(self, package_path):
-        raw = package_path.encode('utf-8')
-        s = self.both_signature + '--Arch_' + self._functional.arch
-        raw += s.encode('utf-8')
+        entry = self.hsaco_entry_name
+        raw = (package_path + entry).encode('utf-8')
         h = hashlib.blake2b(raw, digest_size=8)
         return h.hexdigest(), raw
 

--- a/v3python/op/operator.py
+++ b/v3python/op/operator.py
@@ -8,6 +8,7 @@ from ..base import (
 import numpy as np
 
 class Operator(Interface):
+    CODEGEN_MODULE = 'op'
     TUNE_NAME = 'optune'
     CALL_OPTIONS_NAME = None
 

--- a/v3src/CMakeLists.txt
+++ b/v3src/CMakeLists.txt
@@ -231,6 +231,12 @@ if(NOT AOTRITON_NOIMAGE_MODE)
         ${DIR_FAMILY}
         ${DIR_KERNEL}
         "${FONLY}.aks2")
+      string(JOIN "/" HSACO_MANIFEST
+        ${AOTRITON_KERNEL_STORAGE_V2_DIR}
+        ${DIR_ARCH}
+        ${DIR_FAMILY}
+        ${DIR_KERNEL}
+        "${FONLY}.nsv")
       # message(STATUS "Add AKS2 ${AKS2}")
       add_custom_command(OUTPUT "${AKS2}"
         COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR}
@@ -238,8 +244,7 @@ if(NOT AOTRITON_NOIMAGE_MODE)
         -m v3python.aks2
         -o "${AKS2}"
         ${AKS2_OPTIONS}
-        --
-        ${RULE}
+        --hsaco_manifest "${HSACO_MANIFEST}"
         DEPENDS aotriton_v2_compile
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_PARENT_DIR}"
         COMMAND_EXPAND_LISTS)

--- a/v3src/CMakeLists.txt
+++ b/v3src/CMakeLists.txt
@@ -382,7 +382,8 @@ install(FILES
 
 if(NOT AOTRITON_NOIMAGE_MODE)
   install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/aotriton.images"
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+          PATTERN "*.nsv" EXCLUDE)
 endif(NOT AOTRITON_NOIMAGE_MODE)
 
 # Python binding only available for AOTriton V2 API

--- a/v3src/triton_kernel.cc
+++ b/v3src/triton_kernel.cc
@@ -20,35 +20,25 @@
 
 namespace AOTRITON_NS {
 
-constexpr std::string_view INTER_KERNEL_FUNC { "-Sig-F__" };
-constexpr std::string_view INTER_FUNC_PSEL { "__P__" };
-constexpr std::string_view INTER_PSEL_COPT { "__CO__" };
-constexpr std::string_view INTER_COPT_ARCH { "--Arch_" };
+constexpr std::string_view SEC_F    { ";;#F;" };
+constexpr std::string_view SEC_P    { ";;#P;" };
+constexpr std::string_view SEC_CO   { ";;#CO;" };
+constexpr std::string_view SEC_ARCH { ";;arch=" };
 
-std::string construct_stem_name(std::string_view kernel_name,
+std::string construct_stem_name(std::string_view /* kernel_name */,
                                 std::string_view func_name,
                                 std::string_view psel_name,
                                 std::string_view copt_name,
                                 std::string_view arch_name) {
   std::string ret;
-  ret.reserve(kernel_name.size() +
-              INTER_KERNEL_FUNC.size() +
-              func_name.size() +
-              INTER_FUNC_PSEL.size() +
-              psel_name.size() +
-              INTER_PSEL_COPT.size() +
-              copt_name.size() +
-              INTER_COPT_ARCH.size() +
-              arch_name.size());
-  ret += kernel_name;
-  ret += INTER_KERNEL_FUNC;
-  ret += func_name;
-  ret += INTER_FUNC_PSEL;
-  ret += psel_name;
-  ret += INTER_PSEL_COPT;
-  ret += copt_name;
-  ret += INTER_COPT_ARCH;
-  ret += arch_name;
+  ret.reserve(SEC_F.size() + func_name.size() +
+              SEC_P.size() + psel_name.size() +
+              SEC_CO.size() + copt_name.size() +
+              SEC_ARCH.size() + arch_name.size());
+  ret += SEC_F;    ret += func_name;
+  ret += SEC_P;    ret += psel_name;
+  ret += SEC_CO;   ret += copt_name;
+  ret += SEC_ARCH; ret += arch_name;
   return ret;
 }
 


### PR DESCRIPTION
# Overview

Overhaul HSACO and autotune/optune `.cc` on-disk filenames, parallel code
generation, and AKS2 packaging. HSACO files adopt a structured entry name
(`;;#F;...;;#P;...;;#CO;...;;arch=...`) and SHA-256 on-disk filenames.
Autotune/optune `.cc` shims are similarly renamed. Code generation is
parallelised via subprocess sharding (`--selective`).

## Major Changes

* [codegen] SHA-256 on-disk filenames for hsaco files:
  + `hsaco_ondisk_name` → `<name>-<sha256>.hsaco`;
  + `hsaco_inaks2_name` are more human readable format
    `;;#F;<func>;;#P;<perf>;;#CO;<copt>;;arch=<arch>`, examples:
    - `#F;Q='*bf16:16';BLOCK_DMODEL=160;PADDED_HEAD=False;ENABLE_DROPOUT=True;CAUSAL_TYPE=0;BIAS_TYPE=0;;`
    - `#P;PERSISTENT_TYPE=0;GRID_CU_MULTIP=2;BLOCK_M=32;BLOCK_N=16;PRE_LOAD_V=False;NUM_XCDS=1;;`
    - `#CO;waves_per_eu=1;num_warps=2;num_stages=1;;`
    - `arch=gfx90a`
  + Replace the old `-Sig-F__...__P__...__CO__...--Arch_` scheme, which
    requires UTF-8 char to avoid `*`
  + `.nsv` manifest (`aotriton.images/<ffp>.nsv`) maps `abs_path<NUL>entry_name` for AKS2 packaging
    - `nsv` is for "null-separated variables"
    - manifests are excluded from `ninja install`
* [codegen] SHA-256 on-disk names for autotune/optune `.cc` shims:
  + `tunecc_signature` adopts `#F;<unified_signature>;;arch=<arch>` format
  + `tunecc_ondisk_name(f)` → `<name>-<sha256>.cc`
  + `manifest.nsv` written alongside `.cc` files mapping digest → signature
* [gen] Parallel code generation: `--selective <family>/<module>/<name>` runs
  one item; without it, `launch_workers()` fans out subprocesses via
  `ThreadPoolExecutor` and merges shard files under `Bare.shards/`
  + The `<family>/<codegen_module>/<name>` is returned by `Interface.unique_path` property

## Minor Changes

* [aks2] Replace positional `hsaco_files` with `--hsaco_manifest <nsv>`;
  CMake updated accordingly
  - The old ':<aks2 entry name>:<co file pathname>` rule is replaced with manifest files.
* [build] `build-release.sh`: Use `realpath` for `source_dir`
* [shim] `hsaco_entry_name`, `perf_section`, `copt_section`, `unified_signature`
  promoted to `cached_property`. This saves ~3s/27s in code generation.
* [shim] `construct_stem_name` drops unused `kernel_name` argument
