### PR TITLE
Performance Visualization

### DIFF
--- a/.claude/agents/sdpa-expert.md
+++ b/.claude/agents/sdpa-expert.md
@@ -1,14 +1,6 @@
 ---
 name: sdpa-expert
-description: Use this agent for all tasks related to AOTriton's scaled dot
-  product attention (SDPA/flash attention) implementation — from the Triton GPU
-  kernels through the Python tuning harness to the PyTorch reference. This
-  covers: correctness bugs in fwd/bwd kernels, GQA head indexing,
-  bias/dropout/varlen handling, causal/windowed masking, the Python tuning
-  reference (reference.py, module.py, kernels.py), and the public C++ API
-  (include/aotriton/flash.h, v3src/flash/). Do NOT use for the code generator
-  (v3python/rules/, v3python/codegen/), the PostgreSQL tuning queue
-  (v3python/tune/pq/), or the worker/broker infrastructure.
+description: Use this agent for SDPA/flash-attention tasks — Triton fwd/bwd kernels, GQA, bias/dropout/varlen, causal masking, Python tuning harness (reference.py, module.py, kernels.py), and C++ API (include/aotriton/flash.h, v3src/flash/). Not for codegen, PG tuning queue, or worker infrastructure.
 ---
 
 You are an expert on AOTriton's flash attention / SDPA implementation. You

--- a/.claude/agents/tuner-v3.md
+++ b/.claude/agents/tuner-v3.md
@@ -135,6 +135,19 @@ dispatch_tasks.py → task_queue (PostgreSQL, status=pending)
   - `status` values: `pending`, `running`, `completed`, `failed`, `cancelled`
 - **`tuning_results`** — raw per-kernel results with `impl_desc` (JSONB: psels + copts)
 - **`best_tuning_results`** — aggregated best result per (arch, kernel, task_config)
+- **`optune_results` / `best_optune_results`** — same shape, but for op-mode tuning
+
+### Arch enumeration: prefer kernel_table, do not union op_table
+
+Every operator in AOTriton is implemented on top of one or more Triton
+kernels. The set of arches the library has been built for is therefore
+fully determined by the kernel side of the database — there is no
+op-only arch. When listing available arches for UI/export purposes
+(e.g. `visperf.get_available_archs`), `SELECT DISTINCT arch FROM
+<kernel_table>` is the complete answer; do **not** add a `UNION SELECT
+DISTINCT arch FROM <op_table>` "for safety". The union is dead SQL,
+masks bugs (op rows without a corresponding kernel build), and review
+comments that recommend it should be pushed back on.
 
 ### Unix-socket protocol (localq/protocol.py)
 

--- a/.claude/agents/webui-expert.md
+++ b/.claude/agents/webui-expert.md
@@ -233,6 +233,14 @@ Non-command functions in `tasks.py` query PostgreSQL directly using `psycopg` an
 - `current_app.tracker_registry` — `TrackerRegistry` instance
 - `current_app.scheduler` — `Scheduler` instance
 
+## Notes for `/perf` (visperf)
+
+- The arch dropdown is populated by `v3python.tune.pq.visperf.get_available_archs`,
+  which queries `kernel_table` only. This is intentional and complete:
+  every AOTriton op is backed by one or more Triton kernels, so any arch
+  the library is built for shows up in `best_tuning_results`. Do not
+  "fix" this by unioning `best_optune_results` — the union is dead SQL.
+
 ## Out of scope
 
 - `.tune/bin/` scripts and their internals — use the tuner-v3 agent

--- a/.github/instructions/internal_scripts.instructions.md
+++ b/.github/instructions/internal_scripts.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "v3python/tune/**/*.py",".tune/**/*.py"
+---
+
+These are internal-only scripts for the AOTriton tuning infrastructure.
+They are not a public API, are not shipped to end users, and are not run
+with `python -O` (we never strip asserts).
+
+Reviewers (including Copilot) MUST NOT:
+
+- Flag `assert` used to validate arguments of internal helpers as a bug.
+  `assert` is the preferred form here precisely because it is loud,
+  uncaught, and stops execution immediately — unlike `raise ValueError`
+  which is routinely swallowed by broad `except Exception:` handlers in
+  task runners, Flask error pages, and Celery workers in this codebase.
+- Recommend hardening these scripts as if they were a public library
+  (e.g. "validate user input", "raise typed exceptions", "add retry/
+  timeout for robustness", "handle the `-O` case"). The scope is
+  internal tooling; do not extrapolate.

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -7,6 +7,7 @@ URL routes and handlers for the web dashboard
 
 from flask import Blueprint, render_template, request, jsonify, current_app, Response, g, send_file
 import io
+import os
 import time
 import json
 import logging
@@ -1056,13 +1057,21 @@ def api_perf_export_zip():
       col_dim_filters  – {dim: [allowed_values, ...]} — empty list means all
       url_params       – dict of URL search params to pre-set in the export
     """
-    body        = request.get_json(force=True) or {}
-    col_filters: dict = body.get('col_dim_filters', {})
-    url_params: dict  = body.get('url_params', {})
+    body        = request.get_json(silent=True) or {}
+    if not isinstance(body, dict):
+        return jsonify({'error': 'request body must be a JSON object'}), 400
+    col_filters = body.get('col_dim_filters', {})
+    url_params  = body.get('url_params', {})
+    descriptor_id = body.get('descriptor_id', 'flash')
+    if not isinstance(col_filters, dict) or not isinstance(url_params, dict):
+        return jsonify({'error': 'col_dim_filters and url_params must be objects'}), 400
+    if not isinstance(descriptor_id, str):
+        return jsonify({'error': 'descriptor_id must be a string'}), 400
 
     try:
         html = tasks.build_perf_export_html(col_filters, url_params,
-                                            current_app.config['WORKDIR'])
+                                            current_app.config['WORKDIR'],
+                                            descriptor_id=descriptor_id)
     except Exception as exc:
         logger.error('build_perf_export_html failed: %s', exc)
         return jsonify({'error': str(exc)}), 500
@@ -1094,10 +1103,19 @@ def plotly_cache():
     if not cache_path.exists():
         try:
             cache_path.parent.mkdir(parents=True, exist_ok=True)
+            # Download to a temp file in the same dir, then atomic rename:
+            # avoids serving a truncated cache if the connection drops or
+            # two concurrent first-time requests race.
+            tmp_path = cache_path.with_suffix(cache_path.suffix + f'.tmp.{os.getpid()}')
             with urllib.request.urlopen(_PLOTLY_CDN, timeout=30) as resp:
-                cache_path.write_bytes(resp.read())
+                tmp_path.write_bytes(resp.read())
+            os.replace(tmp_path, cache_path)
         except Exception as exc:
             logger.warning('Failed to download Plotly from CDN: %s', exc)
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except Exception:
+                pass
             return f'Plotly unavailable: {exc}', 503
     return send_file(cache_path, mimetype='application/javascript')
 

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -1094,21 +1094,34 @@ def api_export_visperf():
 
 
 _PLOTLY_CDN = 'https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js'
+# SHA-256 of the upstream plotly.js-dist-min@2.35.2/plotly.min.js bundle.
+# Verified out-of-band; if the CDN returns content that does not match this
+# digest we refuse to cache or serve it.
+_PLOTLY_SHA256 = '6d21266ce1bd7d9e5ab4e115989c70c20de0382fd973a8f26ab58619eba4d603'
 
 @bp.route('/static/cache/plotly.min.js')
 def plotly_cache():
     """Serve Plotly.js from a local cache, downloading it on first request."""
+    import hashlib
     workdir = current_app.config['WORKDIR']
     cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.min.js'
     if not cache_path.exists():
+        # Download to a temp file in the same dir, then atomic rename:
+        # avoids serving a truncated cache if the connection drops or
+        # two concurrent first-time requests race. Pre-declared so the
+        # except cleanup never trips UnboundLocalError on early failure.
+        tmp_path = cache_path.with_suffix(cache_path.suffix + f'.tmp.{os.getpid()}')
         try:
             cache_path.parent.mkdir(parents=True, exist_ok=True)
-            # Download to a temp file in the same dir, then atomic rename:
-            # avoids serving a truncated cache if the connection drops or
-            # two concurrent first-time requests race.
-            tmp_path = cache_path.with_suffix(cache_path.suffix + f'.tmp.{os.getpid()}')
             with urllib.request.urlopen(_PLOTLY_CDN, timeout=30) as resp:
-                tmp_path.write_bytes(resp.read())
+                payload = resp.read()
+            digest = hashlib.sha256(payload).hexdigest()
+            if digest != _PLOTLY_SHA256:
+                raise ValueError(
+                    f'Plotly CDN payload SHA-256 mismatch: got {digest}, '
+                    f'expected {_PLOTLY_SHA256}'
+                )
+            tmp_path.write_bytes(payload)
             os.replace(tmp_path, cache_path)
         except Exception as exc:
             logger.warning('Failed to download Plotly from CDN: %s', exc)

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -5,10 +5,11 @@
 URL routes and handlers for the web dashboard
 """
 
-from flask import Blueprint, render_template, request, jsonify, current_app, Response, g
+from flask import Blueprint, render_template, request, jsonify, current_app, Response, g, send_file
 import time
 import json
 import logging
+from pathlib import Path
 
 from . import tasks
 
@@ -1001,6 +1002,47 @@ def api_download_adiffs():
         'Content-Type': 'text/plain; charset=utf-8',
         'Content-Disposition': f'attachment; filename="{filename}"',
     }
+
+
+@bp.route('/perf')
+def perf():
+    """Performance visualization tab"""
+    workdir = current_app.config['WORKDIR']
+    archs = tasks.get_perf_archs(workdir)
+    return render_template('perf.html', archs=archs, hide_sidebar=True)
+
+
+@bp.route('/api/perf/data')
+def api_perf_data():
+    """Return best results JSON for arch+kernel combination."""
+    workdir = current_app.config['WORKDIR']
+    arch        = request.args.get('arch', '')
+    kernel      = request.args.get('kernel', 'attn_fwd')
+    mode        = request.args.get('mode', 'kernel')
+    seqlen_min  = int(request.args.get('seqlen_min', 0))
+    seqlen_max  = int(request.args.get('seqlen_max', 65536))
+    if not arch:
+        return jsonify({'error': 'arch is required'}), 400
+    data = tasks.query_perf_data(workdir, arch, kernel, mode, seqlen_min, seqlen_max)
+    return jsonify(data)
+
+
+@bp.route('/api/servers/export-visperf', methods=['POST'])
+def api_export_visperf():
+    """Export self-contained perf.html for GitHub Pages."""
+    workdir = current_app.config['WORKDIR']
+    result = tasks.export_visperf(workdir, dry_run=should_dryrun())
+    return jsonify(result)
+
+
+@bp.route('/static/cache/plotly.basic.min.js')
+def plotly_cache():
+    """Serve locally cached Plotly.js from scratch/webcache/."""
+    workdir = current_app.config['WORKDIR']
+    cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.basic.min.js'
+    if not cache_path.exists():
+        return 'Plotly cache not available. Load the Perf page online first.', 503
+    return send_file(cache_path, mimetype='application/javascript')
 
 
 @bp.route('/debug')

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -1086,11 +1086,11 @@ def api_export_visperf():
 
 _PLOTLY_CDN = 'https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js'
 
-@bp.route('/static/cache/plotly.basic.min.js')
+@bp.route('/static/cache/plotly.min.js')
 def plotly_cache():
     """Serve Plotly.js from a local cache, downloading it on first request."""
     workdir = current_app.config['WORKDIR']
-    cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.basic.min.js'
+    cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.min.js'
     if not cache_path.exists():
         try:
             cache_path.parent.mkdir(parents=True, exist_ok=True)

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -1032,39 +1032,30 @@ def api_perf_data():
 
 @bp.route('/api/perf/export_zip', methods=['POST'])
 def api_perf_export_zip():
-    """Build a self-contained autozoom HTML and return it as a .zip download.
+    """Build a self-contained autozoom HTML (all arches/kernels) as a .zip download.
 
     Request JSON:
-      arch, kernel, mode           – same as /api/perf/data
-      col_dim_filters              – {dim: [allowed_values, ...]} — empty list means all
-      url_params                   – dict of URL search params to pre-set in the export
+      col_dim_filters  – {dim: [allowed_values, ...]} — empty list means all
+      url_params       – dict of URL search params to pre-set in the export
     """
-    body       = request.get_json(force=True) or {}
-    arch       = body.get('arch', '')
-    kernel     = body.get('kernel', 'attn_fwd')
-    mode       = body.get('mode', 'kernel')
+    body        = request.get_json(force=True) or {}
     col_filters: dict = body.get('col_dim_filters', {})
     url_params: dict  = body.get('url_params', {})
 
-    if not arch:
-        return jsonify({'error': 'arch is required'}), 400
-
     try:
-        html = tasks.build_perf_export_html(arch, kernel, mode, col_filters, url_params,
+        html = tasks.build_perf_export_html(col_filters, url_params,
                                             current_app.config['WORKDIR'])
     except Exception as exc:
         logger.error('build_perf_export_html failed: %s', exc)
         return jsonify({'error': str(exc)}), 500
 
     buf = io.BytesIO()
-    filename = f'aotriton_perf_{arch}_{kernel}.html'
     with zipfile.ZipFile(buf, 'w', compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(filename, html.encode('utf-8'))
+        zf.writestr('aotriton_perf.html', html.encode('utf-8'))
     buf.seek(0)
 
-    zip_name = f'aotriton_perf_{arch}_{kernel}.zip'
     return send_file(buf, mimetype='application/zip',
-                     as_attachment=True, download_name=zip_name)
+                     as_attachment=True, download_name='aotriton_perf.zip')
 
 
 @bp.route('/api/servers/export-visperf', methods=['POST'])

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -1030,6 +1030,21 @@ def api_perf_data():
     return jsonify(data)
 
 
+@bp.route('/api/perf/cell_detail')
+def api_perf_cell_detail():
+    """Return all candidate (psel/copt) rows + accuracy thresholds for one cell."""
+    workdir = current_app.config['WORKDIR']
+    try:
+        task_id = int(request.args.get('task_id', ''))
+    except ValueError:
+        return jsonify({'error': 'task_id is required (int)'}), 400
+    kernel = request.args.get('kernel', '')
+    mode   = request.args.get('mode', 'kernel')
+    if not kernel:
+        return jsonify({'error': 'kernel is required'}), 400
+    return jsonify(tasks.query_perf_cell_detail(workdir, task_id, kernel, mode))
+
+
 @bp.route('/api/perf/export_zip', methods=['POST'])
 def api_perf_export_zip():
     """Build a self-contained autozoom HTML (all arches/kernels) as a .zip download.

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -1036,7 +1036,7 @@ def api_export_visperf():
     return jsonify(result)
 
 
-_PLOTLY_CDN = 'https://cdn.jsdelivr.net/npm/plotly.js-basic-dist@2.35.2/plotly.basic.min.js'
+_PLOTLY_CDN = 'https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js'
 
 @bp.route('/static/cache/plotly.basic.min.js')
 def plotly_cache():

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -9,6 +9,7 @@ from flask import Blueprint, render_template, request, jsonify, current_app, Res
 import time
 import json
 import logging
+import urllib.request
 from pathlib import Path
 
 from . import tasks
@@ -1035,13 +1036,20 @@ def api_export_visperf():
     return jsonify(result)
 
 
+_PLOTLY_CDN = 'https://cdn.jsdelivr.net/npm/plotly.js-basic-dist@2.35.2/plotly.basic.min.js'
+
 @bp.route('/static/cache/plotly.basic.min.js')
 def plotly_cache():
-    """Serve locally cached Plotly.js from scratch/webcache/."""
+    """Serve Plotly.js from a local cache, downloading it on first request."""
     workdir = current_app.config['WORKDIR']
     cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.basic.min.js'
     if not cache_path.exists():
-        return 'Plotly cache not available. Load the Perf page online first.', 503
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            urllib.request.urlretrieve(_PLOTLY_CDN, cache_path)
+        except Exception as exc:
+            logger.warning('Failed to download Plotly from CDN: %s', exc)
+            return f'Plotly unavailable: {exc}', 503
     return send_file(cache_path, mimetype='application/javascript')
 
 

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -1022,8 +1022,11 @@ def api_perf_data():
     arch        = request.args.get('arch', '')
     kernel      = request.args.get('kernel', 'attn_fwd')
     mode        = request.args.get('mode', 'kernel')
-    seqlen_min  = int(request.args.get('seqlen_min', 0))
-    seqlen_max  = int(request.args.get('seqlen_max', 65536))
+    try:
+        seqlen_min = int(request.args.get('seqlen_min', 0))
+        seqlen_max = int(request.args.get('seqlen_max', 65536))
+    except ValueError:
+        return jsonify({'error': 'seqlen_min/seqlen_max must be integers'}), 400
     if not arch:
         return jsonify({'error': 'arch is required'}), 400
     data = tasks.query_perf_data(workdir, arch, kernel, mode, seqlen_min, seqlen_max)

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -1094,7 +1094,8 @@ def plotly_cache():
     if not cache_path.exists():
         try:
             cache_path.parent.mkdir(parents=True, exist_ok=True)
-            urllib.request.urlretrieve(_PLOTLY_CDN, cache_path)
+            with urllib.request.urlopen(_PLOTLY_CDN, timeout=30) as resp:
+                cache_path.write_bytes(resp.read())
         except Exception as exc:
             logger.warning('Failed to download Plotly from CDN: %s', exc)
             return f'Plotly unavailable: {exc}', 503

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -6,10 +6,12 @@ URL routes and handlers for the web dashboard
 """
 
 from flask import Blueprint, render_template, request, jsonify, current_app, Response, g, send_file
+import io
 import time
 import json
 import logging
 import urllib.request
+import zipfile
 from pathlib import Path
 
 from . import tasks
@@ -1026,6 +1028,43 @@ def api_perf_data():
         return jsonify({'error': 'arch is required'}), 400
     data = tasks.query_perf_data(workdir, arch, kernel, mode, seqlen_min, seqlen_max)
     return jsonify(data)
+
+
+@bp.route('/api/perf/export_zip', methods=['POST'])
+def api_perf_export_zip():
+    """Build a self-contained autozoom HTML and return it as a .zip download.
+
+    Request JSON:
+      arch, kernel, mode           – same as /api/perf/data
+      col_dim_filters              – {dim: [allowed_values, ...]} — empty list means all
+      url_params                   – dict of URL search params to pre-set in the export
+    """
+    body       = request.get_json(force=True) or {}
+    arch       = body.get('arch', '')
+    kernel     = body.get('kernel', 'attn_fwd')
+    mode       = body.get('mode', 'kernel')
+    col_filters: dict = body.get('col_dim_filters', {})
+    url_params: dict  = body.get('url_params', {})
+
+    if not arch:
+        return jsonify({'error': 'arch is required'}), 400
+
+    try:
+        html = tasks.build_perf_export_html(arch, kernel, mode, col_filters, url_params,
+                                            current_app.config['WORKDIR'])
+    except Exception as exc:
+        logger.error('build_perf_export_html failed: %s', exc)
+        return jsonify({'error': str(exc)}), 500
+
+    buf = io.BytesIO()
+    filename = f'aotriton_perf_{arch}_{kernel}.html'
+    with zipfile.ZipFile(buf, 'w', compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(filename, html.encode('utf-8'))
+    buf.seek(0)
+
+    zip_name = f'aotriton_perf_{arch}_{kernel}.zip'
+    return send_file(buf, mimetype='application/zip',
+                     as_attachment=True, download_name=zip_name)
 
 
 @bp.route('/api/servers/export-visperf', methods=['POST'])

--- a/.tune/webui/routes.py
+++ b/.tune/webui/routes.py
@@ -1103,14 +1103,15 @@ _PLOTLY_SHA256 = '6d21266ce1bd7d9e5ab4e115989c70c20de0382fd973a8f26ab58619eba4d6
 def plotly_cache():
     """Serve Plotly.js from a local cache, downloading it on first request."""
     import hashlib
+    import tempfile
     workdir = current_app.config['WORKDIR']
     cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.min.js'
     if not cache_path.exists():
-        # Download to a temp file in the same dir, then atomic rename:
-        # avoids serving a truncated cache if the connection drops or
-        # two concurrent first-time requests race. Pre-declared so the
-        # except cleanup never trips UnboundLocalError on early failure.
-        tmp_path = cache_path.with_suffix(cache_path.suffix + f'.tmp.{os.getpid()}')
+        # tempfile.mkstemp gives us a unique, atomically-created file in the
+        # same directory as the final cache_path so os.replace() is atomic on
+        # the same filesystem. Unique name avoids the PID-only TOCTOU race
+        # where two concurrent threads in the same process collide.
+        tmp_path: Path | None = None
         try:
             cache_path.parent.mkdir(parents=True, exist_ok=True)
             with urllib.request.urlopen(_PLOTLY_CDN, timeout=30) as resp:
@@ -1121,14 +1122,20 @@ def plotly_cache():
                     f'Plotly CDN payload SHA-256 mismatch: got {digest}, '
                     f'expected {_PLOTLY_SHA256}'
                 )
-            tmp_path.write_bytes(payload)
+            fd, tmp_name = tempfile.mkstemp(prefix='plotly.', suffix='.tmp',
+                                            dir=cache_path.parent)
+            tmp_path = Path(tmp_name)
+            with os.fdopen(fd, 'wb') as fh:
+                fh.write(payload)
             os.replace(tmp_path, cache_path)
+            tmp_path = None  # ownership transferred to cache_path
         except Exception as exc:
             logger.warning('Failed to download Plotly from CDN: %s', exc)
-            try:
-                tmp_path.unlink(missing_ok=True)
-            except Exception:
-                pass
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
             return f'Plotly unavailable: {exc}', 503
     return send_file(cache_path, mimetype='application/javascript')
 

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -82,7 +82,10 @@ let state = {
   // null = all values shown. A Set means only those values are shown.
   filter: {},
   displayMode: 'autozoom',  // 'heatmap' | '3d' | 'autozoom'
-  autozoom: { drilldown: null },  // drilldown = {rowCombo, colCombo} or null for overview
+  autozoom: {
+    drilldown: null,   // {rowCombo, colCombo} or null for overview
+    seqMode: 'max_load',  // 'max_load' = arch-specific sq=sk target; 'max_tflops' = max across all seqlens
+  },
   seqlenRange: [0, 65536],
   scale: {
     mode: 'max_observed',   // 'max_observed' | 'theoretical' | 'user'
@@ -241,6 +244,38 @@ function computeAnchor(visibleRows, state) {
 }
 
 // Pick the anchor value for a given dtype from computeAnchor's return value.
+// Like computeAnchor but uses _cellTflops() per cell instead of raw row values.
+// Used by autozoom overview so the anchor matches what is actually displayed.
+function computeAnchorFromCells(cells, state) {
+  const desc = state.descriptor;
+  if (!desc) return new Map([['', 1]]);
+
+  if (state.scale.mode === 'user' && state.scale.userValue > 0) {
+    return state.scale.userValue;
+  }
+  if (state.scale.mode === 'theoretical') {
+    const peak = THEORETICAL_PEAK_TFLOPS[state.arch];
+    if (peak) {
+      const dtypes = state.data && state.data.axes.dtype;
+      const map = new Map();
+      (dtypes || Object.keys(peak)).forEach(d => { if (peak[d]) map.set(d, peak[d]); });
+      if (map.size) return map;
+    }
+  }
+  // max_observed per dtype, using the same per-cell tflops value as displayed.
+  const byDtype = new Map();
+  for (const cell of cells) {
+    const t = _cellTflops(cell.index, desc);
+    if (t > 0) {
+      // Determine dtype from combo dims.
+      const dtype = (cell.colCombo && cell.colCombo.dtype) ||
+                    (cell.rowCombo && cell.rowCombo.dtype) || '';
+      if (!byDtype.has(dtype) || t > byDtype.get(dtype)) byDtype.set(dtype, t);
+    }
+  }
+  return byDtype.size ? byDtype : new Map([['', 1]]);
+}
+
 // When anchor is a Map (max_observed), look up by dtype; otherwise use directly.
 function anchorFor(anchor, dtype) {
   if (!(anchor instanceof Map)) return anchor;
@@ -361,6 +396,36 @@ function render3D(container, seqQ, seqK, index, desc, anchor) {
 // Autozoom rendering
 // ---------------------------------------------------------------------------
 
+// Default "representative" seqlen for autozoom fixed mode, keyed by arch.
+// gfx1100 has limited HBM so 2k×2k is the canonical point; everything else uses 8k×8k.
+const _AZ_TARGET_SEQLEN = {
+  gfx1100: 2048,
+};
+const _AZ_DEFAULT_SEQLEN = 8192;
+
+function _azTargetSeqlen() {
+  return _AZ_TARGET_SEQLEN[state.arch] || _AZ_DEFAULT_SEQLEN;
+}
+
+// Returns the TFLOPS at (sq, sk). If that exact entry is missing, finds the
+// closest available sq and sk independently (by absolute distance) and falls
+// back to that entry, or 0 if still not found.
+function _tflopsAtSeq(index, desc, sq, sk) {
+  const row = index.get(`${sq}|${sk}`);
+  if (row && row.median_ms > 0) return desc.tflops(row);
+
+  // Collect available seqlens from the index keys.
+  const seqQs = new Set(), seqKs = new Set();
+  for (const key of index.keys()) {
+    const [q, k] = key.split('|').map(Number);
+    seqQs.add(q); seqKs.add(k);
+  }
+  const nearQ = [...seqQs].reduce((best, v) => Math.abs(v - sq) < Math.abs(best - sq) ? v : best, [...seqQs][0]);
+  const nearK = [...seqKs].reduce((best, v) => Math.abs(v - sk) < Math.abs(best - sk) ? v : best, [...seqKs][0]);
+  const fallback = index.get(`${nearQ}|${nearK}`);
+  return (fallback && fallback.median_ms > 0) ? desc.tflops(fallback) : 0;
+}
+
 // Returns the max TFLOPS across all seqlen_q×seqlen_k entries in the index.
 function _maxTflops(index, desc) {
   let max = 0;
@@ -371,6 +436,13 @@ function _maxTflops(index, desc) {
     }
   }
   return max;
+}
+
+// Returns the representative TFLOPS for an autozoom cell based on seqMode.
+function _cellTflops(index, desc) {
+  if (state.autozoom.seqMode === 'max_tflops') return _maxTflops(index, desc);
+  const sq = _azTargetSeqlen(), sk = _azTargetSeqlen();
+  return _tflopsAtSeq(index, desc, sq, sk);
 }
 
 // Overview table: rows = rowDims combos, cols = colDims combos.
@@ -453,16 +525,20 @@ function renderAutozoom(grid, layout, anchor) {
       );
 
       if (cell) {
-        const maxT = _maxTflops(cell.index, desc);
-        if (maxT > 0) {
+        const cellT = _cellTflops(cell.index, desc);
+        if (cellT > 0) {
           const dtype = colCombo.dtype || rowCombo.dtype;
           const a    = anchorFor(anchor, dtype);
-          const frac = perfFrac(maxT, a);
+          const frac = perfFrac(cellT, a);
           td.style.background = perfColor(frac);
           td.style.color      = cellTextColor(frac);
-          const pct = Math.round(maxT / a * 100);
-          td.innerHTML = `<div style="line-height:1.2">${maxT.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
-          td.title = `Max TFLOPS: ${maxT.toFixed(2)}\nClick to view seqlen matrix`;
+          const pct = Math.round(cellT / a * 100);
+          td.innerHTML = `<div style="line-height:1.2">${cellT.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
+          const sq = _azTargetSeqlen();
+          const tooltipLabel = state.autozoom.seqMode === 'max_tflops'
+            ? `Max TFLOPS: ${cellT.toFixed(2)}`
+            : `TFLOPS @ ${sq}×${sq}: ${cellT.toFixed(2)}`;
+          td.title = `${tooltipLabel}\nClick to view seqlen matrix`;
           td.addEventListener('click', () => {
             state.autozoom.drilldown = { rowCombo, colCombo };
             renderGrid();
@@ -543,14 +619,16 @@ function renderGrid() {
       legend.textContent = `Scale anchor: ${anchor instanceof Map ? [...anchor.entries()].map(([d,v])=>`${d}:${v.toFixed(1)}`).join(", ") : anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
       grid.appendChild(legend);
     } else {
-      // Overview: anchor from all visible rows.
-      const allVisible = layout.cells.flatMap(c => [...c.index.values()].filter(Boolean));
-      const anchor = computeAnchor(allVisible, state);
+      // Overview: anchor based on the same per-cell tflops values that will be displayed.
+      const anchor = computeAnchorFromCells(layout.cells, state);
       renderAutozoom(grid, layout, anchor);
 
       const legend = document.createElement('div');
       legend.style.cssText = 'margin-top:8px;opacity:0.75;';
-      legend.textContent = `Scale anchor: ${anchor instanceof Map ? [...anchor.entries()].map(([d,v])=>`${d}:${v.toFixed(1)}`).join(", ") : anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
+      const azLabel = state.autozoom.seqMode === 'max_tflops'
+        ? 'max TFLOPS'
+        : `${_azTargetSeqlen()}×${_azTargetSeqlen()} TFLOPS`;
+      legend.textContent = `Showing: ${azLabel} — Scale anchor: ${anchor instanceof Map ? [...anchor.entries()].map(([d,v])=>`${d}:${v.toFixed(1)}`).join(", ") : anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
       grid.appendChild(legend);
     }
     return;
@@ -690,8 +768,9 @@ function pushURLState() {
   if (state.arch)         p.set('arch',    state.arch);
   if (state.descriptorId) p.set('module',  state.descriptorId);
   if (state.kernel)       p.set('kernel',  state.kernel);
-  p.set('display', state.displayMode);
-  p.set('scale',   state.scale.mode);
+  p.set('display',  state.displayMode);
+  p.set('az_mode',  state.autozoom.seqMode);
+  p.set('scale',    state.scale.mode);
   if (state.scale.mode === 'user' && state.scale.userValue)
     p.set('scale_value', state.scale.userValue);
   if (state.colDims.length) p.set('col_dims', state.colDims.join(','));
@@ -712,6 +791,7 @@ function restoreFromURL() {
     display:     p.get('display')     || '',
     scale:       p.get('scale')       || '',
     scale_value: p.get('scale_value') || '',
+    az_mode:     p.get('az_mode')     || '',
     col_dims:    p.get('col_dims')    || '',
     row_dims:    p.get('row_dims')    || '',
     filters:     [...p.entries()]
@@ -730,15 +810,30 @@ function initPerf() {
   const scaleSel   = document.getElementById('perf-scale');
   const scaleInput = document.getElementById('perf-scale-value');
   const dispSel    = document.getElementById('perf-display');
+  const azModeSel  = document.getElementById('perf-az-mode');
+  const azModeLabel = document.getElementById('perf-az-mode-label');
   const refreshBtn = document.getElementById('perf-refresh');
   const status     = document.getElementById('perf-status');
+
+  function _syncAzModeVisibility() {
+    if (azModeLabel) azModeLabel.style.display =
+      (state.displayMode === 'autozoom') ? '' : 'none';
+  }
 
   // Apply URL params to selectors before load().
   const saved = restoreFromURL();
   if (saved.module) state.descriptorId = saved.module;
   if (saved.arch   && archSel)   archSel.value   = saved.arch;
   if (saved.kernel && kernelSel) kernelSel.value = saved.kernel;
-  if (saved.display && dispSel)  dispSel.value   = saved.display;
+  if (saved.display && dispSel) {
+    dispSel.value = saved.display;
+    state.displayMode = saved.display || 'autozoom';
+  }
+  if (saved.az_mode && azModeSel) {
+    azModeSel.value = saved.az_mode;
+    state.autozoom.seqMode = saved.az_mode;
+  }
+  _syncAzModeVisibility();
   if (saved.scale  && scaleSel) {
     scaleSel.value = saved.scale;
     state.scale.mode = saved.scale;
@@ -949,6 +1044,14 @@ function initPerf() {
     dispSel.addEventListener('change', () => {
       state.displayMode = dispSel.value;
       state.autozoom.drilldown = null;
+      _syncAzModeVisibility();
+      renderGrid();
+      pushURLState();
+    });
+  }
+  if (azModeSel) {
+    azModeSel.addEventListener('change', () => {
+      state.autozoom.seqMode = azModeSel.value;
       renderGrid();
       pushURLState();
     });

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -592,17 +592,16 @@ function renderAutozoom(grid, layout, anchor) {
   const table = document.createElement('table');
   table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
 
-  // Precompute separator positions (same logic as heatmap/3D grid).
-  const colSeps = state.colDims.map((dimKey) => {
-    const seps = new Set();
-    let prev = null;
-    colCombos.forEach((cc, ci) => {
-      if (ci > 0 && cc[dimKey] !== prev) seps.add(ci);
-      prev = cc[dimKey];
-    });
-    return seps;
+  // Per-column dim-value tuples in colDims order; used both for separators and
+  // for the merged-header spans below.
+  const colVecs = colCombos.map(cc => state.colDims.map(k => cc[k]));
+  const colNeedsSep = colCombos.map((_, ci) => {
+    if (ci === 0) return false;
+    for (let li = 0; li < state.colDims.length; li++) {
+      if (colVecs[ci][li] !== colVecs[ci - 1][li]) return true;
+    }
+    return false;
   });
-  const colNeedsSep = colCombos.map((_, ci) => colSeps.some(s => s.has(ci)));
 
   // Column header rows.
   for (let di = 0; di < numColDims; di++) {
@@ -616,19 +615,8 @@ function renderAutozoom(grid, layout, anchor) {
       tr.appendChild(th);
     }
     const dimKey = state.colDims[di];
-    const spans = [];
-    let curLabel = null, curCount = 0, curStart = 0;
-    colCombos.forEach((cc, ci) => {
-      const label = _dimLabel(desc, dimKey, cc[dimKey]);
-      // Break when this dim's value changes OR any ancestor dim changes.
-      const ancestorBreak = ci > 0 && colSeps.slice(0, di).some(s => s.has(ci));
-      if (label !== curLabel || ancestorBreak) {
-        if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
-        curLabel = label; curCount = 0; curStart = ci;
-      }
-      curCount++;
-    });
-    if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
+    const spans = computeHeaderSpans(colVecs, di,
+      (vec, l) => _dimLabel(desc, state.colDims[l], vec[l]));
     for (const { label, count, start } of spans) {
       const th = document.createElement('th');
       th.colSpan = count;
@@ -696,6 +684,40 @@ function renderAutozoom(grid, layout, anchor) {
 // ---------------------------------------------------------------------------
 // Grid rendering
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Generic header-merging helper
+// ---------------------------------------------------------------------------
+
+// Compute colSpan groups for a hierarchical-header row at `level`.
+//   vectors: array of per-column tuples (each tuple is an array of length L).
+//   level:   0..L-1 — which entry of the tuple this header row displays.
+//   labelFn: (vec, level) → display label string (defaults to String(vec[level])).
+// A new span starts when the label at `level` changes OR any earlier (ancestor)
+// level changes — so a child header never spans across a parent's break.
+// Returns [{label, count, start}].
+function computeHeaderSpans(vectors, level, labelFn) {
+  labelFn = labelFn || ((v, l) => String(v[l]));
+  const spans = [];
+  let curLabel = null, curCount = 0, curStart = 0;
+  vectors.forEach((vec, i) => {
+    const label = labelFn(vec, level);
+    let ancestorBreak = false;
+    if (i > 0) {
+      const prev = vectors[i - 1];
+      for (let li = 0; li < level; li++) {
+        if (vec[li] !== prev[li]) { ancestorBreak = true; break; }
+      }
+    }
+    if (i === 0 || label !== curLabel || ancestorBreak) {
+      if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
+      curLabel = label; curCount = 0; curStart = i;
+    }
+    curCount++;
+  });
+  if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
+  return spans;
+}
 
 // ---------------------------------------------------------------------------
 // Rendering: level-2 (psel × copt) cell detail
@@ -798,26 +820,29 @@ function renderCellDetail(container, cd) {
   tbl.style.cssText = 'border-collapse:collapse;font-size:0.8em;font-family:monospace;';
 
   const thead = tbl.createTHead();
-  // One header row per psel field; each cell shows that field's value.
+  const pselVecs = psels.map(([, v]) => v);
+  // One header row per psel field, with adjacent identical values merged.
   for (let li = 0; li < schema.psels.length; li++) {
     const tr = thead.insertRow();
     const lbl = document.createElement('th');
     lbl.textContent = li === 0 ? `psel \\ copt` : '';
     lbl.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.7;font-weight:normal;';
     tr.appendChild(lbl);
-    // Skip the copt-label columns at the start (we use one column per copt field below).
+    // Pad the copt-label columns at the start (we use one column per copt field below).
     for (let cj = 0; cj < schema.copts.length - 1; cj++) {
-      const pad = document.createElement('th');
-      tr.appendChild(pad);
+      tr.appendChild(document.createElement('th'));
     }
     const fieldName = document.createElement('th');
     fieldName.textContent = schema.psels[li];
     fieldName.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.8;font-weight:normal;';
     tr.appendChild(fieldName);
-    for (const [, vec] of psels) {
+    const spans = computeHeaderSpans(pselVecs, li);
+    for (const { label, count, start } of spans) {
       const th = document.createElement('th');
-      th.textContent = String(vec[li]);
-      th.style.cssText = 'padding:2px 4px;text-align:center;opacity:0.8;font-weight:normal;white-space:nowrap;';
+      th.colSpan = count;
+      th.textContent = label;
+      const sep = start > 0 ? 'border-left:2px solid currentColor;' : '';
+      th.style.cssText = `padding:2px 4px;text-align:center;border-bottom:1px solid currentColor;opacity:0.8;font-weight:normal;white-space:nowrap;${sep}`;
       tr.appendChild(th);
     }
   }
@@ -864,11 +889,20 @@ function renderCellDetail(container, cd) {
       const pct = Math.round(info.tflops / anchor * 100);
       let html = `<div style="line-height:1.2">${info.tflops.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
       if (!info.passed) {
-        // SVG cross overlay; bright red so it shows on any background.
+        // Black ✕ with a white halo via paint-order:stroke — readable on any
+        // background (the perfColor() palette spans hues 0..220, so avoiding
+        // pure chromatic markers entirely is the safest).
         html += `<svg style="position:absolute;inset:0;width:100%;height:100%;pointer-events:none"
                      viewBox="0 0 10 10" preserveAspectRatio="none">
-                  <line x1="0" y1="0" x2="10" y2="10" stroke="#e00" stroke-width="1.2"/>
-                  <line x1="10" y1="0" x2="0" y2="10" stroke="#e00" stroke-width="1.2"/>
+                  <g stroke="#111" stroke-width="1.1" fill="none"
+                     style="paint-order:stroke;stroke-linecap:round">
+                    <line x1="1.5" y1="1.5" x2="8.5" y2="8.5"
+                          stroke="#fff" stroke-width="2.4"/>
+                    <line x1="8.5" y1="1.5" x2="1.5" y2="8.5"
+                          stroke="#fff" stroke-width="2.4"/>
+                    <line x1="1.5" y1="1.5" x2="8.5" y2="8.5"/>
+                    <line x1="8.5" y1="1.5" x2="1.5" y2="8.5"/>
+                  </g>
                 </svg>`;
       }
       td.innerHTML = html;
@@ -989,20 +1023,15 @@ function renderGrid() {
   const table = document.createElement('table');
   table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
 
-  // Precompute which colCombo indices start a new group for each dim level.
-  // colSeps[di] is a Set of colCombo indices where dim di's value changes.
-  const colSeps = state.colDims.map((dimKey, di) => {
-    const seps = new Set();
-    let prev = null;
-    layout.colCombos.forEach((cc, ci) => {
-      const val = cc[dimKey];
-      if (ci > 0 && val !== prev) seps.add(ci);
-      prev = val;
-    });
-    return seps;
+  // Per-column dim-value tuples in colDims order; powers separators + spans.
+  const colVecs = layout.colCombos.map(cc => state.colDims.map(k => cc[k]));
+  const colNeedsSep = layout.colCombos.map((_, ci) => {
+    if (ci === 0) return false;
+    for (let li = 0; li < state.colDims.length; li++) {
+      if (colVecs[ci][li] !== colVecs[ci - 1][li]) return true;
+    }
+    return false;
   });
-  // A column index needs a separator if ANY dim level starts a new group there.
-  const colNeedsSep = layout.colCombos.map((_, ci) => colSeps.some(s => s.has(ci)));
 
   // Header rows — one per colDim.
   for (let di = 0; di < numColDims; di++) {
@@ -1016,24 +1045,9 @@ function renderGrid() {
       }
       tr.appendChild(th);
     }
-    // Compute spans for this dim level.
     const dimKey = state.colDims[di];
-    const spans = [];
-    let curLabel = null, curCount = 0, curStart = 0;
-    layout.colCombos.forEach((cc, ci) => {
-      const label = _dimLabel(state.descriptor, dimKey, cc[dimKey]);
-      // Break when this dim's value changes OR any ancestor dim changes.
-      const ancestorBreak = ci > 0 && colSeps.slice(0, di).some(s => s.has(ci));
-      if (label !== curLabel || ancestorBreak) {
-        if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
-        curLabel = label;
-        curCount = 0;
-        curStart = ci;
-      }
-      curCount++;
-    });
-    if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
-
+    const spans = computeHeaderSpans(colVecs, di,
+      (vec, l) => _dimLabel(state.descriptor, state.colDims[l], vec[l]));
     for (const { label, count, start } of spans) {
       const th = document.createElement('th');
       th.colSpan = count;

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -39,6 +39,20 @@ function _hslComponents(fraction) {
   };
 }
 
+// Map a raw linear fraction [0,1] to a perceptual fraction using log scaling.
+// log(1 + k*x)/log(1+k) with k=9 maps 10% linear → ~53% perceptual,
+// spreading the color range across the lower-performance majority.
+const _LOG_K = 9;
+function _logFrac(linearFrac) {
+  const x = Math.max(0, Math.min(1, linearFrac));
+  return Math.log1p(_LOG_K * x) / Math.log1p(_LOG_K);
+}
+
+// Compute the display fraction for tflops/anchor, log-scaled.
+function perfFrac(tflops, anchor) {
+  return _logFrac(tflops / anchor);
+}
+
 // Background color for a performance fraction.
 function perfColor(fraction) {
   const { h, s, l } = _hslComponents(fraction);
@@ -245,12 +259,12 @@ function renderHeatmap(container, seqQ, seqK, index, desc, anchor) {
       }
 
       const tflops = desc.tflops(row);
-      const frac   = Math.min(1, tflops / anchor);
+      const frac   = perfFrac(tflops, anchor);
       td.style.background = perfColor(frac);
       td.style.color      = cellTextColor(frac);
       td.style.cursor     = 'default';
 
-      const pct = Math.round(frac * 100);
+      const pct = Math.round(tflops / anchor * 100);
       td.innerHTML = `<div style="line-height:1.2">${tflops.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
 
       // Tooltip.
@@ -393,10 +407,10 @@ function renderAutozoom(grid, layout, anchor) {
       if (cell) {
         const maxT = _maxTflops(cell.index, desc);
         if (maxT > 0) {
-          const frac = Math.min(1, maxT / anchor);
+          const frac = perfFrac(maxT, anchor);
           td.style.background = perfColor(frac);
           td.style.color      = cellTextColor(frac);
-          const pct = Math.round(frac * 100);
+          const pct = Math.round(maxT / anchor * 100);
           td.innerHTML = `<div style="line-height:1.2">${maxT.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
           td.title = `Max TFLOPS: ${maxT.toFixed(2)}\nClick to view seqlen matrix`;
           td.addEventListener('click', () => {

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -678,21 +678,8 @@ function initPerf() {
 
   // Move dim to a new role (and optionally a position within that role's list).
   function moveDim(key, toRole, beforeKey) {
-    // Remove from current role list.
     state.colDims = state.colDims.filter(k => k !== key);
     state.rowDims = state.rowDims.filter(k => k !== key);
-    // Also clear fixed value when moving into col/row.
-    if (toRole === 'fixed') {
-      if (state.fixed[key] === undefined) {
-        const vals = state.data && state.data.axes[key];
-        state.fixed[key] = vals && vals.length ? vals[0] : null;
-      }
-      delete state.filter[key];   // fixed select takes over; no grid filter needed
-    } else {
-      delete state.fixed[key];
-      // Preserve any existing filter[key] when moving back to col/row.
-    }
-    // Insert into target list.
     const targetList = toRole === 'col' ? state.colDims : toRole === 'row' ? state.rowDims : null;
     if (targetList !== null) {
       const idx = beforeKey ? targetList.indexOf(beforeKey) : -1;
@@ -768,30 +755,6 @@ function initPerf() {
     return chip;
   }
 
-  function buildFixedSelect(key) {
-    const vals = (state.data && state.data.axes[key]) || [];
-    const wrap = document.createElement('span');
-    wrap.style.cssText = 'display:inline-flex;align-items:center;gap:0.3rem;margin:0.15rem;';
-    const lbl = document.createElement('span');
-    lbl.textContent = key + ':';
-    const sel = document.createElement('select');
-    vals.forEach(v => {
-      const opt = document.createElement('option');
-      opt.value = v;
-      opt.textContent = _dimLabel(state.descriptor, key, v);
-      if (state.fixed[key] !== undefined && String(state.fixed[key]) === String(v)) opt.selected = true;
-      sel.appendChild(opt);
-    });
-    sel.addEventListener('change', () => {
-      const raw = sel.value;
-      state.fixed[key] = isNaN(Number(raw)) ? raw : Number(raw);
-      renderGrid();
-    });
-    wrap.appendChild(lbl);
-    wrap.appendChild(sel);
-    return wrap;
-  }
-
   function wireDropTarget(zone) {
     zone.addEventListener('dragover', e => {
       e.preventDefault();
@@ -824,30 +787,21 @@ function initPerf() {
                        .filter(k => (state.data.axes[k] || []).length > 1 ||
                                     state.colDims.includes(k) || state.rowDims.includes(k));
 
-    const colZone   = document.getElementById('perf-col-dims');
-    const rowZone   = document.getElementById('perf-row-dims');
-    const fixedZone = document.getElementById('perf-fixed-filters');
-    if (!colZone || !rowZone || !fixedZone) return;
+    const colZone = document.getElementById('perf-col-dims');
+    const rowZone = document.getElementById('perf-row-dims');
+    if (!colZone || !rowZone) return;
 
-    colZone.innerHTML   = '';
-    rowZone.innerHTML   = '';
-    fixedZone.innerHTML = '';
+    colZone.innerHTML = '';
+    rowZone.innerHTML = '';
 
-    // Render chips in order for col/row zones; fixed zone gets selects.
     for (const key of state.colDims) {
       if (allDims.includes(key)) colZone.appendChild(buildDimChip(key));
     }
     for (const key of state.rowDims) {
       if (allDims.includes(key)) rowZone.appendChild(buildDimChip(key));
     }
-    for (const key of allDims) {
-      if (!state.colDims.includes(key) && !state.rowDims.includes(key)) {
-        fixedZone.appendChild(buildFixedSelect(key));
-      }
-    }
 
-    // Wire drop targets once per rebuild (they are fresh DOM nodes).
-    [colZone, rowZone, fixedZone].forEach(wireDropTarget);
+    [colZone, rowZone].forEach(wireDropTarget);
   }
 
   if (refreshBtn) refreshBtn.addEventListener('click', load);

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -681,6 +681,43 @@ function _dimLabel(desc, key, value) {
 }
 
 // ---------------------------------------------------------------------------
+// URL state persistence
+// ---------------------------------------------------------------------------
+
+function pushURLState() {
+  const p = new URLSearchParams();
+  if (state.arch)   p.set('arch',    state.arch);
+  if (state.kernel) p.set('kernel',  state.kernel);
+  p.set('display', state.displayMode);
+  p.set('scale',   state.scale.mode);
+  if (state.scale.mode === 'user' && state.scale.userValue)
+    p.set('scale_value', state.scale.userValue);
+  if (state.colDims.length) p.set('col_dims', state.colDims.join(','));
+  if (state.rowDims.length) p.set('row_dims', state.rowDims.join(','));
+  // Encode active single-value filters as f_<key>=<value>.
+  for (const [k, v] of Object.entries(state.filter)) {
+    if (v instanceof Set) p.set(`f_${k}`, [...v][0]);
+  }
+  history.replaceState(null, '', `?${p}`);
+}
+
+function restoreFromURL() {
+  const p = new URLSearchParams(location.search);
+  return {
+    arch:        p.get('arch')        || '',
+    kernel:      p.get('kernel')      || '',
+    display:     p.get('display')     || '',
+    scale:       p.get('scale')       || '',
+    scale_value: p.get('scale_value') || '',
+    col_dims:    p.get('col_dims')    || '',
+    row_dims:    p.get('row_dims')    || '',
+    filters:     [...p.entries()]
+                   .filter(([k]) => k.startsWith('f_'))
+                   .map(([k, v]) => [k.slice(2), v]),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Initialization and event wiring
 // ---------------------------------------------------------------------------
 
@@ -692,6 +729,21 @@ function initPerf() {
   const dispSel    = document.getElementById('perf-display');
   const refreshBtn = document.getElementById('perf-refresh');
   const status     = document.getElementById('perf-status');
+
+  // Apply URL params to selectors before load().
+  const saved = restoreFromURL();
+  if (saved.arch   && archSel)   archSel.value   = saved.arch;
+  if (saved.kernel && kernelSel) kernelSel.value = saved.kernel;
+  if (saved.display && dispSel)  dispSel.value   = saved.display;
+  if (saved.scale  && scaleSel) {
+    scaleSel.value = saved.scale;
+    state.scale.mode = saved.scale;
+    if (scaleInput) scaleInput.style.display = saved.scale === 'user' ? 'inline' : 'none';
+  }
+  if (saved.scale_value && scaleInput) {
+    scaleInput.value = saved.scale_value;
+    state.scale.userValue = parseFloat(saved.scale_value) || null;
+  }
 
   async function load() {
     if (!archSel || !kernelSel) return;
@@ -712,14 +764,24 @@ function initPerf() {
       // Pick descriptor by kernel family — currently always flash.
       state.descriptor = DESCRIPTORS['flash'];
       if (state.descriptor) {
-        state.colDims = [...state.descriptor.defaultColDims];
-        state.rowDims = [...state.descriptor.defaultRowDims];
+        // Restore col/row dims from URL if present, else use descriptor defaults.
+        state.colDims = saved.col_dims
+          ? saved.col_dims.split(',').filter(Boolean)
+          : [...state.descriptor.defaultColDims];
+        state.rowDims = saved.row_dims
+          ? saved.row_dims.split(',').filter(Boolean)
+          : [...state.descriptor.defaultRowDims];
         state.fixed   = { ...state.descriptor.defaultFixed };
-        state.filter  = {};   // clear all value filters on fresh load
+        state.filter  = {};
+        // Restore per-dim filters from URL.
+        for (const [k, v] of saved.filters) {
+          state.filter[k] = new Set([v]);
+        }
         state.autozoom.drilldown = null;
       }
       updateDimPanel();
       renderGrid();
+      pushURLState();
       if (status) status.textContent = `${state.data.rows.length} rows loaded.`;
       // Open the layout panel on first load so users discover it.
       const panel = document.getElementById('perf-layout-panel');
@@ -771,6 +833,7 @@ function initPerf() {
       e.stopPropagation();
       state.filter[key] = new Set([sel.value]);
       renderGrid();
+      pushURLState();
     });
 
     // Checkbox toggles between "all values" (dropdown disabled) and "single value" (dropdown enabled).
@@ -788,6 +851,7 @@ function initPerf() {
         sel.disabled = false;
       }
       renderGrid();
+      pushURLState();
     });
 
     // Label (not draggable-sensitive).
@@ -833,6 +897,7 @@ function initPerf() {
       moveDim(key, role, beforeKey);
       updateDimPanel();
       renderGrid();
+      pushURLState();
     });
   }
 
@@ -866,12 +931,14 @@ function initPerf() {
       state.scale.mode = scaleSel.value;
       if (scaleInput) scaleInput.style.display = scaleSel.value === 'user' ? 'inline' : 'none';
       renderGrid();
+      pushURLState();
     });
   }
   if (scaleInput) {
     scaleInput.addEventListener('change', () => {
       state.scale.userValue = parseFloat(scaleInput.value) || null;
       renderGrid();
+      pushURLState();
     });
   }
   if (dispSel) {
@@ -879,10 +946,11 @@ function initPerf() {
       state.displayMode = dispSel.value;
       state.autozoom.drilldown = null;
       renderGrid();
+      pushURLState();
     });
   }
 
-  // Auto-load on first visit if arch+kernel already selected.
+  // Auto-load if arch+kernel are set (either from URL or server-rendered default).
   if (archSel && archSel.value && kernelSel && kernelSel.value) {
     load();
   }

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -347,47 +347,126 @@ function renderHeatmap(container, seqQ, seqK, index, desc, anchor) {
   container.appendChild(tbl);
 }
 
+
 // ---------------------------------------------------------------------------
-// Rendering: 3-D bars via Plotly
+// Rendering: 3-D bars via Plotly (one bar per autozoom cell)
 // ---------------------------------------------------------------------------
 
-function render3D(container, seqQ, seqK, index, desc, anchor) {
+// Build a single Plotly mesh3d figure where each autozoom cell becomes one
+// colored rectangular bar. X axis = colCombo index, Y axis = rowCombo index,
+// Z axis = TFLOPS. Each bar is a unit-width box.
+function render3D(container, layout, anchor) {
   if (typeof Plotly === 'undefined') {
     container.textContent = 'Plotly.js not loaded — 3D view unavailable.';
     return;
   }
-  const z = seqQ.map(q =>
-    seqK.map(k => {
-      const row = index.get(`${q}|${k}`);
-      return (row && row.median_ms > 0) ? desc.tflops(row) : null;
-    })
-  );
-  const div = document.createElement('div');
-  div.style.cssText = 'width:320px;height:280px;';
-  container.appendChild(div);
 
-  Plotly.newPlot(div, [{
-    type: 'surface',
-    x: seqK,
-    y: seqQ,
-    z,
-    colorscale: [
-      [0,    'hsl(0,90%,45%)'],
-      [0.25, 'hsl(30,90%,50%)'],
-      [0.5,  'hsl(60,90%,50%)'],
-      [0.75, 'hsl(120,70%,40%)'],
-      [1,    'hsl(220,80%,45%)'],
-    ],
-    cmin: 0,
-    cmax: anchor,
+  const desc = state.descriptor;
+  const { rowCombos, colCombos, cells } = layout;
+  const nCol = colCombos.length;
+  const nRow = rowCombos.length;
+
+  // Collect (xi, yi, tflops, color) per cell.
+  const xs = [], ys = [], zs = [], colors = [];
+  for (let ri = 0; ri < nRow; ri++) {
+    for (let ci = 0; ci < nCol; ci++) {
+      const rowCombo = rowCombos[ri];
+      const colCombo = colCombos[ci];
+      const cell = cells.find(c =>
+        state.rowDims.every(k => c.rowCombo[k] === rowCombo[k]) &&
+        state.colDims.every(k => c.colCombo[k] === colCombo[k])
+      );
+      const cellT = cell ? _cellTflops(cell.index, desc) : 0;
+      const dtype = colCombo.dtype || rowCombo.dtype;
+      const a = anchorFor(anchor, dtype);
+      const frac = cellT > 0 ? perfFrac(cellT, a) : 0;
+      xs.push(ci);
+      ys.push(ri);
+      zs.push(cellT > 0 ? cellT : 0);
+      colors.push(frac);
+    }
+  }
+
+  // Build one mesh3d bar per cell using 8 vertices + 12 triangles.
+  const BAR_W = 0.8;  // fraction of unit grid spacing
+  const allVx = [], allVy = [], allVz = [], allI = [], allJ = [], allK = [];
+  const allColor = [];
+  let vOffset = 0;
+
+  for (let bi = 0; bi < xs.length; bi++) {
+    const cx = xs[bi], cy = ys[bi], h = zs[bi], c = colors[bi];
+    const x0 = cx - BAR_W / 2, x1 = cx + BAR_W / 2;
+    const y0 = cy - BAR_W / 2, y1 = cy + BAR_W / 2;
+    // 8 corners: bottom face then top face
+    allVx.push(x0, x1, x1, x0,  x0, x1, x1, x0);
+    allVy.push(y0, y0, y1, y1,  y0, y0, y1, y1);
+    allVz.push( 0,  0,  0,  0,   h,  h,  h,  h);
+    for (let v = 0; v < 8; v++) allColor.push(c);
+
+    // 12 triangles (6 faces × 2 triangles each), using local indices 0–7.
+    const tris = [
+      [0,1,2],[0,2,3],  // bottom
+      [4,6,5],[4,7,6],  // top
+      [0,4,5],[0,5,1],  // front
+      [2,6,7],[2,7,3],  // back
+      [1,5,6],[1,6,2],  // right
+      [0,3,7],[0,7,4],  // left
+    ];
+    for (const [a, b, c2] of tris) {
+      allI.push(vOffset + a);
+      allJ.push(vOffset + b);
+      allK.push(vOffset + c2);
+    }
+    vOffset += 8;
+  }
+
+  // Axis tick labels from combo labels.
+  const xTickText  = colCombos.map((cc, ci) =>
+    state.colDims.map(k => _dimLabel(desc, k, cc[k])).join('/'));
+  const yTickText  = rowCombos.map((rc, ri) =>
+    state.rowDims.map(k => _dimLabel(desc, k, rc[k])).join('/'));
+
+  // HSL colorscale matching the hue-wheel.
+  const plotlyScale = [
+    [0,    'hsl(0,90%,45%)'],
+    [0.25, 'hsl(30,90%,50%)'],
+    [0.5,  'hsl(60,90%,50%)'],
+    [0.75, 'hsl(120,70%,40%)'],
+    [1,    'hsl(220,80%,45%)'],
+  ];
+
+  const plotDiv = document.createElement('div');
+  plotDiv.style.cssText = 'width:100%;height:520px;';
+  container.appendChild(plotDiv);
+
+  Plotly.newPlot(plotDiv, [{
+    type: 'mesh3d',
+    x: allVx, y: allVy, z: allVz,
+    i: allI,  j: allJ,  k: allK,
+    intensity: allColor,
+    colorscale: plotlyScale,
+    cmin: 0, cmax: 1,
     showscale: false,
-    hovertemplate: 'sk=%{x}<br>sq=%{y}<br>TFLOPS=%{z:.2f}<extra></extra>',
+    flatshading: true,
+    lighting: { ambient: 0.9, diffuse: 0.3 },
   }], {
-    margin: { t: 0, b: 0, l: 0, r: 0 },
+    margin: { t: 20, b: 0, l: 0, r: 0 },
     scene: {
-      xaxis: { title: 'seqlen_k' },
-      yaxis: { title: 'seqlen_q' },
+      xaxis: {
+        title: state.colDims.join('/'),
+        tickvals: colCombos.map((_, i) => i),
+        ticktext: xTickText,
+        tickfont: { size: 9 },
+      },
+      yaxis: {
+        title: state.rowDims.join('/'),
+        tickvals: rowCombos.map((_, i) => i),
+        ticktext: yTickText,
+        tickfont: { size: 9 },
+      },
       zaxis: { title: 'TFLOPS' },
+      aspectmode: 'manual',
+      aspectratio: { x: Math.max(1, nCol * 0.4), y: Math.max(1, nRow * 0.4), z: 1 },
     },
   }, { responsive: true, displayModeBar: false });
 }
@@ -446,7 +525,7 @@ function _cellTflops(index, desc) {
 }
 
 // Overview table: rows = rowDims combos, cols = colDims combos.
-// Each cell shows max TFLOPS across seqlen_q×seqlen_k; click to drill in.
+// Each cell shows the representative TFLOPS value; click to drill in.
 function renderAutozoom(grid, layout, anchor) {
   const desc = state.descriptor;
   const { rowCombos, colCombos, seqQ, seqK, cells } = layout;
@@ -577,8 +656,8 @@ function renderGrid() {
     return;
   }
 
-  // Autozoom: overview or drilldown.
-  if (state.displayMode === 'autozoom') {
+  // Autozoom and 3D both use the autozoom data path (one value per cell).
+  if (state.displayMode === 'autozoom' || state.displayMode === '3d') {
     const dd = state.autozoom.drilldown;
     if (dd) {
       // Anchor from drilldown cell rows only.
@@ -621,7 +700,11 @@ function renderGrid() {
     } else {
       // Overview: anchor based on the same per-cell tflops values that will be displayed.
       const anchor = computeAnchorFromCells(layout.cells, state);
-      renderAutozoom(grid, layout, anchor);
+      if (state.displayMode === '3d') {
+        render3D(grid, layout, anchor);
+      } else {
+        renderAutozoom(grid, layout, anchor);
+      }
 
       const legend = document.createElement('div');
       legend.style.cssText = 'margin-top:8px;opacity:0.75;';
@@ -724,11 +807,7 @@ function renderGrid() {
       );
       if (matchingCell) {
         const { seqQ, seqK, index } = matchingCell;
-        if (state.displayMode === '3d') {
-          render3D(td, seqQ, seqK, index, state.descriptor, anchor);
-        } else {
-          renderHeatmap(td, seqQ, seqK, index, state.descriptor, anchor);
-        }
+        renderHeatmap(td, seqQ, seqK, index, state.descriptor, anchor);
       }
       tr.appendChild(td);
     }

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -39,6 +39,16 @@ function _hslComponents(fraction) {
   };
 }
 
+// Returns the ratio fp16_peak/dtype_peak for the given arch+dtype, so that
+// fp32 TFLOPS are scaled up before color mapping — penalizing them relative
+// to the machine's fp16 headroom. Returns 1 if peaks are unknown or equal.
+function dtypeScale(arch, dtype) {
+  if (!dtype || dtype === 'float16' || dtype === 'bfloat16') return 1;
+  const peak = THEORETICAL_PEAK_TFLOPS[arch];
+  if (!peak || !peak['float16'] || !peak[dtype] || peak[dtype] === 0) return 1;
+  return peak['float16'] / peak[dtype];
+}
+
 // Map a raw linear fraction [0,1] to a perceptual fraction using log scaling.
 // log(1 + k*x)/log(1+k) with k=9 maps 10% linear → ~53% perceptual,
 // spreading the color range across the lower-performance majority.
@@ -260,12 +270,13 @@ function renderHeatmap(container, seqQ, seqK, index, desc, anchor) {
       }
 
       const tflops = desc.tflops(row);
-      const frac   = perfFrac(tflops, anchor);
+      const scale  = dtypeScale(state.arch, row.dtype);
+      const frac   = perfFrac(tflops * scale, anchor);
       td.style.background = perfColor(frac);
       td.style.color      = cellTextColor(frac);
       td.style.cursor     = 'default';
 
-      const pct = Math.round(tflops / anchor * 100);
+      const pct = Math.round(tflops * scale / anchor * 100);
       td.innerHTML = `<div style="line-height:1.2">${tflops.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
 
       // Tooltip.
@@ -408,10 +419,12 @@ function renderAutozoom(grid, layout, anchor) {
       if (cell) {
         const maxT = _maxTflops(cell.index, desc);
         if (maxT > 0) {
-          const frac = perfFrac(maxT, anchor);
+          const dtype = colCombo.dtype || rowCombo.dtype;
+          const scale = dtypeScale(state.arch, dtype);
+          const frac = perfFrac(maxT * scale, anchor);
           td.style.background = perfColor(frac);
           td.style.color      = cellTextColor(frac);
-          const pct = Math.round(maxT / anchor * 100);
+          const pct = Math.round(maxT * scale / anchor * 100);
           td.innerHTML = `<div style="line-height:1.2">${maxT.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
           td.title = `Max TFLOPS: ${maxT.toFixed(2)}\nClick to view seqlen matrix`;
           td.addEventListener('click', () => {

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -206,18 +206,24 @@ function buildLayout(state) {
   const seqQ = axes.seqlen_q || [];
   const seqK = axes.seqlen_k || [];
 
+  // Single pass over filtered: bin each row by its (rowCombo, colCombo) key
+  // into a per-cell index. O(nRows) instead of O(nCells * nRows).
+  const _comboKey = (r, dims) => dims.map(k => r[k]).join('\x1f');
+  const cellMap = new Map();  // key -> Map<sq|sk, row>
+  for (const r of filtered) {
+    const key = _comboKey(r, state.rowDims) + '\x1e' + _comboKey(r, state.colDims);
+    let idx = cellMap.get(key);
+    if (!idx) { idx = new Map(); cellMap.set(key, idx); }
+    idx.set(`${r.seqlen_q}|${r.seqlen_k}`, r);
+  }
+
+  // Walk row × col in fixed order so cells[ri * nCol + ci] is addressable.
   const cells = [];
   for (const rowCombo of rowCombos) {
+    const rk = state.rowDims.map(k => rowCombo[k]).join('\x1f');
     for (const colCombo of colCombos) {
-      // Build index of (seqlen_q, seqlen_k) -> row for this combo.
-      const index = new Map();
-      for (const r of filtered) {
-        const matchRow = state.rowDims.every(k => r[k] === rowCombo[k]);
-        const matchCol = state.colDims.every(k => r[k] === colCombo[k]);
-        if (matchRow && matchCol) {
-          index.set(`${r.seqlen_q}|${r.seqlen_k}`, r);
-        }
-      }
+      const ck = state.colDims.map(k => colCombo[k]).join('\x1f');
+      const index = cellMap.get(rk + '\x1e' + ck) || new Map();
       cells.push({ rowCombo, colCombo, seqQ, seqK, index });
     }
   }
@@ -411,14 +417,13 @@ function render3D(container, layout, anchor) {
 
   // Collect (xi, yi, tflops, color) per cell.
   const xs = [], ys = [], zs = [], colors = [];
+  // cells[] is filled by buildLayout() in row-major order (rowCombos outer,
+  // colCombos inner), so direct indexing is O(1) per cell.
   for (let ri = 0; ri < nRow; ri++) {
     for (let ci = 0; ci < nCol; ci++) {
       const rowCombo = rowCombos[ri];
       const colCombo = colCombos[ci];
-      const cell = cells.find(c =>
-        state.rowDims.every(k => c.rowCombo[k] === rowCombo[k]) &&
-        state.colDims.every(k => c.colCombo[k] === colCombo[k])
-      );
+      const cell = cells[ri * nCol + ci];
       const cellT = cell ? _cellTflops(cell.index, desc) : 0;
       const dtype = colCombo.dtype || rowCombo.dtype;
       const a = anchorFor(anchor, dtype);

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -381,6 +381,18 @@ function renderAutozoom(grid, layout, anchor) {
   const table = document.createElement('table');
   table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
 
+  // Precompute separator positions (same logic as heatmap/3D grid).
+  const colSeps = state.colDims.map((dimKey) => {
+    const seps = new Set();
+    let prev = null;
+    colCombos.forEach((cc, ci) => {
+      if (ci > 0 && cc[dimKey] !== prev) seps.add(ci);
+      prev = cc[dimKey];
+    });
+    return seps;
+  });
+  const colNeedsSep = colCombos.map((_, ci) => colSeps.some(s => s.has(ci)));
+
   // Column header rows.
   for (let di = 0; di < numColDims; di++) {
     const tr = document.createElement('tr');
@@ -394,22 +406,22 @@ function renderAutozoom(grid, layout, anchor) {
     }
     const dimKey = state.colDims[di];
     const spans = [];
-    let curLabel = null, curCount = 0;
-    for (const cc of colCombos) {
+    let curLabel = null, curCount = 0, curStart = 0;
+    colCombos.forEach((cc, ci) => {
       const label = _dimLabel(desc, dimKey, cc[dimKey]);
       if (label !== curLabel) {
-        if (curCount) spans.push({ label: curLabel, count: curCount });
-        curLabel = label;
-        curCount = 0;
+        if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
+        curLabel = label; curCount = 0; curStart = ci;
       }
       curCount++;
-    }
-    if (curCount) spans.push({ label: curLabel, count: curCount });
-    for (const { label, count } of spans) {
+    });
+    if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
+    for (const { label, count, start } of spans) {
       const th = document.createElement('th');
       th.colSpan = count;
       th.textContent = `${dimKey}=${label}`;
-      th.style.cssText = 'text-align:center;border-bottom:1px solid currentColor;opacity:0.8;';
+      const sep = start > 0 ? 'border-left:2px solid currentColor;' : '';
+      th.style.cssText = `text-align:center;border-bottom:1px solid currentColor;opacity:0.8;${sep}`;
       tr.appendChild(th);
     }
     table.appendChild(tr);
@@ -425,9 +437,10 @@ function renderAutozoom(grid, layout, anchor) {
       tr.appendChild(th);
     }
 
-    for (const colCombo of colCombos) {
+    for (const [ci, colCombo] of colCombos.entries()) {
       const td = document.createElement('td');
-      td.style.cssText = 'padding:0;width:5rem;height:2.4rem;text-align:center;vertical-align:middle;cursor:pointer;';
+      const sep = colNeedsSep[ci] ? 'border-left:2px solid currentColor;' : '';
+      td.style.cssText = `padding:0;width:5rem;height:2.4rem;text-align:center;vertical-align:middle;cursor:pointer;${sep}`;
 
       const cell = cells.find(c =>
         state.rowDims.every(k => c.rowCombo[k] === rowCombo[k]) &&
@@ -548,6 +561,21 @@ function renderGrid() {
   const table = document.createElement('table');
   table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
 
+  // Precompute which colCombo indices start a new group for each dim level.
+  // colSeps[di] is a Set of colCombo indices where dim di's value changes.
+  const colSeps = state.colDims.map((dimKey, di) => {
+    const seps = new Set();
+    let prev = null;
+    layout.colCombos.forEach((cc, ci) => {
+      const val = cc[dimKey];
+      if (ci > 0 && val !== prev) seps.add(ci);
+      prev = val;
+    });
+    return seps;
+  });
+  // A column index needs a separator if ANY dim level starts a new group there.
+  const colNeedsSep = layout.colCombos.map((_, ci) => colSeps.some(s => s.has(ci)));
+
   // Header rows — one per colDim.
   for (let di = 0; di < numColDims; di++) {
     const tr = document.createElement('tr');
@@ -562,25 +590,26 @@ function renderGrid() {
     }
     // Compute spans for this dim level.
     const dimKey = state.colDims[di];
-    // Group consecutive colCombos by the shared prefix up to di.
     const spans = [];
-    let curLabel = null, curCount = 0;
-    for (const cc of layout.colCombos) {
+    let curLabel = null, curCount = 0, curStart = 0;
+    layout.colCombos.forEach((cc, ci) => {
       const label = _dimLabel(state.descriptor, dimKey, cc[dimKey]);
       if (label !== curLabel) {
-        if (curCount) spans.push({ label: curLabel, count: curCount });
+        if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
         curLabel = label;
         curCount = 0;
+        curStart = ci;
       }
       curCount++;
-    }
-    if (curCount) spans.push({ label: curLabel, count: curCount });
+    });
+    if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
 
-    for (const { label, count } of spans) {
+    for (const { label, count, start } of spans) {
       const th = document.createElement('th');
       th.colSpan = count;
       th.textContent = `${state.colDims[di]}=${label}`;
-      th.style.cssText = 'text-align:center;border-bottom:1px solid currentColor;opacity:0.8;';
+      const sep = start > 0 ? 'border-left:2px solid currentColor;' : '';
+      th.style.cssText = `text-align:center;border-bottom:1px solid currentColor;opacity:0.8;${sep}`;
       tr.appendChild(th);
     }
     table.appendChild(tr);
@@ -599,9 +628,10 @@ function renderGrid() {
     }
 
     // Matrix cells.
-    for (const colCombo of layout.colCombos) {
+    for (const [ci, colCombo] of layout.colCombos.entries()) {
       const td = document.createElement('td');
-      td.style.cssText = 'vertical-align:top;padding:2px;';
+      const sep = colNeedsSep[ci] ? 'border-left:2px solid currentColor;' : '';
+      td.style.cssText = `vertical-align:top;padding:2px;${sep}`;
 
       const matchingCell = layout.cells.find(c =>
         state.rowDims.every(k => c.rowCombo[k] === rowCombo[k]) &&

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -383,19 +383,7 @@ function renderAutozoom(grid, layout, anchor) {
   const table = document.createElement('table');
   table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
 
-  // Precompute separator positions (same logic as heatmap/3D grid).
-  const colSeps = state.colDims.map((dimKey) => {
-    const seps = new Set();
-    let prev = null;
-    colCombos.forEach((cc, ci) => {
-      if (ci > 0 && cc[dimKey] !== prev) seps.add(ci);
-      prev = cc[dimKey];
-    });
-    return seps;
-  });
-  const colNeedsSep = colCombos.map((_, ci) => colSeps.some(s => s.has(ci)));
-
-  // Column header rows.
+  // Column header rows — one <th> per colCombo, border-left when this dim's value changes.
   for (let di = 0; di < numColDims; di++) {
     const tr = document.createElement('tr');
     for (let ri = 0; ri < numRowDims; ri++) {
@@ -407,27 +395,14 @@ function renderAutozoom(grid, layout, anchor) {
       tr.appendChild(th);
     }
     const dimKey = state.colDims[di];
-    const spans = [];
-    let curLabel = null, curCount = 0, curStart = 0;
     colCombos.forEach((cc, ci) => {
-      const label = _dimLabel(desc, dimKey, cc[dimKey]);
-      // Break when this dim's value changes OR any ancestor dim changes.
-      const ancestorBreak = ci > 0 && colSeps.slice(0, di).some(s => s.has(ci));
-      if (label !== curLabel || ancestorBreak) {
-        if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
-        curLabel = label; curCount = 0; curStart = ci;
-      }
-      curCount++;
-    });
-    if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
-    for (const { label, count, start } of spans) {
       const th = document.createElement('th');
-      th.colSpan = count;
+      const label = _dimLabel(desc, dimKey, cc[dimKey]);
       th.textContent = `${dimKey}=${label}`;
-      const sep = start > 0 ? 'border-left:2px solid currentColor;' : '';
+      const sep = ci > 0 && cc[dimKey] !== colCombos[ci - 1][dimKey] ? 'border-left:2px solid currentColor;' : '';
       th.style.cssText = `text-align:center;border-bottom:1px solid currentColor;opacity:0.8;${sep}`;
       tr.appendChild(th);
-    }
+    });
     table.appendChild(tr);
   }
 
@@ -443,7 +418,8 @@ function renderAutozoom(grid, layout, anchor) {
 
     for (const [ci, colCombo] of colCombos.entries()) {
       const td = document.createElement('td');
-      const sep = colNeedsSep[ci] ? 'border-left:2px solid currentColor;' : '';
+      const sepNeeded = ci > 0 && state.colDims.some(k => colCombo[k] !== colCombos[ci - 1][k]);
+      const sep = sepNeeded ? 'border-left:2px solid currentColor;' : '';
       td.style.cssText = `padding:0;width:5rem;height:2.4rem;text-align:center;vertical-align:middle;cursor:pointer;${sep}`;
 
       const cell = cells.find(c =>
@@ -565,22 +541,7 @@ function renderGrid() {
   const table = document.createElement('table');
   table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
 
-  // Precompute which colCombo indices start a new group for each dim level.
-  // colSeps[di] is a Set of colCombo indices where dim di's value changes.
-  const colSeps = state.colDims.map((dimKey, di) => {
-    const seps = new Set();
-    let prev = null;
-    layout.colCombos.forEach((cc, ci) => {
-      const val = cc[dimKey];
-      if (ci > 0 && val !== prev) seps.add(ci);
-      prev = val;
-    });
-    return seps;
-  });
-  // A column index needs a separator if ANY dim level starts a new group there.
-  const colNeedsSep = layout.colCombos.map((_, ci) => colSeps.some(s => s.has(ci)));
-
-  // Header rows — one per colDim.
+  // Header rows — one <th> per colCombo, border-left when this dim's value changes.
   for (let di = 0; di < numColDims; di++) {
     const tr = document.createElement('tr');
     // Empty corner cells.
@@ -592,32 +553,15 @@ function renderGrid() {
       }
       tr.appendChild(th);
     }
-    // Compute spans for this dim level.
     const dimKey = state.colDims[di];
-    const spans = [];
-    let curLabel = null, curCount = 0, curStart = 0;
     layout.colCombos.forEach((cc, ci) => {
-      const label = _dimLabel(state.descriptor, dimKey, cc[dimKey]);
-      // Break when this dim's value changes OR any ancestor dim changes.
-      const ancestorBreak = ci > 0 && colSeps.slice(0, di).some(s => s.has(ci));
-      if (label !== curLabel || ancestorBreak) {
-        if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
-        curLabel = label;
-        curCount = 0;
-        curStart = ci;
-      }
-      curCount++;
-    });
-    if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
-
-    for (const { label, count, start } of spans) {
       const th = document.createElement('th');
-      th.colSpan = count;
-      th.textContent = `${state.colDims[di]}=${label}`;
-      const sep = start > 0 ? 'border-left:2px solid currentColor;' : '';
+      const label = _dimLabel(state.descriptor, dimKey, cc[dimKey]);
+      th.textContent = `${dimKey}=${label}`;
+      const sep = ci > 0 && cc[dimKey] !== layout.colCombos[ci - 1][dimKey] ? 'border-left:2px solid currentColor;' : '';
       th.style.cssText = `text-align:center;border-bottom:1px solid currentColor;opacity:0.8;${sep}`;
       tr.appendChild(th);
-    }
+    });
     table.appendChild(tr);
   }
 
@@ -636,7 +580,8 @@ function renderGrid() {
     // Matrix cells.
     for (const [ci, colCombo] of layout.colCombos.entries()) {
       const td = document.createElement('td');
-      const sep = colNeedsSep[ci] ? 'border-left:2px solid currentColor;' : '';
+      const sepNeeded = ci > 0 && state.colDims.some(k => colCombo[k] !== layout.colCombos[ci - 1][k]);
+      const sep = sepNeeded ? 'border-left:2px solid currentColor;' : '';
       td.style.cssText = `vertical-align:top;padding:2px;${sep}`;
 
       const matchingCell = layout.cells.find(c =>

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -409,7 +409,9 @@ function renderAutozoom(grid, layout, anchor) {
     let curLabel = null, curCount = 0, curStart = 0;
     colCombos.forEach((cc, ci) => {
       const label = _dimLabel(desc, dimKey, cc[dimKey]);
-      if (label !== curLabel) {
+      // Break when this dim's value changes OR any ancestor dim changes.
+      const ancestorBreak = ci > 0 && colSeps.slice(0, di).some(s => s.has(ci));
+      if (label !== curLabel || ancestorBreak) {
         if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
         curLabel = label; curCount = 0; curStart = ci;
       }
@@ -594,7 +596,9 @@ function renderGrid() {
     let curLabel = null, curCount = 0, curStart = 0;
     layout.colCombos.forEach((cc, ci) => {
       const label = _dimLabel(state.descriptor, dimKey, cc[dimKey]);
-      if (label !== curLabel) {
+      // Break when this dim's value changes OR any ancestor dim changes.
+      const ancestorBreak = ci > 0 && colSeps.slice(0, di).some(s => s.has(ci));
+      if (label !== curLabel || ancestorBreak) {
         if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
         curLabel = label;
         curCount = 0;

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -86,6 +86,8 @@ let state = {
     drilldown: null,   // {rowCombo, colCombo} or null for overview
     seqMode: 'max_load',  // 'max_load' = arch-specific sq=sk target; 'max_tflops' = max across all seqlens
   },
+  // Level-2 (psel/copt) drilldown — null when not active.
+  cellDetail: null,    // {rowCombo, colCombo, seqQ, seqK, row, data, loading}
   seqlenRange: [0, 65536],
   scale: {
     mode: 'max_observed',   // 'max_observed' | 'theoretical' | 'user'
@@ -113,6 +115,21 @@ async function fetchData(arch, kernel, mode) {
 
   // Annotate rows with the kernel name for the tflops() function.
   data.rows.forEach(r => { r._kernel = kernel; });
+  return data;
+}
+
+async function fetchCellDetail(row) {
+  const mode = state.descriptor && state.descriptor.ops &&
+               state.descriptor.ops.has(row._kernel) ? 'op' : 'kernel';
+  const params = new URLSearchParams({
+    task_id: row.task_id,
+    kernel:  row._kernel,
+    mode:    mode,
+  });
+  const resp = await fetch(`/api/perf/cell_detail?${params}`);
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  const data = await resp.json();
+  if (data.error) throw new Error(data.error);
   return data;
 }
 
@@ -330,15 +347,41 @@ function renderHeatmap(container, seqQ, seqK, index, desc, anchor) {
       const frac   = perfFrac(tflops, a);
       td.style.background = perfColor(frac);
       td.style.color      = cellTextColor(frac);
-      td.style.cursor     = 'default';
 
       const pct = Math.round(tflops / a * 100);
       td.innerHTML = `<div style="line-height:1.2">${tflops.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
+
+      // Level-2 click-through: psel × copt matrix for this (task_id, kernel).
+      const cd = desc.cellDetail;
+      const supportsL2 = cd && row.task_id != null
+                         && cd.kernels && cd.kernels[row._kernel];
+      if (supportsL2) {
+        td.style.cursor = 'pointer';
+        td.addEventListener('click', () => {
+          state.cellDetail = { row, loading: true, data: null };
+          renderGrid();
+          fetchCellDetail(row).then(data => {
+            // Bail if user navigated away in the meantime.
+            if (state.cellDetail && state.cellDetail.row === row) {
+              state.cellDetail = { row, loading: false, data };
+              renderGrid();
+            }
+          }).catch(err => {
+            if (state.cellDetail && state.cellDetail.row === row) {
+              state.cellDetail = { row, loading: false, data: null, error: String(err) };
+              renderGrid();
+            }
+          });
+        });
+      } else {
+        td.style.cursor = 'default';
+      }
 
       // Tooltip.
       if (desc.tooltip) {
         const lines = desc.tooltip(row);
         lines.unshift(`TFLOPS (matrix): ${tflops.toFixed(2)}`);
+        if (supportsL2) lines.push('Click to view psel × copt matrix');
         td.title = lines.join('\n');
       }
     });
@@ -654,6 +697,205 @@ function renderAutozoom(grid, layout, anchor) {
 // Grid rendering
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Rendering: level-2 (psel × copt) cell detail
+// ---------------------------------------------------------------------------
+
+// Build a stable column-vector key from a list of (field, value) pairs.
+function _vecKey(fields, src) {
+  return fields.map(f => `${f}=${src[f]}`).join('|');
+}
+
+function renderCellDetail(container, cd) {
+  const desc   = state.descriptor;
+  const schema = desc.cellDetail.kernels[cd.row._kernel];
+
+  const back = document.createElement('button');
+  back.textContent = '← Return to seqlen matrix';
+  back.style.cssText = 'margin-bottom:0.6rem;';
+  back.addEventListener('click', () => { state.cellDetail = null; renderGrid(); });
+  container.appendChild(back);
+
+  const title = document.createElement('div');
+  title.style.cssText = 'margin-bottom:0.4rem;font-weight:bold;';
+  title.textContent =
+    `${cd.row._kernel} @ sq=${cd.row.seqlen_q} sk=${cd.row.seqlen_k}, ` +
+    `hdim=${cd.row.hdim}, ${cd.row.dtype}, causal=${cd.row.causal ? 'T' : 'F'}, ` +
+    `task_id=${cd.row.task_id}`;
+  container.appendChild(title);
+
+  if (cd.loading) {
+    const p = document.createElement('p');
+    p.textContent = 'Loading psel × copt detail…';
+    container.appendChild(p);
+    return;
+  }
+  if (cd.error) {
+    const p = document.createElement('p');
+    p.style.color = 'red';
+    p.textContent = `Error: ${cd.error}`;
+    container.appendChild(p);
+    return;
+  }
+  if (!cd.data) return;
+
+  const cands = cd.data.candidates || [];
+  if (!cands.length) {
+    const p = document.createElement('p');
+    p.textContent = 'No candidate tuning_results rows for this cell.';
+    container.appendChild(p);
+    return;
+  }
+
+  // Build threshold lookup {tc: {tensor: abs_err}}.
+  const threshold = {};
+  for (const t of (cd.data.thresholds || [])) {
+    (threshold[t.test_case] = threshold[t.test_case] || {})[t.tensor] = t.absolute_error;
+  }
+
+  // Index by (psel-vector, copt-vector) → candidate.
+  const cellByKey = new Map();
+  const pselSet = new Map();   // key → ordered field values
+  const coptSet = new Map();
+  for (const cand of cands) {
+    const pkey = _vecKey(schema.psels, cand.psels);
+    const ckey = _vecKey(schema.copts, cand.copts);
+    if (!pselSet.has(pkey)) pselSet.set(pkey, schema.psels.map(f => cand.psels[f]));
+    if (!coptSet.has(ckey)) coptSet.set(ckey, schema.copts.map(f => cand.copts[f]));
+    cellByKey.set(`${pkey}||${ckey}`, cand);
+  }
+
+  // Lexicographic sort by field values.
+  const cmpVec = (a, b) => {
+    for (let i = 0; i < a.length; i++) {
+      const av = a[i], bv = b[i];
+      if (av === bv) continue;
+      if (av === undefined || av === null) return 1;
+      if (bv === undefined || bv === null) return -1;
+      if (av < bv) return -1;
+      if (av > bv) return 1;
+    }
+    return 0;
+  };
+  const psels = [...pselSet.entries()].sort((a, b) => cmpVec(a[1], b[1]));
+  const copts = [...coptSet.entries()].sort((a, b) => cmpVec(a[1], b[1]));
+
+  // Compute TFLOPS for each cell + max for anchor.
+  const cellInfo = new Map();
+  let maxT = 0;
+  for (const cand of cands) {
+    const t = desc.cellDetail.candidateTflops(cand, cd.row);
+    const pkey = _vecKey(schema.psels, cand.psels);
+    const ckey = _vecKey(schema.copts, cand.copts);
+    const passed = desc.passesAccuracy(cand, threshold);
+    cellInfo.set(`${pkey}||${ckey}`, { tflops: t, passed, cand });
+    if (t > maxT) maxT = t;
+  }
+  const anchor = maxT > 0 ? maxT : 1;
+
+  // Build table: rows = copts (Y), cols = psels (X).
+  const tbl = document.createElement('table');
+  tbl.style.cssText = 'border-collapse:collapse;font-size:0.8em;font-family:monospace;';
+
+  const thead = tbl.createTHead();
+  // One header row per psel field; each cell shows that field's value.
+  for (let li = 0; li < schema.psels.length; li++) {
+    const tr = thead.insertRow();
+    const lbl = document.createElement('th');
+    lbl.textContent = li === 0 ? `psel \\ copt` : '';
+    lbl.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.7;font-weight:normal;';
+    tr.appendChild(lbl);
+    // Skip the copt-label columns at the start (we use one column per copt field below).
+    for (let cj = 0; cj < schema.copts.length - 1; cj++) {
+      const pad = document.createElement('th');
+      tr.appendChild(pad);
+    }
+    const fieldName = document.createElement('th');
+    fieldName.textContent = schema.psels[li];
+    fieldName.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.8;font-weight:normal;';
+    tr.appendChild(fieldName);
+    for (const [, vec] of psels) {
+      const th = document.createElement('th');
+      th.textContent = String(vec[li]);
+      th.style.cssText = 'padding:2px 4px;text-align:center;opacity:0.8;font-weight:normal;white-space:nowrap;';
+      tr.appendChild(th);
+    }
+  }
+  // Header row with copt field names.
+  const tr0 = thead.insertRow();
+  const lbl0 = document.createElement('th');
+  lbl0.textContent = 'copt:';
+  lbl0.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.7;font-weight:normal;';
+  tr0.appendChild(lbl0);
+  for (const cf of schema.copts) {
+    const th = document.createElement('th');
+    th.textContent = cf;
+    th.style.cssText = 'padding:2px 4px;text-align:center;opacity:0.8;font-weight:normal;';
+    tr0.appendChild(th);
+  }
+  for (let i = 0; i < psels.length; i++) {
+    tr0.appendChild(document.createElement('th'));
+  }
+
+  const tbody = tbl.createTBody();
+  for (const [ckey, cvec] of copts) {
+    const tr = tbody.insertRow();
+    const lbl = document.createElement('th');
+    lbl.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.5;font-weight:normal;';
+    tr.appendChild(lbl);
+    for (const v of cvec) {
+      const th = document.createElement('th');
+      th.textContent = String(v);
+      th.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.8;font-weight:normal;white-space:nowrap;';
+      tr.appendChild(th);
+    }
+    for (const [pkey, pvec] of psels) {
+      const td = tr.insertCell();
+      td.style.cssText = 'padding:0;width:5rem;height:2.2rem;text-align:center;vertical-align:middle;position:relative;';
+      const info = cellInfo.get(`${pkey}||${ckey}`);
+      if (!info || !(info.tflops > 0)) {
+        td.style.background = 'rgba(128,128,128,0.15)';
+        td.title = info ? `index=${info.cand.index}, result=${info.cand.result}` : 'missing';
+        continue;
+      }
+      const frac = perfFrac(info.tflops, anchor);
+      td.style.background = perfColor(frac);
+      td.style.color      = cellTextColor(frac);
+      const pct = Math.round(info.tflops / anchor * 100);
+      let html = `<div style="line-height:1.2">${info.tflops.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
+      if (!info.passed) {
+        // SVG cross overlay; bright red so it shows on any background.
+        html += `<svg style="position:absolute;inset:0;width:100%;height:100%;pointer-events:none"
+                     viewBox="0 0 10 10" preserveAspectRatio="none">
+                  <line x1="0" y1="0" x2="10" y2="10" stroke="#e00" stroke-width="1.2"/>
+                  <line x1="10" y1="0" x2="0" y2="10" stroke="#e00" stroke-width="1.2"/>
+                </svg>`;
+      }
+      td.innerHTML = html;
+      const psStr = schema.psels.map((f, i) => `${f}=${pvec[i]}`).join(', ');
+      const coStr = schema.copts.map((f, i) => `${f}=${cvec[i]}`).join(', ');
+      td.title = [
+        `TFLOPS: ${info.tflops.toFixed(2)} (${pct}% of best)`,
+        `psels: ${psStr}`,
+        `copts: ${coStr}`,
+        `median_ms: ${info.cand.median_ms != null ? info.cand.median_ms.toFixed(4) : 'n/a'}`,
+        `index: ${info.cand.index}, result: ${info.cand.result}`,
+        info.passed ? 'accuracy: PASS' : 'accuracy: FAIL (✕)',
+      ].join('\n');
+    }
+  }
+
+  container.appendChild(tbl);
+
+  const legend = document.createElement('div');
+  legend.style.cssText = 'margin-top:8px;opacity:0.75;';
+  const nFail = [...cellInfo.values()].filter(c => !c.passed).length;
+  legend.textContent =
+    `${cellInfo.size} candidates, ${nFail} failed accuracy gate (✕). ` +
+    `Anchor: best in this cell = ${anchor.toFixed(1)} TFLOPS.`;
+  container.appendChild(legend);
+}
+
 function renderGrid() {
   const grid = document.getElementById('perf-grid');
   if (!grid) return;
@@ -661,6 +903,12 @@ function renderGrid() {
 
   if (!state.data || !state.descriptor) {
     grid.textContent = 'No data.';
+    return;
+  }
+
+  // Level-2 view supersedes everything else when active.
+  if (state.cellDetail) {
+    renderCellDetail(grid, state.cellDetail);
     return;
   }
 

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -894,6 +894,86 @@ function restoreFromURL() {
 }
 
 // ---------------------------------------------------------------------------
+// Single-page HTML export (autozoom only)
+// ---------------------------------------------------------------------------
+
+// Collect the col-dim filter: for each col dim, if it has an active single-
+// value filter (Set in state.filter), include that value; otherwise include
+// all values present in the data axes (empty list = "all allowed" on server).
+function _colDimFilters() {
+  const filters = {};
+  for (const k of state.colDims) {
+    const f = state.filter[k];
+    if (f instanceof Set) {
+      filters[k] = [...f].map(String);
+    } else {
+      filters[k] = [];  // empty = all values
+    }
+  }
+  return filters;
+}
+
+// Build the URL params object that the exported HTML should start with.
+function _exportURLParams() {
+  const p = {};
+  if (state.arch)    p.arch    = state.arch;
+  if (state.kernel)  p.kernel  = state.kernel;
+  if (state.descriptorId) p.module = state.descriptorId;
+  p.display  = 'autozoom';  // export only supports autozoom
+  p.az_mode  = state.autozoom.seqMode;
+  p.scale    = state.scale.mode;
+  if (state.scale.mode === 'user' && state.scale.userValue)
+    p.scale_value = String(state.scale.userValue);
+  if (state.colDims.length) p.col_dims = state.colDims.join(',');
+  if (state.rowDims.length) p.row_dims = state.rowDims.join(',');
+  for (const [k, v] of Object.entries(state.filter)) {
+    if (v instanceof Set) p[`f_${k}`] = [...v][0];
+  }
+  return p;
+}
+
+async function exportZip(statusEl) {
+  if (!state.data || !state.arch || !state.kernel) return;
+  if (statusEl) statusEl.textContent = 'Building export…';
+
+  const desc = state.descriptor;
+  const mode = (desc && desc.ops && desc.ops.has(state.kernel)) ? 'op' : 'kernel';
+
+  const body = {
+    arch:            state.arch,
+    kernel:          state.kernel,
+    mode,
+    col_dim_filters: _colDimFilters(),
+    url_params:      _exportURLParams(),
+  };
+
+  try {
+    const resp = await fetch('/api/perf/export_zip', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ error: resp.statusText }));
+      if (statusEl) statusEl.textContent = `Export failed: ${err.error || resp.statusText}`;
+      return;
+    }
+    const blob = await resp.blob();
+    const url  = URL.createObjectURL(blob);
+    const a    = document.createElement('a');
+    a.href = url;
+    a.download = `aotriton_perf_${state.arch}_${state.kernel}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    if (statusEl) statusEl.textContent = 'Export downloaded.';
+  } catch (err) {
+    if (statusEl) statusEl.textContent = `Export error: ${err.message}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Initialization and event wiring
 // ---------------------------------------------------------------------------
 
@@ -906,6 +986,7 @@ function initPerf() {
   const azModeSel  = document.getElementById('perf-az-mode');
   const azModeLabel = document.getElementById('perf-az-mode-label');
   const refreshBtn = document.getElementById('perf-refresh');
+  const exportBtn  = document.getElementById('perf-export');
   const status     = document.getElementById('perf-status');
 
   function _syncAzModeVisibility() {
@@ -975,6 +1056,7 @@ function initPerf() {
       renderGrid();
       pushURLState();
       if (status) status.textContent = `${state.data.rows.length} rows loaded.`;
+      if (exportBtn) { exportBtn.disabled = false; exportBtn.title = ''; }
       // Open the layout panel on first load so users discover it.
       const panel = document.getElementById('perf-layout-panel');
       if (panel && !panel.open) panel.open = true;
@@ -1117,6 +1199,7 @@ function initPerf() {
   }
 
   if (refreshBtn) refreshBtn.addEventListener('click', load);
+  if (exportBtn)  exportBtn.addEventListener('click', () => exportZip(status));
 
   if (scaleSel) {
     scaleSel.addEventListener('change', () => {

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -15,6 +15,26 @@ const THEORETICAL_PEAK_TFLOPS = {
 const DESCRIPTORS = {};
 function registerDescriptor(desc) { DESCRIPTORS[desc.id] = desc; }
 
+// Populate the Kernel/Op <select> from a descriptor's kernels/opsList.
+// Empties existing options first so re-population is idempotent.
+function populateKernelSelect(selectEl, desc) {
+  if (!selectEl || !desc) return;
+  while (selectEl.firstChild) selectEl.removeChild(selectEl.firstChild);
+  const _grp = (label, names) => {
+    if (!names || !names.length) return;
+    const og = document.createElement('optgroup');
+    og.label = label;
+    for (const n of names) {
+      const opt = document.createElement('option');
+      opt.value = opt.textContent = n;
+      og.appendChild(opt);
+    }
+    selectEl.appendChild(og);
+  };
+  _grp('Kernels', desc.kernels);
+  _grp('Ops',     desc.opsList);
+}
+
 // ---------------------------------------------------------------------------
 // Color utilities
 // ---------------------------------------------------------------------------
@@ -1259,6 +1279,11 @@ function initPerf() {
   // Apply URL params to selectors before load().
   let saved = restoreFromURL();
   if (saved.module) state.descriptorId = saved.module;
+  // Populate the Kernel/Op dropdown from the active descriptor so adding
+  // new kernels/descriptors does not require editing the template.
+  const _activeDesc = DESCRIPTORS[state.descriptorId]
+                   || DESCRIPTORS[Object.keys(DESCRIPTORS)[0]];
+  populateKernelSelect(kernelSel, _activeDesc);
   if (saved.arch   && archSel)   archSel.value   = saved.arch;
   if (saved.kernel && kernelSel) kernelSel.value = saved.kernel;
   if (saved.display && dispSel) {

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -65,7 +65,8 @@ let state = {
   // filter: per-dim allowed value sets for grid dims (col/row).
   // null = all values shown. A Set means only those values are shown.
   filter: {},
-  displayMode: 'heatmap',   // 'heatmap' | '3d'
+  displayMode: 'heatmap',   // 'heatmap' | '3d' | 'autozoom'
+  autozoom: { drilldown: null },  // drilldown = {rowCombo, colCombo} or null for overview
   seqlenRange: [0, 65536],
   scale: {
     mode: 'max_observed',   // 'max_observed' | 'theoretical' | 'user'
@@ -310,6 +311,113 @@ function render3D(container, seqQ, seqK, index, desc, anchor) {
 }
 
 // ---------------------------------------------------------------------------
+// Autozoom rendering
+// ---------------------------------------------------------------------------
+
+// Returns the max TFLOPS across all seqlen_q×seqlen_k entries in the index.
+function _maxTflops(index, desc) {
+  let max = 0;
+  for (const row of index.values()) {
+    if (row && row.median_ms > 0) {
+      const t = desc.tflops(row);
+      if (t > max) max = t;
+    }
+  }
+  return max;
+}
+
+// Overview table: rows = rowDims combos, cols = colDims combos.
+// Each cell shows max TFLOPS across seqlen_q×seqlen_k; click to drill in.
+function renderAutozoom(grid, layout, anchor) {
+  const desc = state.descriptor;
+  const { rowCombos, colCombos, seqQ, seqK, cells } = layout;
+  const numRowDims = state.rowDims.length;
+  const numColDims = state.colDims.length;
+
+  const table = document.createElement('table');
+  table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
+
+  // Column header rows.
+  for (let di = 0; di < numColDims; di++) {
+    const tr = document.createElement('tr');
+    for (let ri = 0; ri < numRowDims; ri++) {
+      const th = document.createElement('th');
+      if (di === 0 && ri === numRowDims - 1) {
+        th.textContent = 'features →';
+        th.style.cssText = 'text-align:right;opacity:0.7;';
+      }
+      tr.appendChild(th);
+    }
+    const dimKey = state.colDims[di];
+    const spans = [];
+    let curLabel = null, curCount = 0;
+    for (const cc of colCombos) {
+      const label = _dimLabel(desc, dimKey, cc[dimKey]);
+      if (label !== curLabel) {
+        if (curCount) spans.push({ label: curLabel, count: curCount });
+        curLabel = label;
+        curCount = 0;
+      }
+      curCount++;
+    }
+    if (curCount) spans.push({ label: curLabel, count: curCount });
+    for (const { label, count } of spans) {
+      const th = document.createElement('th');
+      th.colSpan = count;
+      th.textContent = `${dimKey}=${label}`;
+      th.style.cssText = 'text-align:center;border-bottom:1px solid currentColor;opacity:0.8;';
+      tr.appendChild(th);
+    }
+    table.appendChild(tr);
+  }
+
+  // Data rows.
+  for (const rowCombo of rowCombos) {
+    const tr = document.createElement('tr');
+    for (const rk of state.rowDims) {
+      const th = document.createElement('th');
+      th.textContent = `${rk}=${_dimLabel(desc, rk, rowCombo[rk])}`;
+      th.style.cssText = 'text-align:right;white-space:nowrap;padding-right:6px;';
+      tr.appendChild(th);
+    }
+
+    for (const colCombo of colCombos) {
+      const td = document.createElement('td');
+      td.style.cssText = 'padding:0;width:5rem;height:2.4rem;text-align:center;vertical-align:middle;cursor:pointer;';
+
+      const cell = cells.find(c =>
+        state.rowDims.every(k => c.rowCombo[k] === rowCombo[k]) &&
+        state.colDims.every(k => c.colCombo[k] === colCombo[k])
+      );
+
+      if (cell) {
+        const maxT = _maxTflops(cell.index, desc);
+        if (maxT > 0) {
+          const frac = Math.min(1, maxT / anchor);
+          td.style.background = perfColor(frac);
+          td.style.color      = cellTextColor(frac);
+          const pct = Math.round(frac * 100);
+          td.innerHTML = `<div style="line-height:1.2">${maxT.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
+          td.title = `Max TFLOPS: ${maxT.toFixed(2)}\nClick to view seqlen matrix`;
+          td.addEventListener('click', () => {
+            state.autozoom.drilldown = { rowCombo, colCombo };
+            renderGrid();
+          });
+        } else {
+          td.style.background = 'rgba(128,128,128,0.15)';
+        }
+      } else {
+        td.style.background = 'rgba(128,128,128,0.15)';
+      }
+      tr.appendChild(td);
+    }
+    table.appendChild(tr);
+  }
+
+  grid.appendChild(table);
+}
+
+// ---------------------------------------------------------------------------
 // Grid rendering
 // ---------------------------------------------------------------------------
 
@@ -327,6 +435,50 @@ function renderGrid() {
   const layout = buildLayout(state);
   if (!layout.cells || !layout.cells.length) {
     grid.textContent = 'No matching data for current filters.';
+    return;
+  }
+
+  // Autozoom: overview or drilldown.
+  if (state.displayMode === 'autozoom') {
+    const dd = state.autozoom.drilldown;
+    if (dd) {
+      // Drilldown: show full heatmap for one cell + return button.
+      const returnBtn = document.createElement('button');
+      returnBtn.textContent = '← Return to overview';
+      returnBtn.style.cssText = 'margin-bottom:0.6rem;';
+      returnBtn.addEventListener('click', () => {
+        state.autozoom.drilldown = null;
+        renderGrid();
+      });
+      grid.appendChild(returnBtn);
+
+      // Title.
+      const title = document.createElement('div');
+      const label = [
+        ...state.rowDims.map(k => `${k}=${_dimLabel(state.descriptor, k, dd.rowCombo[k])}`),
+        ...state.colDims.map(k => `${k}=${_dimLabel(state.descriptor, k, dd.colCombo[k])}`),
+      ].join(', ');
+      title.style.cssText = 'margin-bottom:0.4rem;font-weight:bold;';
+      title.textContent = label;
+      grid.appendChild(title);
+
+      const cell = layout.cells.find(c =>
+        state.rowDims.every(k => c.rowCombo[k] === dd.rowCombo[k]) &&
+        state.colDims.every(k => c.colCombo[k] === dd.colCombo[k])
+      );
+      if (cell) {
+        const container = document.createElement('div');
+        renderHeatmap(container, cell.seqQ, cell.seqK, cell.index, state.descriptor, anchor);
+        grid.appendChild(container);
+      }
+    } else {
+      renderAutozoom(grid, layout, anchor);
+    }
+
+    const legend = document.createElement('div');
+    legend.style.cssText = 'margin-top:8px;opacity:0.75;';
+    legend.textContent = `Scale anchor: ${anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
+    grid.appendChild(legend);
     return;
   }
 
@@ -467,6 +619,7 @@ function initPerf() {
         state.rowDims = [...state.descriptor.defaultRowDims];
         state.fixed   = { ...state.descriptor.defaultFixed };
         state.filter  = {};   // clear all value filters on fresh load
+        state.autozoom.drilldown = null;
       }
       updateDimPanel();
       renderGrid();
@@ -673,6 +826,7 @@ function initPerf() {
   if (dispSel) {
     dispSel.addEventListener('change', () => {
       state.displayMode = dispSel.value;
+      state.autozoom.drilldown = null;
       renderGrid();
     });
   }

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -188,8 +188,8 @@ function buildLayout(state) {
 // Scale anchor computation
 // ---------------------------------------------------------------------------
 
-function computeAnchor(data, state) {
-  if (!data) return 1;
+// visibleRows: the rows actually rendered in the current view (caller's responsibility).
+function computeAnchor(visibleRows, state) {
   const desc = state.descriptor;
   if (!desc) return 1;
 
@@ -198,15 +198,16 @@ function computeAnchor(data, state) {
   }
   if (state.scale.mode === 'theoretical') {
     const arch = state.arch;
-    const dtype = state.fixed.dtype || (data.axes.dtype && data.axes.dtype[0]) || 'float16';
+    const dtype = state.fixed.dtype
+      || (state.data && state.data.axes.dtype && state.data.axes.dtype[0])
+      || 'float16';
     const peak = THEORETICAL_PEAK_TFLOPS[arch];
     if (peak && peak[dtype]) return peak[dtype];
     // Fall through to max_observed if not found.
   }
-  // max_observed: max TFLOPS across all currently displayed rows.
-  const filtered = applyFixed(data.rows, state.fixed, state.filter);
+  // max_observed: max TFLOPS across the rows currently visible.
   let maxT = 0;
-  for (const r of filtered) {
+  for (const r of visibleRows) {
     if (r.median_ms > 0) {
       const t = desc.tflops(r);
       if (t > maxT) maxT = t;
@@ -445,7 +446,6 @@ function renderGrid() {
     return;
   }
 
-  const anchor = computeAnchor(state.data, state);
   const layout = buildLayout(state);
   if (!layout.cells || !layout.cells.length) {
     grid.textContent = 'No matching data for current filters.';
@@ -456,6 +456,14 @@ function renderGrid() {
   if (state.displayMode === 'autozoom') {
     const dd = state.autozoom.drilldown;
     if (dd) {
+      // Anchor from drilldown cell rows only.
+      const cell = layout.cells.find(c =>
+        state.rowDims.every(k => c.rowCombo[k] === dd.rowCombo[k]) &&
+        state.colDims.every(k => c.colCombo[k] === dd.colCombo[k])
+      );
+      const visibleRows = cell ? [...cell.index.values()].filter(Boolean) : [];
+      const anchor = computeAnchor(visibleRows, state);
+
       // Drilldown: show full heatmap for one cell + return button.
       const returnBtn = document.createElement('button');
       returnBtn.textContent = '← Return to overview';
@@ -466,7 +474,6 @@ function renderGrid() {
       });
       grid.appendChild(returnBtn);
 
-      // Title.
       const title = document.createElement('div');
       const label = [
         ...state.rowDims.map(k => `${k}=${_dimLabel(state.descriptor, k, dd.rowCombo[k])}`),
@@ -476,25 +483,33 @@ function renderGrid() {
       title.textContent = label;
       grid.appendChild(title);
 
-      const cell = layout.cells.find(c =>
-        state.rowDims.every(k => c.rowCombo[k] === dd.rowCombo[k]) &&
-        state.colDims.every(k => c.colCombo[k] === dd.colCombo[k])
-      );
       if (cell) {
         const container = document.createElement('div');
         renderHeatmap(container, cell.seqQ, cell.seqK, cell.index, state.descriptor, anchor);
         grid.appendChild(container);
       }
-    } else {
-      renderAutozoom(grid, layout, anchor);
-    }
 
-    const legend = document.createElement('div');
-    legend.style.cssText = 'margin-top:8px;opacity:0.75;';
-    legend.textContent = `Scale anchor: ${anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
-    grid.appendChild(legend);
+      const legend = document.createElement('div');
+      legend.style.cssText = 'margin-top:8px;opacity:0.75;';
+      legend.textContent = `Scale anchor: ${anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
+      grid.appendChild(legend);
+    } else {
+      // Overview: anchor from all visible rows.
+      const allVisible = layout.cells.flatMap(c => [...c.index.values()].filter(Boolean));
+      const anchor = computeAnchor(allVisible, state);
+      renderAutozoom(grid, layout, anchor);
+
+      const legend = document.createElement('div');
+      legend.style.cssText = 'margin-top:8px;opacity:0.75;';
+      legend.textContent = `Scale anchor: ${anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
+      grid.appendChild(legend);
+    }
     return;
   }
+
+  // Heatmap / 3D: anchor from all visible rows.
+  const visibleRows = layout.cells.flatMap(c => [...c.index.values()].filter(Boolean));
+  const anchor = computeAnchor(visibleRows, state);
 
   // Build column-header rows.
   const numRowDims = state.rowDims.length;

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -39,15 +39,6 @@ function _hslComponents(fraction) {
   };
 }
 
-// Returns the ratio fp16_peak/dtype_peak for the given arch+dtype, so that
-// fp32 TFLOPS are scaled up before color mapping — penalizing them relative
-// to the machine's fp16 headroom. Returns 1 if peaks are unknown or equal.
-function dtypeScale(arch, dtype) {
-  if (!dtype || dtype === 'float16' || dtype === 'bfloat16') return 1;
-  const peak = THEORETICAL_PEAK_TFLOPS[arch];
-  if (!peak || !peak['float16'] || !peak[dtype] || peak[dtype] === 0) return 1;
-  return peak['float16'] / peak[dtype];
-}
 
 // Map a raw linear fraction [0,1] to a perceptual fraction using log scaling.
 // log(1 + k*x)/log(1+k) with k=9 maps 10% linear → ~53% perceptual,
@@ -215,15 +206,24 @@ function computeAnchor(visibleRows, state) {
     if (peak && peak[dtype]) return peak[dtype];
     // Fall through to max_observed if not found.
   }
-  // max_observed: max TFLOPS across the rows currently visible.
-  let maxT = 0;
+  // max_observed: per-dtype max TFLOPS across the rows currently visible.
+  // Returns a Map<dtype, number> so each dtype is normalized to its own peak.
+  const byDtype = new Map();
   for (const r of visibleRows) {
     if (r.median_ms > 0) {
       const t = desc.tflops(r);
-      if (t > maxT) maxT = t;
+      const d = r.dtype || '';
+      if (!byDtype.has(d) || t > byDtype.get(d)) byDtype.set(d, t);
     }
   }
-  return maxT || 1;
+  return byDtype.size ? byDtype : new Map([['', 1]]);
+}
+
+// Pick the anchor value for a given dtype from computeAnchor's return value.
+// When anchor is a Map (max_observed), look up by dtype; otherwise use directly.
+function anchorFor(anchor, dtype) {
+  if (!(anchor instanceof Map)) return anchor;
+  return anchor.get(dtype) || anchor.get('') || [...anchor.values()][0] || 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -270,13 +270,13 @@ function renderHeatmap(container, seqQ, seqK, index, desc, anchor) {
       }
 
       const tflops = desc.tflops(row);
-      const scale  = dtypeScale(state.arch, row.dtype);
-      const frac   = perfFrac(tflops * scale, anchor);
+      const a      = anchorFor(anchor, row.dtype);
+      const frac   = perfFrac(tflops, a);
       td.style.background = perfColor(frac);
       td.style.color      = cellTextColor(frac);
       td.style.cursor     = 'default';
 
-      const pct = Math.round(tflops * scale / anchor * 100);
+      const pct = Math.round(tflops / a * 100);
       td.innerHTML = `<div style="line-height:1.2">${tflops.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
 
       // Tooltip.
@@ -420,11 +420,11 @@ function renderAutozoom(grid, layout, anchor) {
         const maxT = _maxTflops(cell.index, desc);
         if (maxT > 0) {
           const dtype = colCombo.dtype || rowCombo.dtype;
-          const scale = dtypeScale(state.arch, dtype);
-          const frac = perfFrac(maxT * scale, anchor);
+          const a    = anchorFor(anchor, dtype);
+          const frac = perfFrac(maxT, a);
           td.style.background = perfColor(frac);
           td.style.color      = cellTextColor(frac);
-          const pct = Math.round(maxT * scale / anchor * 100);
+          const pct = Math.round(maxT / a * 100);
           td.innerHTML = `<div style="line-height:1.2">${maxT.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
           td.title = `Max TFLOPS: ${maxT.toFixed(2)}\nClick to view seqlen matrix`;
           td.addEventListener('click', () => {
@@ -504,7 +504,7 @@ function renderGrid() {
 
       const legend = document.createElement('div');
       legend.style.cssText = 'margin-top:8px;opacity:0.75;';
-      legend.textContent = `Scale anchor: ${anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
+      legend.textContent = `Scale anchor: ${anchor instanceof Map ? [...anchor.entries()].map(([d,v])=>`${d}:${v.toFixed(1)}`).join(", ") : anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
       grid.appendChild(legend);
     } else {
       // Overview: anchor from all visible rows.
@@ -514,7 +514,7 @@ function renderGrid() {
 
       const legend = document.createElement('div');
       legend.style.cssText = 'margin-top:8px;opacity:0.75;';
-      legend.textContent = `Scale anchor: ${anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
+      legend.textContent = `Scale anchor: ${anchor instanceof Map ? [...anchor.entries()].map(([d,v])=>`${d}:${v.toFixed(1)}`).join(", ") : anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
       grid.appendChild(legend);
     }
     return;
@@ -607,7 +607,7 @@ function renderGrid() {
   // Scale legend.
   const legend = document.createElement('div');
   legend.style.cssText = 'margin-top:8px;opacity:0.75;';
-  legend.textContent = `Scale anchor: ${anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
+  legend.textContent = `Scale anchor: ${anchor instanceof Map ? [...anchor.entries()].map(([d,v])=>`${d}:${v.toFixed(1)}`).join(", ") : anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
   grid.appendChild(legend);
 }
 

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -205,84 +205,63 @@ function computeAnchor(data, state) {
 // ---------------------------------------------------------------------------
 
 function renderHeatmap(container, seqQ, seqK, index, desc, anchor) {
-  const cellW = 72, cellH = 36, headerH = 24, headerW = 56;
-  const width  = headerW + seqK.length * cellW;
-  const height = headerH + seqQ.length * cellH;
+  const tbl = document.createElement('table');
+  tbl.style.cssText = 'border-collapse:collapse;font-size:0.8em;font-family:monospace;';
 
-  const canvas = document.createElement('canvas');
-  canvas.width  = width;
-  canvas.height = height;
-  canvas.style.display = 'block';
-  const ctx = canvas.getContext('2d');
-  ctx.font = '13px monospace';
-  // Use the page's current text color for axis labels (theme-aware).
-  const labelColor = getComputedStyle(document.body).color || '#888';
-
-  // Column headers (seqlen_k)
-  ctx.fillStyle = labelColor;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-  seqK.forEach((k, ci) => {
-    ctx.fillText(k, headerW + ci * cellW + cellW / 2, headerH / 2);
+  // Header row: empty corner + one th per seqlen_k value.
+  const thead = tbl.createTHead();
+  const hrow = thead.insertRow();
+  const corner = document.createElement('th');
+  corner.style.cssText = 'padding:2px 6px;opacity:0.5;font-weight:normal;';
+  corner.textContent = 'sq \\ sk';
+  hrow.appendChild(corner);
+  seqK.forEach(k => {
+    const th = document.createElement('th');
+    th.style.cssText = 'padding:2px 4px;text-align:center;opacity:0.7;font-weight:normal;white-space:nowrap;';
+    th.textContent = k;
+    hrow.appendChild(th);
   });
 
-  // Row headers (seqlen_q) + cells
-  seqQ.forEach((q, ri) => {
-    const y = headerH + ri * cellH;
-    ctx.fillStyle = labelColor;
-    ctx.textAlign = 'right';
-    ctx.fillText(q, headerW - 4, y + cellH / 2);
+  // Data rows: one per seqlen_q.
+  const tbody = tbl.createTBody();
+  seqQ.forEach(q => {
+    const tr = tbody.insertRow();
 
-    seqK.forEach((k, ci) => {
-      const x = headerW + ci * cellW;
+    // Row header.
+    const th = document.createElement('th');
+    th.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.7;font-weight:normal;white-space:nowrap;';
+    th.textContent = q;
+    tr.appendChild(th);
+
+    seqK.forEach(k => {
+      const td = tr.insertCell();
+      td.style.cssText = 'padding:0;width:4.5rem;height:2.2rem;text-align:center;vertical-align:middle;';
+
       const row = index.get(`${q}|${k}`);
       if (!row || !(row.median_ms > 0)) {
-        ctx.fillStyle = 'rgba(128,128,128,0.15)';
-        ctx.fillRect(x, y, cellW - 1, cellH - 1);
+        td.style.background = 'rgba(128,128,128,0.15)';
         return;
       }
+
       const tflops = desc.tflops(row);
-      const frac = Math.min(1, tflops / anchor);
-      ctx.fillStyle = perfColor(frac);
-      ctx.fillRect(x, y, cellW - 1, cellH - 1);
+      const frac   = Math.min(1, tflops / anchor);
+      td.style.background = perfColor(frac);
+      td.style.color      = cellTextColor(frac);
+      td.style.cursor     = 'default';
 
       const pct = Math.round(frac * 100);
-      ctx.fillStyle = cellTextColor(frac);
-      ctx.textAlign = 'center';
-      ctx.fillText(tflops.toFixed(1), x + cellW / 2, y + cellH * 0.33);
-      ctx.fillText(`${pct}%`,          x + cellW / 2, y + cellH * 0.67);
+      td.innerHTML = `<div style="line-height:1.2">${tflops.toFixed(1)}<br><span style="opacity:0.8">${pct}%</span></div>`;
+
+      // Tooltip.
+      if (desc.tooltip) {
+        const lines = desc.tooltip(row);
+        lines.unshift(`TFLOPS (matrix): ${tflops.toFixed(2)}`);
+        td.title = lines.join('\n');
+      }
     });
   });
 
-  // Tooltip via title on a transparent overlay div.
-  const wrap = document.createElement('div');
-  wrap.style.cssText = 'position:relative;display:inline-block;';
-  const overlay = document.createElement('canvas');
-  overlay.width  = width;
-  overlay.height = height;
-  overlay.style.cssText = `position:absolute;top:0;left:0;cursor:crosshair;`;
-  overlay.addEventListener('mousemove', e => {
-    const rect = overlay.getBoundingClientRect();
-    const mx = e.clientX - rect.left;
-    const my = e.clientY - rect.top;
-    const ci = Math.floor((mx - headerW) / cellW);
-    const ri = Math.floor((my - headerH) / cellH);
-    if (ci < 0 || ri < 0 || ci >= seqK.length || ri >= seqQ.length) {
-      overlay.title = '';
-      return;
-    }
-    const q = seqQ[ri], k = seqK[ci];
-    const row = index.get(`${q}|${k}`);
-    if (!row) { overlay.title = 'no data'; return; }
-    const tflops = desc.tflops(row);
-    const lines = desc.tooltip ? desc.tooltip(row) : [];
-    lines.unshift(`TFLOPS (matrix): ${tflops.toFixed(2)}`);
-    overlay.title = lines.join('\n');
-  });
-
-  wrap.appendChild(canvas);
-  wrap.appendChild(overlay);
-  container.appendChild(wrap);
+  container.appendChild(tbl);
 }
 
 // ---------------------------------------------------------------------------

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -390,8 +390,19 @@ function render3D(container, layout, anchor) {
   // Build one mesh3d bar per cell using 8 vertices + 12 triangles.
   const BAR_W = 0.8;  // fraction of unit grid spacing
   const allVx = [], allVy = [], allVz = [], allI = [], allJ = [], allK = [];
-  const allColor = [];
+  const allColor = [], allCustom = [];
   let vOffset = 0;
+
+  // Pre-build per-cell hover label: all feature dims + TFLOPS.
+  function _cellHoverLabel(bi) {
+    const ri = Math.floor(bi / nCol), ci = bi % nCol;
+    const rowCombo = rowCombos[ri], colCombo = colCombos[ci];
+    const parts = [];
+    for (const k of state.rowDims) parts.push(`${k}=${_dimLabel(desc, k, rowCombo[k])}`);
+    for (const k of state.colDims) parts.push(`${k}=${_dimLabel(desc, k, colCombo[k])}`);
+    parts.push(`TFLOPS=${zs[bi].toFixed(1)}`);
+    return parts.join('<br>');
+  }
 
   for (let bi = 0; bi < xs.length; bi++) {
     const cx = xs[bi], cy = ys[bi], h = zs[bi], c = colors[bi];
@@ -401,7 +412,8 @@ function render3D(container, layout, anchor) {
     allVx.push(x0, x1, x1, x0,  x0, x1, x1, x0);
     allVy.push(y0, y0, y1, y1,  y0, y0, y1, y1);
     allVz.push( 0,  0,  0,  0,   h,  h,  h,  h);
-    for (let v = 0; v < 8; v++) allColor.push(c);
+    const label = _cellHoverLabel(bi);
+    for (let v = 0; v < 8; v++) { allColor.push(c); allCustom.push(label); }
 
     // 12 triangles (6 faces × 2 triangles each), using local indices 0–7.
     const tris = [
@@ -449,6 +461,8 @@ function render3D(container, layout, anchor) {
     showscale: false,
     flatshading: true,
     lighting: { ambient: 0.9, diffuse: 0.3 },
+    customdata: allCustom,
+    hovertemplate: '%{customdata}<extra></extra>',
   }], {
     margin: { t: 20, b: 0, l: 0, r: 0 },
     scene: {

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -112,6 +112,7 @@ async function fetchData(arch, kernel, mode) {
   const resp = await fetch(`/api/perf/data?${params}`);
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   const data = await resp.json();
+  if (data.error) throw new Error(data.error);
 
   // Annotate rows with the kernel name for the tflops() function.
   data.rows.forEach(r => { r._kernel = kernel; });

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -364,7 +364,7 @@ function renderGrid() {
     for (let ri = 0; ri < numRowDims; ri++) {
       const th = document.createElement('th');
       if (di === 0 && ri === numRowDims - 1) {
-        th.textContent = state.colDims.join(' / ') + ' →';
+        th.textContent = 'features →';
         th.style.cssText = 'text-align:right;opacity:0.7;';
       }
       tr.appendChild(th);

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -1,0 +1,638 @@
+// Copyright © 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Theoretical peak matrix TFLOPS (dense, no sparsity).
+// Source: AMD datasheets and third-party benchmarks (see visperf_rev1.md).
+const THEORETICAL_PEAK_TFLOPS = {
+  gfx942:  { float16: 1307.4, bfloat16: 1307.4, float32: 163.4 },
+  gfx950:  { float16: 2880,   bfloat16: 2880,   float32: 157   },
+  gfx90a:  { float16: 383.0,  bfloat16: 383.0,  float32: 95.7  },
+  gfx1100: { float16: 90.4,   bfloat16: 90.4,   float32: 45.2  },
+  gfx1201: { float16: 191,    bfloat16: 191,     float32: 47.8  },
+};
+
+// Descriptor registry — populated by vis_descriptors/*.js files loaded before this script.
+const DESCRIPTORS = {};
+function registerDescriptor(desc) { DESCRIPTORS[desc.id] = desc; }
+
+// ---------------------------------------------------------------------------
+// Color utilities
+// ---------------------------------------------------------------------------
+
+const _HUE_STOPS = [0,   30,  60,  120, 220];
+const _SAT_STOPS = [90,  90,  90,  70,  80];
+const _LIT_STOPS = [45,  50,  50,  40,  45];
+
+function _interpStops(stops, t) {
+  const i = Math.min(Math.floor(t), stops.length - 2);
+  const f = t - i;
+  return stops[i] + f * (stops[i + 1] - stops[i]);
+}
+
+// Returns {h, s, l} for a fraction in [0,1].
+function _hslComponents(fraction) {
+  const t = Math.max(0, Math.min(1, fraction)) * (_HUE_STOPS.length - 1);
+  return {
+    h: _interpStops(_HUE_STOPS, t),
+    s: _interpStops(_SAT_STOPS, t),
+    l: _interpStops(_LIT_STOPS, t),
+  };
+}
+
+// Background color for a performance fraction.
+function perfColor(fraction) {
+  const { h, s, l } = _hslComponents(fraction);
+  return `hsl(${h.toFixed(1)},${s.toFixed(1)}%,${l.toFixed(1)}%)`;
+}
+
+// Text color (black or white) for readability on the given performance fraction background.
+// Uses WCAG luminance approximation: lightness > 0.35 → black text.
+function cellTextColor(fraction) {
+  const { l } = _hslComponents(fraction);
+  return (l / 100) > 0.35 ? '#111' : '#fff';
+}
+
+// ---------------------------------------------------------------------------
+// Application state
+// ---------------------------------------------------------------------------
+
+let state = {
+  descriptor: null,
+  data: null,           // raw API response {arch, kernel, axes, rows}
+  colDims: [],
+  rowDims: [],
+  fixed: {},
+  displayMode: 'heatmap',   // 'heatmap' | '3d'
+  seqlenRange: [0, 65536],
+  scale: {
+    mode: 'max_observed',   // 'max_observed' | 'theoretical' | 'user'
+    userValue: null,
+  },
+  arch: '',
+  kernel: '',
+};
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+
+async function fetchData(arch, kernel, mode) {
+  const params = new URLSearchParams({
+    arch,
+    kernel,
+    mode: mode || 'kernel',
+    seqlen_min: state.seqlenRange[0],
+    seqlen_max: state.seqlenRange[1],
+  });
+  const resp = await fetch(`/api/perf/data?${params}`);
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  const data = await resp.json();
+
+  // Annotate rows with the kernel name for the tflops() function.
+  data.rows.forEach(r => { r._kernel = kernel; });
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Layout builder
+// ---------------------------------------------------------------------------
+
+// Returns the Cartesian product of arrays.
+function cartesian(arrays) {
+  if (!arrays.length) return [[]];
+  const [head, ...tail] = arrays;
+  const rest = cartesian(tail);
+  return head.flatMap(v => rest.map(t => [v, ...t]));
+}
+
+// Enumerate distinct dim-value tuples present in rows (for a given set of dim keys).
+function distinctCombos(rows, dimKeys) {
+  const seen = new Set();
+  const result = [];
+  for (const r of rows) {
+    const key = dimKeys.map(k => r[k]).join('|');
+    if (!seen.has(key)) {
+      seen.add(key);
+      const obj = {};
+      dimKeys.forEach(k => { obj[k] = r[k]; });
+      result.push(obj);
+    }
+  }
+  return result;
+}
+
+// Apply fixed filters to rows.
+function applyFixed(rows, fixed) {
+  return rows.filter(r => Object.entries(fixed).every(([k, v]) => r[k] === v));
+}
+
+// Build nested layout: array of {rowCombo, colCombo, matrix} objects.
+function buildLayout(state) {
+  if (!state.data) return [];
+  const { rows, axes } = state.data;
+
+  const filtered = applyFixed(rows, state.fixed);
+
+  const rowCombos = distinctCombos(filtered, state.rowDims);
+  const colCombos = distinctCombos(filtered, state.colDims);
+  const seqQ = axes.seqlen_q || [];
+  const seqK = axes.seqlen_k || [];
+
+  const cells = [];
+  for (const rowCombo of rowCombos) {
+    for (const colCombo of colCombos) {
+      // Build index of (seqlen_q, seqlen_k) -> row for this combo.
+      const index = new Map();
+      for (const r of filtered) {
+        const matchRow = state.rowDims.every(k => r[k] === rowCombo[k]);
+        const matchCol = state.colDims.every(k => r[k] === colCombo[k]);
+        if (matchRow && matchCol) {
+          index.set(`${r.seqlen_q}|${r.seqlen_k}`, r);
+        }
+      }
+      cells.push({ rowCombo, colCombo, seqQ, seqK, index });
+    }
+  }
+  return { rowCombos, colCombos, seqQ, seqK, cells };
+}
+
+// ---------------------------------------------------------------------------
+// Scale anchor computation
+// ---------------------------------------------------------------------------
+
+function computeAnchor(data, state) {
+  if (!data) return 1;
+  const desc = state.descriptor;
+  if (!desc) return 1;
+
+  if (state.scale.mode === 'user' && state.scale.userValue > 0) {
+    return state.scale.userValue;
+  }
+  if (state.scale.mode === 'theoretical') {
+    const arch = state.arch;
+    const dtype = state.fixed.dtype || (data.axes.dtype && data.axes.dtype[0]) || 'float16';
+    const peak = THEORETICAL_PEAK_TFLOPS[arch];
+    if (peak && peak[dtype]) return peak[dtype];
+    // Fall through to max_observed if not found.
+  }
+  // max_observed: max TFLOPS across all currently displayed rows.
+  const filtered = applyFixed(data.rows, state.fixed);
+  let maxT = 0;
+  for (const r of filtered) {
+    if (r.median_ms > 0) {
+      const t = desc.tflops(r);
+      if (t > maxT) maxT = t;
+    }
+  }
+  return maxT || 1;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering: heatmap
+// ---------------------------------------------------------------------------
+
+function renderHeatmap(container, seqQ, seqK, index, desc, anchor) {
+  const cellW = 72, cellH = 36, headerH = 24, headerW = 56;
+  const width  = headerW + seqK.length * cellW;
+  const height = headerH + seqQ.length * cellH;
+
+  const canvas = document.createElement('canvas');
+  canvas.width  = width;
+  canvas.height = height;
+  canvas.style.display = 'block';
+  const ctx = canvas.getContext('2d');
+  ctx.font = '13px monospace';
+  // Use the page's current text color for axis labels (theme-aware).
+  const labelColor = getComputedStyle(document.body).color || '#888';
+
+  // Column headers (seqlen_k)
+  ctx.fillStyle = labelColor;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  seqK.forEach((k, ci) => {
+    ctx.fillText(k, headerW + ci * cellW + cellW / 2, headerH / 2);
+  });
+
+  // Row headers (seqlen_q) + cells
+  seqQ.forEach((q, ri) => {
+    const y = headerH + ri * cellH;
+    ctx.fillStyle = labelColor;
+    ctx.textAlign = 'right';
+    ctx.fillText(q, headerW - 4, y + cellH / 2);
+
+    seqK.forEach((k, ci) => {
+      const x = headerW + ci * cellW;
+      const row = index.get(`${q}|${k}`);
+      if (!row || !(row.median_ms > 0)) {
+        ctx.fillStyle = 'rgba(128,128,128,0.15)';
+        ctx.fillRect(x, y, cellW - 1, cellH - 1);
+        return;
+      }
+      const tflops = desc.tflops(row);
+      const frac = Math.min(1, tflops / anchor);
+      ctx.fillStyle = perfColor(frac);
+      ctx.fillRect(x, y, cellW - 1, cellH - 1);
+
+      const pct = Math.round(frac * 100);
+      ctx.fillStyle = cellTextColor(frac);
+      ctx.textAlign = 'center';
+      ctx.fillText(tflops.toFixed(1), x + cellW / 2, y + cellH * 0.33);
+      ctx.fillText(`${pct}%`,          x + cellW / 2, y + cellH * 0.67);
+    });
+  });
+
+  // Tooltip via title on a transparent overlay div.
+  const wrap = document.createElement('div');
+  wrap.style.cssText = 'position:relative;display:inline-block;';
+  const overlay = document.createElement('canvas');
+  overlay.width  = width;
+  overlay.height = height;
+  overlay.style.cssText = `position:absolute;top:0;left:0;cursor:crosshair;`;
+  overlay.addEventListener('mousemove', e => {
+    const rect = overlay.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    const ci = Math.floor((mx - headerW) / cellW);
+    const ri = Math.floor((my - headerH) / cellH);
+    if (ci < 0 || ri < 0 || ci >= seqK.length || ri >= seqQ.length) {
+      overlay.title = '';
+      return;
+    }
+    const q = seqQ[ri], k = seqK[ci];
+    const row = index.get(`${q}|${k}`);
+    if (!row) { overlay.title = 'no data'; return; }
+    const tflops = desc.tflops(row);
+    const lines = desc.tooltip ? desc.tooltip(row) : [];
+    lines.unshift(`TFLOPS (matrix): ${tflops.toFixed(2)}`);
+    overlay.title = lines.join('\n');
+  });
+
+  wrap.appendChild(canvas);
+  wrap.appendChild(overlay);
+  container.appendChild(wrap);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering: 3-D bars via Plotly
+// ---------------------------------------------------------------------------
+
+function render3D(container, seqQ, seqK, index, desc, anchor) {
+  if (typeof Plotly === 'undefined') {
+    container.textContent = 'Plotly.js not loaded — 3D view unavailable.';
+    return;
+  }
+  const z = seqQ.map(q =>
+    seqK.map(k => {
+      const row = index.get(`${q}|${k}`);
+      return (row && row.median_ms > 0) ? desc.tflops(row) : null;
+    })
+  );
+  const div = document.createElement('div');
+  div.style.cssText = 'width:320px;height:280px;';
+  container.appendChild(div);
+
+  Plotly.newPlot(div, [{
+    type: 'surface',
+    x: seqK,
+    y: seqQ,
+    z,
+    colorscale: [
+      [0,    'hsl(0,90%,45%)'],
+      [0.25, 'hsl(30,90%,50%)'],
+      [0.5,  'hsl(60,90%,50%)'],
+      [0.75, 'hsl(120,70%,40%)'],
+      [1,    'hsl(220,80%,45%)'],
+    ],
+    cmin: 0,
+    cmax: anchor,
+    showscale: false,
+    hovertemplate: 'sk=%{x}<br>sq=%{y}<br>TFLOPS=%{z:.2f}<extra></extra>',
+  }], {
+    margin: { t: 0, b: 0, l: 0, r: 0 },
+    scene: {
+      xaxis: { title: 'seqlen_k' },
+      yaxis: { title: 'seqlen_q' },
+      zaxis: { title: 'TFLOPS' },
+    },
+  }, { responsive: true, displayModeBar: false });
+}
+
+// ---------------------------------------------------------------------------
+// Grid rendering
+// ---------------------------------------------------------------------------
+
+function renderGrid() {
+  const grid = document.getElementById('perf-grid');
+  if (!grid) return;
+  grid.innerHTML = '';
+
+  if (!state.data || !state.descriptor) {
+    grid.textContent = 'No data.';
+    return;
+  }
+
+  const anchor = computeAnchor(state.data, state);
+  const layout = buildLayout(state);
+  if (!layout.cells || !layout.cells.length) {
+    grid.textContent = 'No matching data for current filters.';
+    return;
+  }
+
+  // Build column-header rows.
+  const numRowDims = state.rowDims.length;
+  const numColDims = state.colDims.length;
+  const table = document.createElement('table');
+  table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
+
+  // Header rows — one per colDim.
+  for (let di = 0; di < numColDims; di++) {
+    const tr = document.createElement('tr');
+    // Empty corner cells.
+    for (let ri = 0; ri < numRowDims; ri++) {
+      const th = document.createElement('th');
+      if (di === 0 && ri === numRowDims - 1) {
+        th.textContent = state.colDims.join(' / ') + ' →';
+        th.style.cssText = 'text-align:right;opacity:0.7;';
+      }
+      tr.appendChild(th);
+    }
+    // Compute spans for this dim level.
+    const dimKey = state.colDims[di];
+    // Group consecutive colCombos by the shared prefix up to di.
+    const spans = [];
+    let curLabel = null, curCount = 0;
+    for (const cc of layout.colCombos) {
+      const label = _dimLabel(state.descriptor, dimKey, cc[dimKey]);
+      if (label !== curLabel) {
+        if (curCount) spans.push({ label: curLabel, count: curCount });
+        curLabel = label;
+        curCount = 0;
+      }
+      curCount++;
+    }
+    if (curCount) spans.push({ label: curLabel, count: curCount });
+
+    for (const { label, count } of spans) {
+      const th = document.createElement('th');
+      th.colSpan = count;
+      th.textContent = `${state.colDims[di]}=${label}`;
+      th.style.cssText = 'text-align:center;border-bottom:1px solid currentColor;opacity:0.8;';
+      tr.appendChild(th);
+    }
+    table.appendChild(tr);
+  }
+
+  // Data rows — one per rowCombo, with a cell per colCombo.
+  for (const rowCombo of layout.rowCombos) {
+    const tr = document.createElement('tr');
+
+    // Row header cells.
+    for (const rk of state.rowDims) {
+      const th = document.createElement('th');
+      th.textContent = `${rk}=${_dimLabel(state.descriptor, rk, rowCombo[rk])}`;
+      th.style.cssText = 'text-align:right;white-space:nowrap;padding-right:6px;';
+      tr.appendChild(th);
+    }
+
+    // Matrix cells.
+    for (const colCombo of layout.colCombos) {
+      const td = document.createElement('td');
+      td.style.cssText = 'vertical-align:top;padding:2px;';
+
+      const matchingCell = layout.cells.find(c =>
+        state.rowDims.every(k => c.rowCombo[k] === rowCombo[k]) &&
+        state.colDims.every(k => c.colCombo[k] === colCombo[k])
+      );
+      if (matchingCell) {
+        const { seqQ, seqK, index } = matchingCell;
+        if (state.displayMode === '3d') {
+          render3D(td, seqQ, seqK, index, state.descriptor, anchor);
+        } else {
+          renderHeatmap(td, seqQ, seqK, index, state.descriptor, anchor);
+        }
+      }
+      tr.appendChild(td);
+    }
+    table.appendChild(tr);
+  }
+
+  grid.appendChild(table);
+
+  // Scale legend.
+  const legend = document.createElement('div');
+  legend.style.cssText = 'margin-top:8px;opacity:0.75;';
+  legend.textContent = `Scale anchor: ${anchor.toFixed(1)} TFLOPS (${state.scale.mode})`;
+  grid.appendChild(legend);
+}
+
+// ---------------------------------------------------------------------------
+// Dimension label helper
+// ---------------------------------------------------------------------------
+
+function _dimLabel(desc, key, value) {
+  if (!desc) return String(value);
+  const dim = desc.dims.find(d => d.key === key);
+  if (!dim) return String(value);
+  if (dim.valueLabels) {
+    const idx = dim.values.indexOf(value);
+    if (idx >= 0 && dim.valueLabels[idx] !== undefined) return dim.valueLabels[idx];
+  }
+  return String(value);
+}
+
+// ---------------------------------------------------------------------------
+// Initialization and event wiring
+// ---------------------------------------------------------------------------
+
+function initPerf() {
+  const archSel    = document.getElementById('perf-arch');
+  const kernelSel  = document.getElementById('perf-kernel');
+  const modeSel    = document.getElementById('perf-mode');
+  const scaleSel   = document.getElementById('perf-scale');
+  const scaleInput = document.getElementById('perf-scale-value');
+  const dispSel    = document.getElementById('perf-display');
+  const refreshBtn = document.getElementById('perf-refresh');
+  const status     = document.getElementById('perf-status');
+
+  async function load() {
+    if (!archSel || !kernelSel) return;
+    const arch   = archSel.value;
+    const kernel = kernelSel.value;
+    const mode   = modeSel ? modeSel.value : 'kernel';
+    if (!arch || !kernel) return;
+
+    state.arch = arch;
+    state.kernel = kernel;
+    if (status) status.textContent = 'Loading…';
+
+    try {
+      state.data = await fetchData(arch, kernel, mode);
+      // Pick descriptor by kernel family — currently always flash.
+      state.descriptor = DESCRIPTORS['flash'];
+      if (state.descriptor) {
+        state.colDims = [...state.descriptor.defaultColDims];
+        state.rowDims = [...state.descriptor.defaultRowDims];
+        state.fixed   = { ...state.descriptor.defaultFixed };
+      }
+      updateDimPanel();
+      renderGrid();
+      if (status) status.textContent = `${state.data.rows.length} rows loaded.`;
+      // Open the layout panel on first load so users discover it.
+      const panel = document.getElementById('perf-layout-panel');
+      if (panel && !panel.open) panel.open = true;
+    } catch (err) {
+      if (status) status.textContent = `Error: ${err.message}`;
+    }
+  }
+
+  // ---- Dimension layout panel ------------------------------------------------
+
+  // Move dim to a new role (and optionally a position within that role's list).
+  function moveDim(key, toRole, beforeKey) {
+    // Remove from current role list.
+    state.colDims = state.colDims.filter(k => k !== key);
+    state.rowDims = state.rowDims.filter(k => k !== key);
+    // Also clear fixed value when moving into col/row.
+    if (toRole === 'fixed') {
+      if (state.fixed[key] === undefined) {
+        const vals = state.data && state.data.axes[key];
+        state.fixed[key] = vals && vals.length ? vals[0] : null;
+      }
+    } else {
+      delete state.fixed[key];
+    }
+    // Insert into target list.
+    const targetList = toRole === 'col' ? state.colDims : toRole === 'row' ? state.rowDims : null;
+    if (targetList !== null) {
+      const idx = beforeKey ? targetList.indexOf(beforeKey) : -1;
+      if (idx >= 0) targetList.splice(idx, 0, key);
+      else targetList.push(key);
+    }
+  }
+
+  function buildDimChip(key) {
+    const chip = document.createElement('span');
+    chip.className = 'dim-chip';
+    chip.draggable = true;
+    chip.dataset.dim = key;
+    chip.textContent = key;
+    chip.addEventListener('dragstart', e => {
+      e.dataTransfer.setData('text/plain', key);
+      e.dataTransfer.effectAllowed = 'move';
+      chip.classList.add('dragging');
+    });
+    chip.addEventListener('dragend', () => chip.classList.remove('dragging'));
+    return chip;
+  }
+
+  function buildFixedSelect(key) {
+    const vals = (state.data && state.data.axes[key]) || [];
+    const wrap = document.createElement('span');
+    wrap.style.cssText = 'display:inline-flex;align-items:center;gap:0.3rem;margin:0.15rem;';
+    const lbl = document.createElement('span');
+    lbl.textContent = key + ':';
+    const sel = document.createElement('select');
+    vals.forEach(v => {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = _dimLabel(state.descriptor, key, v);
+      if (state.fixed[key] !== undefined && String(state.fixed[key]) === String(v)) opt.selected = true;
+      sel.appendChild(opt);
+    });
+    sel.addEventListener('change', () => {
+      const raw = sel.value;
+      state.fixed[key] = isNaN(Number(raw)) ? raw : Number(raw);
+      renderGrid();
+    });
+    wrap.appendChild(lbl);
+    wrap.appendChild(sel);
+    return wrap;
+  }
+
+  function wireDropTarget(zone) {
+    zone.addEventListener('dragover', e => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      zone.classList.add('drag-over');
+    });
+    zone.addEventListener('dragleave', () => zone.classList.remove('drag-over'));
+    zone.addEventListener('drop', e => {
+      e.preventDefault();
+      zone.classList.remove('drag-over');
+      const key = e.dataTransfer.getData('text/plain');
+      if (!key) return;
+      const role = zone.dataset.role;
+      // Detect drop before a sibling chip.
+      const siblings = [...zone.querySelectorAll('[data-dim]')];
+      let beforeKey = null;
+      for (const sib of siblings) {
+        const r = sib.getBoundingClientRect();
+        if (e.clientX < r.left + r.width / 2) { beforeKey = sib.dataset.dim; break; }
+      }
+      moveDim(key, role, beforeKey);
+      updateDimPanel();
+      renderGrid();
+    });
+  }
+
+  function updateDimPanel() {
+    if (!state.descriptor || !state.data) return;
+    const allDims = state.descriptor.dims.map(d => d.key)
+                       .filter(k => (state.data.axes[k] || []).length > 1 ||
+                                    state.colDims.includes(k) || state.rowDims.includes(k));
+
+    const colZone   = document.getElementById('perf-col-dims');
+    const rowZone   = document.getElementById('perf-row-dims');
+    const fixedZone = document.getElementById('perf-fixed-filters');
+    if (!colZone || !rowZone || !fixedZone) return;
+
+    colZone.innerHTML   = '';
+    rowZone.innerHTML   = '';
+    fixedZone.innerHTML = '';
+
+    // Render chips in order for col/row zones; fixed zone gets selects.
+    for (const key of state.colDims) {
+      if (allDims.includes(key)) colZone.appendChild(buildDimChip(key));
+    }
+    for (const key of state.rowDims) {
+      if (allDims.includes(key)) rowZone.appendChild(buildDimChip(key));
+    }
+    for (const key of allDims) {
+      if (!state.colDims.includes(key) && !state.rowDims.includes(key)) {
+        fixedZone.appendChild(buildFixedSelect(key));
+      }
+    }
+
+    // Wire drop targets once per rebuild (they are fresh DOM nodes).
+    [colZone, rowZone, fixedZone].forEach(wireDropTarget);
+  }
+
+  if (refreshBtn) refreshBtn.addEventListener('click', load);
+
+  if (scaleSel) {
+    scaleSel.addEventListener('change', () => {
+      state.scale.mode = scaleSel.value;
+      if (scaleInput) scaleInput.style.display = scaleSel.value === 'user' ? 'inline' : 'none';
+      renderGrid();
+    });
+  }
+  if (scaleInput) {
+    scaleInput.addEventListener('change', () => {
+      state.scale.userValue = parseFloat(scaleInput.value) || null;
+      renderGrid();
+    });
+  }
+  if (dispSel) {
+    dispSel.addEventListener('change', () => {
+      state.displayMode = dispSel.value;
+      renderGrid();
+    });
+  }
+
+  // Auto-load on first visit if arch+kernel already selected.
+  if (archSel && archSel.value && kernelSel && kernelSel.value) {
+    load();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initPerf);

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -933,16 +933,10 @@ function _exportURLParams() {
 }
 
 async function exportZip(statusEl) {
-  if (!state.data || !state.arch || !state.kernel) return;
-  if (statusEl) statusEl.textContent = 'Building export…';
-
-  const desc = state.descriptor;
-  const mode = (desc && desc.ops && desc.ops.has(state.kernel)) ? 'op' : 'kernel';
+  if (!state.data) return;
+  if (statusEl) statusEl.textContent = 'Building export (all arches/kernels)…';
 
   const body = {
-    arch:            state.arch,
-    kernel:          state.kernel,
-    mode,
     col_dim_filters: _colDimFilters(),
     url_params:      _exportURLParams(),
   };
@@ -962,7 +956,7 @@ async function exportZip(statusEl) {
     const url  = URL.createObjectURL(blob);
     const a    = document.createElement('a');
     a.href = url;
-    a.download = `aotriton_perf_${state.arch}_${state.kernel}.zip`;
+    a.download = 'aotriton_perf.zip';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -62,6 +62,9 @@ let state = {
   colDims: [],
   rowDims: [],
   fixed: {},
+  // filter: per-dim allowed value sets for grid dims (col/row).
+  // null = all values shown. A Set means only those values are shown.
+  filter: {},
   displayMode: 'heatmap',   // 'heatmap' | '3d'
   seqlenRange: [0, 65536],
   scale: {
@@ -121,9 +124,19 @@ function distinctCombos(rows, dimKeys) {
   return result;
 }
 
-// Apply fixed filters to rows.
-function applyFixed(rows, fixed) {
-  return rows.filter(r => Object.entries(fixed).every(([k, v]) => r[k] === v));
+// Apply fixed filters and per-dim value filters to rows.
+function applyFixed(rows, fixed, filter) {
+  return rows.filter(r => {
+    for (const [k, v] of Object.entries(fixed)) {
+      if (r[k] !== v) return false;
+    }
+    if (filter) {
+      for (const [k, allowed] of Object.entries(filter)) {
+        if (allowed !== null && !allowed.has(String(r[k]))) return false;
+      }
+    }
+    return true;
+  });
 }
 
 // Build nested layout: array of {rowCombo, colCombo, matrix} objects.
@@ -131,7 +144,7 @@ function buildLayout(state) {
   if (!state.data) return [];
   const { rows, axes } = state.data;
 
-  const filtered = applyFixed(rows, state.fixed);
+  const filtered = applyFixed(rows, state.fixed, state.filter);
 
   const rowCombos = distinctCombos(filtered, state.rowDims);
   const colCombos = distinctCombos(filtered, state.colDims);
@@ -176,7 +189,7 @@ function computeAnchor(data, state) {
     // Fall through to max_observed if not found.
   }
   // max_observed: max TFLOPS across all currently displayed rows.
-  const filtered = applyFixed(data.rows, state.fixed);
+  const filtered = applyFixed(data.rows, state.fixed, state.filter);
   let maxT = 0;
   for (const r of filtered) {
     if (r.median_ms > 0) {
@@ -473,6 +486,7 @@ function initPerf() {
         state.colDims = [...state.descriptor.defaultColDims];
         state.rowDims = [...state.descriptor.defaultRowDims];
         state.fixed   = { ...state.descriptor.defaultFixed };
+        state.filter  = {};   // clear all value filters on fresh load
       }
       updateDimPanel();
       renderGrid();
@@ -498,8 +512,10 @@ function initPerf() {
         const vals = state.data && state.data.axes[key];
         state.fixed[key] = vals && vals.length ? vals[0] : null;
       }
+      delete state.filter[key];   // fixed select takes over; no grid filter needed
     } else {
       delete state.fixed[key];
+      // Preserve any existing filter[key] when moving back to col/row.
     }
     // Insert into target list.
     const targetList = toRole === 'col' ? state.colDims : toRole === 'row' ? state.rowDims : null;
@@ -511,17 +527,69 @@ function initPerf() {
   }
 
   function buildDimChip(key) {
+    const vals = (state.data && state.data.axes[key]) || [];
+    const isChecked = !state.filter[key];   // null = all shown = checked
+
     const chip = document.createElement('span');
     chip.className = 'dim-chip';
-    chip.draggable = true;
     chip.dataset.dim = key;
-    chip.textContent = key;
-    chip.addEventListener('dragstart', e => {
+
+    // Checkbox toggles whether this dim is fully expanded or value-filtered.
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = isChecked;
+    cb.title = 'Uncheck to filter values shown in the grid';
+    cb.addEventListener('change', e => {
+      e.stopPropagation();   // don't trigger drag
+      if (cb.checked) {
+        state.filter[key] = null;    // all values
+        sel.style.display = 'none';
+      } else {
+        // Default: keep currently selected options, or all if none chosen yet.
+        const chosen = [...sel.options].filter(o => o.selected).map(o => o.value);
+        state.filter[key] = new Set(chosen.length ? chosen : vals.map(String));
+        sel.style.display = '';
+      }
+      renderGrid();
+    });
+
+    // Label (not draggable-sensitive).
+    const lbl = document.createElement('span');
+    lbl.textContent = key;
+
+    // Multi-select for value filtering — shown only when unchecked.
+    const sel = document.createElement('select');
+    sel.multiple = true;
+    sel.size = Math.min(vals.length, 4);
+    sel.style.cssText = 'margin-left:0.3rem;' + (isChecked ? 'display:none;' : '');
+    vals.forEach(v => {
+      const opt = document.createElement('option');
+      opt.value = String(v);
+      opt.textContent = _dimLabel(state.descriptor, key, v);
+      // Pre-select values currently in the filter set (or all if filter is null).
+      opt.selected = !state.filter[key] || state.filter[key].has(String(v));
+      sel.appendChild(opt);
+    });
+    sel.addEventListener('change', e => {
+      e.stopPropagation();
+      const chosen = [...sel.options].filter(o => o.selected).map(o => o.value);
+      state.filter[key] = chosen.length ? new Set(chosen) : null;
+      renderGrid();
+    });
+
+    // Make chip draggable only from the label, not from controls.
+    lbl.draggable = true;
+    lbl.style.cursor = 'grab';
+    lbl.addEventListener('dragstart', e => {
       e.dataTransfer.setData('text/plain', key);
       e.dataTransfer.effectAllowed = 'move';
       chip.classList.add('dragging');
     });
     chip.addEventListener('dragend', () => chip.classList.remove('dragging'));
+
+    chip.appendChild(cb);
+    chip.appendChild(lbl);
+    chip.appendChild(sel);
     return chip;
   }
 

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -534,20 +534,39 @@ function initPerf() {
     chip.className = 'dim-chip';
     chip.dataset.dim = key;
 
-    // Checkbox toggles whether this dim is fully expanded or value-filtered.
+    // Dropdown for value filtering — shown only when unchecked.
+    // Built before the checkbox so the checkbox handler can reference it.
+    const sel = document.createElement('select');
+    sel.style.cssText = 'margin-left:0.3rem;' + (isChecked ? 'display:none;' : '');
+    // Pick the currently filtered value, or the first value as default.
+    const currentVal = state.filter[key]
+      ? [...state.filter[key]][0]
+      : (vals.length ? String(vals[0]) : '');
+    vals.forEach(v => {
+      const opt = document.createElement('option');
+      opt.value = String(v);
+      opt.textContent = _dimLabel(state.descriptor, key, v);
+      opt.selected = String(v) === currentVal;
+      sel.appendChild(opt);
+    });
+    sel.addEventListener('change', e => {
+      e.stopPropagation();
+      state.filter[key] = new Set([sel.value]);
+      renderGrid();
+    });
+
+    // Checkbox toggles between "all values" and "single value from dropdown".
     const cb = document.createElement('input');
     cb.type = 'checkbox';
     cb.checked = isChecked;
-    cb.title = 'Uncheck to filter values shown in the grid';
+    cb.title = 'Uncheck to filter to a single value';
     cb.addEventListener('change', e => {
-      e.stopPropagation();   // don't trigger drag
+      e.stopPropagation();
       if (cb.checked) {
-        state.filter[key] = null;    // all values
+        state.filter[key] = null;
         sel.style.display = 'none';
       } else {
-        // Default: keep currently selected options, or all if none chosen yet.
-        const chosen = [...sel.options].filter(o => o.selected).map(o => o.value);
-        state.filter[key] = new Set(chosen.length ? chosen : vals.map(String));
+        state.filter[key] = new Set([sel.value || currentVal]);
         sel.style.display = '';
       }
       renderGrid();
@@ -556,26 +575,6 @@ function initPerf() {
     // Label (not draggable-sensitive).
     const lbl = document.createElement('span');
     lbl.textContent = key;
-
-    // Multi-select for value filtering — shown only when unchecked.
-    const sel = document.createElement('select');
-    sel.multiple = true;
-    sel.size = Math.min(vals.length, 4);
-    sel.style.cssText = 'margin-left:0.3rem;' + (isChecked ? 'display:none;' : '');
-    vals.forEach(v => {
-      const opt = document.createElement('option');
-      opt.value = String(v);
-      opt.textContent = _dimLabel(state.descriptor, key, v);
-      // Pre-select values currently in the filter set (or all if filter is null).
-      opt.selected = !state.filter[key] || state.filter[key].has(String(v));
-      sel.appendChild(opt);
-    });
-    sel.addEventListener('change', e => {
-      e.stopPropagation();
-      const chosen = [...sel.options].filter(o => o.selected).map(o => o.value);
-      state.filter[key] = chosen.length ? new Set(chosen) : null;
-      renderGrid();
-    });
 
     // Make chip draggable only from the label, not from controls.
     lbl.draggable = true;

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -216,13 +216,15 @@ function computeAnchor(visibleRows, state) {
     return state.scale.userValue;
   }
   if (state.scale.mode === 'theoretical') {
-    const arch = state.arch;
-    const dtype = state.fixed.dtype
-      || (state.data && state.data.axes.dtype && state.data.axes.dtype[0])
-      || 'float16';
-    const peak = THEORETICAL_PEAK_TFLOPS[arch];
-    if (peak && peak[dtype]) return peak[dtype];
-    // Fall through to max_observed if not found.
+    const peak = THEORETICAL_PEAK_TFLOPS[state.arch];
+    if (peak) {
+      // Return a per-dtype Map so each dtype column is normalized to its own peak.
+      const dtypes = state.data && state.data.axes.dtype;
+      const map = new Map();
+      (dtypes || Object.keys(peak)).forEach(d => { if (peak[d]) map.set(d, peak[d]); });
+      if (map.size) return map;
+    }
+    // Fall through to max_observed if arch not found.
   }
   // max_observed: per-dtype max TFLOPS across the rows currently visible.
   // Returns a Map<dtype, number> so each dtype is normalized to its own peak.

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -73,6 +73,7 @@ function cellTextColor(fraction) {
 
 let state = {
   descriptor: null,
+  descriptorId: 'flash',
   data: null,           // raw API response {arch, kernel, axes, rows}
   colDims: [],
   rowDims: [],
@@ -686,8 +687,9 @@ function _dimLabel(desc, key, value) {
 
 function pushURLState() {
   const p = new URLSearchParams();
-  if (state.arch)   p.set('arch',    state.arch);
-  if (state.kernel) p.set('kernel',  state.kernel);
+  if (state.arch)         p.set('arch',    state.arch);
+  if (state.descriptorId) p.set('module',  state.descriptorId);
+  if (state.kernel)       p.set('kernel',  state.kernel);
   p.set('display', state.displayMode);
   p.set('scale',   state.scale.mode);
   if (state.scale.mode === 'user' && state.scale.userValue)
@@ -706,6 +708,7 @@ function restoreFromURL() {
   return {
     arch:        p.get('arch')        || '',
     kernel:      p.get('kernel')      || '',
+    module:      p.get('module')      || '',
     display:     p.get('display')     || '',
     scale:       p.get('scale')       || '',
     scale_value: p.get('scale_value') || '',
@@ -732,6 +735,7 @@ function initPerf() {
 
   // Apply URL params to selectors before load().
   const saved = restoreFromURL();
+  if (saved.module) state.descriptorId = saved.module;
   if (saved.arch   && archSel)   archSel.value   = saved.arch;
   if (saved.kernel && kernelSel) kernelSel.value = saved.kernel;
   if (saved.display && dispSel)  dispSel.value   = saved.display;
@@ -751,7 +755,7 @@ function initPerf() {
     const kernel = kernelSel.value;
     if (!arch || !kernel) return;
     // Infer mode from the active descriptor's ops set; fall back to kernel.
-    const activeDesc = Object.values(DESCRIPTORS)[0];
+    const activeDesc = DESCRIPTORS[state.descriptorId] || DESCRIPTORS[Object.keys(DESCRIPTORS)[0]];
     const mode = (activeDesc && activeDesc.ops && activeDesc.ops.has(kernel)) ? 'op' : 'kernel';
 
     state.arch = arch;
@@ -761,8 +765,8 @@ function initPerf() {
 
     try {
       state.data = await fetchData(arch, kernel, mode);
-      // Pick descriptor by kernel family — currently always flash.
-      state.descriptor = DESCRIPTORS['flash'];
+      // Pick descriptor by id (from URL state or default).
+      state.descriptor = DESCRIPTORS[state.descriptorId] || DESCRIPTORS[Object.keys(DESCRIPTORS)[0]];
       if (state.descriptor) {
         // Restore col/row dims from URL if present, else use descriptor defaults.
         state.colDims = saved.col_dims

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -513,10 +513,11 @@ function initPerf() {
     chip.className = 'dim-chip';
     chip.dataset.dim = key;
 
-    // Dropdown for value filtering — shown only when unchecked.
+    // Dropdown for value filtering — always visible, disabled when checkbox is checked.
     // Built before the checkbox so the checkbox handler can reference it.
     const sel = document.createElement('select');
-    sel.style.cssText = 'margin-left:0.3rem;' + (isChecked ? 'display:none;' : '');
+    sel.style.cssText = 'margin-left:0.3rem;';
+    sel.disabled = isChecked;
     // Pick the currently filtered value, or the first value as default.
     const currentVal = state.filter[key]
       ? [...state.filter[key]][0]
@@ -534,7 +535,7 @@ function initPerf() {
       renderGrid();
     });
 
-    // Checkbox toggles between "all values" and "single value from dropdown".
+    // Checkbox toggles between "all values" (dropdown disabled) and "single value" (dropdown enabled).
     const cb = document.createElement('input');
     cb.type = 'checkbox';
     cb.checked = isChecked;
@@ -543,10 +544,10 @@ function initPerf() {
       e.stopPropagation();
       if (cb.checked) {
         state.filter[key] = null;
-        sel.style.display = 'none';
+        sel.disabled = true;
       } else {
         state.filter[key] = new Set([sel.value || currentVal]);
-        sel.style.display = '';
+        sel.disabled = false;
       }
       renderGrid();
     });

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -1257,7 +1257,7 @@ function initPerf() {
   }
 
   // Apply URL params to selectors before load().
-  const saved = restoreFromURL();
+  let saved = restoreFromURL();
   if (saved.module) state.descriptorId = saved.module;
   if (saved.arch   && archSel)   archSel.value   = saved.arch;
   if (saved.kernel && kernelSel) kernelSel.value = saved.kernel;
@@ -1285,6 +1285,8 @@ function initPerf() {
     const arch   = archSel.value;
     const kernel = kernelSel.value;
     if (!arch || !kernel) return;
+    // Refresh saved from current URL so prior pushURLState() updates are picked up.
+    saved = restoreFromURL();
     // Infer mode from the active descriptor's ops set; fall back to kernel.
     const activeDesc = DESCRIPTORS[state.descriptorId] || DESCRIPTORS[Object.keys(DESCRIPTORS)[0]];
     const mode = (activeDesc && activeDesc.ops && activeDesc.ops.has(kernel)) ? 'op' : 'kernel';

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -124,7 +124,8 @@ function cartesian(arrays) {
   return head.flatMap(v => rest.map(t => [v, ...t]));
 }
 
-// Enumerate distinct dim-value tuples present in rows (for a given set of dim keys).
+// Enumerate distinct dim-value tuples present in rows, ordered by the
+// descriptor's declared values[] order for each key (falls back to natural order).
 function distinctCombos(rows, dimKeys) {
   const seen = new Set();
   const result = [];
@@ -137,6 +138,23 @@ function distinctCombos(rows, dimKeys) {
       result.push(obj);
     }
   }
+  // Sort by descriptor values[] order for each dim key.
+  const desc = state.descriptor;
+  result.sort((a, b) => {
+    for (const k of dimKeys) {
+      const dim = desc && desc.dims.find(d => d.key === k);
+      const order = dim ? dim.values : null;
+      const ai = order ? order.indexOf(a[k]) : -1;
+      const bi = order ? order.indexOf(b[k]) : -1;
+      // Known values sort by index; unknowns go last, then by natural order.
+      const av = ai >= 0 ? ai : Infinity;
+      const bv = bi >= 0 ? bi : Infinity;
+      if (av !== bv) return av - bv;
+      if (a[k] < b[k]) return -1;
+      if (a[k] > b[k]) return 1;
+    }
+    return 0;
+  });
   return result;
 }
 

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -79,7 +79,7 @@ let state = {
   // filter: per-dim allowed value sets for grid dims (col/row).
   // null = all values shown. A Set means only those values are shown.
   filter: {},
-  displayMode: 'heatmap',   // 'heatmap' | '3d' | 'autozoom'
+  displayMode: 'autozoom',  // 'heatmap' | '3d' | 'autozoom'
   autozoom: { drilldown: null },  // drilldown = {rowCombo, colCombo} or null for overview
   seqlenRange: [0, 65536],
   scale: {
@@ -622,6 +622,7 @@ function initPerf() {
 
     state.arch = arch;
     state.kernel = kernel;
+    if (dispSel) state.displayMode = dispSel.value;
     if (status) status.textContent = 'Loading…';
 
     try {

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -1313,6 +1313,7 @@ function initPerf() {
           state.filter[k] = new Set([v]);
         }
         state.autozoom.drilldown = null;
+        state.cellDetail = null;
       }
       updateDimPanel();
       renderGrid();

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -206,7 +206,7 @@ function computeAnchor(data, state) {
 
 function renderHeatmap(container, seqQ, seqK, index, desc, anchor) {
   const tbl = document.createElement('table');
-  tbl.style.cssText = 'border-collapse:collapse;font-size:0.8em;font-family:monospace;';
+  tbl.style.cssText = 'border-collapse:collapse;font-size:0.8em;font-family:monospace;width:auto;';
 
   // Header row: empty corner + one th per seqlen_k value.
   const thead = tbl.createTHead();
@@ -229,7 +229,7 @@ function renderHeatmap(container, seqQ, seqK, index, desc, anchor) {
 
     // Row header.
     const th = document.createElement('th');
-    th.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.7;font-weight:normal;white-space:nowrap;';
+    th.style.cssText = 'padding:2px 6px;text-align:right;opacity:0.7;font-weight:normal;white-space:nowrap;width:1px;';
     th.textContent = q;
     tr.appendChild(th);
 

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -383,7 +383,19 @@ function renderAutozoom(grid, layout, anchor) {
   const table = document.createElement('table');
   table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
 
-  // Column header rows — one <th> per colCombo, border-left when this dim's value changes.
+  // Precompute separator positions (same logic as heatmap/3D grid).
+  const colSeps = state.colDims.map((dimKey) => {
+    const seps = new Set();
+    let prev = null;
+    colCombos.forEach((cc, ci) => {
+      if (ci > 0 && cc[dimKey] !== prev) seps.add(ci);
+      prev = cc[dimKey];
+    });
+    return seps;
+  });
+  const colNeedsSep = colCombos.map((_, ci) => colSeps.some(s => s.has(ci)));
+
+  // Column header rows.
   for (let di = 0; di < numColDims; di++) {
     const tr = document.createElement('tr');
     for (let ri = 0; ri < numRowDims; ri++) {
@@ -395,14 +407,27 @@ function renderAutozoom(grid, layout, anchor) {
       tr.appendChild(th);
     }
     const dimKey = state.colDims[di];
+    const spans = [];
+    let curLabel = null, curCount = 0, curStart = 0;
     colCombos.forEach((cc, ci) => {
-      const th = document.createElement('th');
       const label = _dimLabel(desc, dimKey, cc[dimKey]);
+      // Break when this dim's value changes OR any ancestor dim changes.
+      const ancestorBreak = ci > 0 && colSeps.slice(0, di).some(s => s.has(ci));
+      if (label !== curLabel || ancestorBreak) {
+        if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
+        curLabel = label; curCount = 0; curStart = ci;
+      }
+      curCount++;
+    });
+    if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
+    for (const { label, count, start } of spans) {
+      const th = document.createElement('th');
+      th.colSpan = count;
       th.textContent = `${dimKey}=${label}`;
-      const sep = ci > 0 && cc[dimKey] !== colCombos[ci - 1][dimKey] ? 'border-left:2px solid currentColor;' : '';
+      const sep = start > 0 ? 'border-left:2px solid currentColor;' : '';
       th.style.cssText = `text-align:center;border-bottom:1px solid currentColor;opacity:0.8;${sep}`;
       tr.appendChild(th);
-    });
+    }
     table.appendChild(tr);
   }
 
@@ -418,8 +443,7 @@ function renderAutozoom(grid, layout, anchor) {
 
     for (const [ci, colCombo] of colCombos.entries()) {
       const td = document.createElement('td');
-      const sepNeeded = ci > 0 && state.colDims.some(k => colCombo[k] !== colCombos[ci - 1][k]);
-      const sep = sepNeeded ? 'border-left:2px solid currentColor;' : '';
+      const sep = colNeedsSep[ci] ? 'border-left:2px solid currentColor;' : '';
       td.style.cssText = `padding:0;width:5rem;height:2.4rem;text-align:center;vertical-align:middle;cursor:pointer;${sep}`;
 
       const cell = cells.find(c =>
@@ -541,7 +565,22 @@ function renderGrid() {
   const table = document.createElement('table');
   table.style.cssText = 'border-collapse:separate;border-spacing:4px;';
 
-  // Header rows — one <th> per colCombo, border-left when this dim's value changes.
+  // Precompute which colCombo indices start a new group for each dim level.
+  // colSeps[di] is a Set of colCombo indices where dim di's value changes.
+  const colSeps = state.colDims.map((dimKey, di) => {
+    const seps = new Set();
+    let prev = null;
+    layout.colCombos.forEach((cc, ci) => {
+      const val = cc[dimKey];
+      if (ci > 0 && val !== prev) seps.add(ci);
+      prev = val;
+    });
+    return seps;
+  });
+  // A column index needs a separator if ANY dim level starts a new group there.
+  const colNeedsSep = layout.colCombos.map((_, ci) => colSeps.some(s => s.has(ci)));
+
+  // Header rows — one per colDim.
   for (let di = 0; di < numColDims; di++) {
     const tr = document.createElement('tr');
     // Empty corner cells.
@@ -553,15 +592,32 @@ function renderGrid() {
       }
       tr.appendChild(th);
     }
+    // Compute spans for this dim level.
     const dimKey = state.colDims[di];
+    const spans = [];
+    let curLabel = null, curCount = 0, curStart = 0;
     layout.colCombos.forEach((cc, ci) => {
-      const th = document.createElement('th');
       const label = _dimLabel(state.descriptor, dimKey, cc[dimKey]);
-      th.textContent = `${dimKey}=${label}`;
-      const sep = ci > 0 && cc[dimKey] !== layout.colCombos[ci - 1][dimKey] ? 'border-left:2px solid currentColor;' : '';
+      // Break when this dim's value changes OR any ancestor dim changes.
+      const ancestorBreak = ci > 0 && colSeps.slice(0, di).some(s => s.has(ci));
+      if (label !== curLabel || ancestorBreak) {
+        if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
+        curLabel = label;
+        curCount = 0;
+        curStart = ci;
+      }
+      curCount++;
+    });
+    if (curCount) spans.push({ label: curLabel, count: curCount, start: curStart });
+
+    for (const { label, count, start } of spans) {
+      const th = document.createElement('th');
+      th.colSpan = count;
+      th.textContent = `${state.colDims[di]}=${label}`;
+      const sep = start > 0 ? 'border-left:2px solid currentColor;' : '';
       th.style.cssText = `text-align:center;border-bottom:1px solid currentColor;opacity:0.8;${sep}`;
       tr.appendChild(th);
-    });
+    }
     table.appendChild(tr);
   }
 
@@ -580,8 +636,7 @@ function renderGrid() {
     // Matrix cells.
     for (const [ci, colCombo] of layout.colCombos.entries()) {
       const td = document.createElement('td');
-      const sepNeeded = ci > 0 && state.colDims.some(k => colCombo[k] !== layout.colCombos[ci - 1][k]);
-      const sep = sepNeeded ? 'border-left:2px solid currentColor;' : '';
+      const sep = colNeedsSep[ci] ? 'border-left:2px solid currentColor;' : '';
       td.style.cssText = `vertical-align:top;padding:2px;${sep}`;
 
       const matchingCell = layout.cells.find(c =>

--- a/.tune/webui/static/js/perf.js
+++ b/.tune/webui/static/js/perf.js
@@ -439,7 +439,6 @@ function _dimLabel(desc, key, value) {
 function initPerf() {
   const archSel    = document.getElementById('perf-arch');
   const kernelSel  = document.getElementById('perf-kernel');
-  const modeSel    = document.getElementById('perf-mode');
   const scaleSel   = document.getElementById('perf-scale');
   const scaleInput = document.getElementById('perf-scale-value');
   const dispSel    = document.getElementById('perf-display');
@@ -450,8 +449,10 @@ function initPerf() {
     if (!archSel || !kernelSel) return;
     const arch   = archSel.value;
     const kernel = kernelSel.value;
-    const mode   = modeSel ? modeSel.value : 'kernel';
     if (!arch || !kernel) return;
+    // Infer mode from the active descriptor's ops set; fall back to kernel.
+    const activeDesc = Object.values(DESCRIPTORS)[0];
+    const mode = (activeDesc && activeDesc.ops && activeDesc.ops.has(kernel)) ? 'op' : 'kernel';
 
     state.arch = arch;
     state.kernel = kernel;

--- a/.tune/webui/static/js/vis_descriptors/flash.js
+++ b/.tune/webui/static/js/vis_descriptors/flash.js
@@ -50,6 +50,77 @@ const FLASH_DESCRIPTOR = {
   // kernel names that use the forward FLOPs formula
   fwdKernels: new Set(['attn_fwd', 'attn_fwd_op']),
 
+  // ---------------------------------------------------------------------------
+  // Level-2 (psel/copt) drilldown schema.
+  // Source: v3python/rules/flash/*.py gen_autotune_configs().
+  // Listed explicitly — do not infer field names from DB.
+  // ---------------------------------------------------------------------------
+  cellDetail: {
+    // Kernels that support level-2 drilldown.
+    // Ops use a single backend_index so a psel×copt matrix is degenerate.
+    kernels: {
+      attn_fwd: {
+        psels: ['PERSISTENT_TYPE', 'GRID_CU_MULTIP',
+                'BLOCK_M', 'BLOCK_N', 'PRE_LOAD_V', 'NUM_XCDS'],
+        copts: ['num_warps', 'num_stages', 'waves_per_eu'],
+      },
+      bwd_kernel_dk_dv: {
+        psels: ['BLOCK_M', 'BLOCK_N', 'NUM_XCDS'],
+        copts: ['num_warps', 'num_stages', 'waves_per_eu'],
+      },
+      bwd_kernel_dq: {
+        psels: ['BLOCK_M', 'BLOCK_N', 'NUM_XCDS'],
+        copts: ['num_warps', 'num_stages', 'waves_per_eu'],
+      },
+      bwd_kernel_fuse: {
+        psels: ['BLOCK_M', 'BLOCK_N', 'NUM_XCDS'],
+        copts: ['num_warps', 'num_stages', 'waves_per_eu'],
+      },
+    },
+
+    // Skipped test cases — must match v3python/tune/pq/compute_best_results.SKIP_TEST_CASES.
+    skipTestCases: new Set([]),
+
+    // Accuracy gate: must match compute_best_results.ACCURACY_MULTIPLIER.
+    accuracyMultiplier: 10.0,
+
+    // TFLOPS for one psel/copt candidate, given its median_ms and the
+    // level-1 row context (so we know seqlen_q/seqlen_k/hdim/causal/etc).
+    candidateTflops(cand, cellRow) {
+      if (!cand || !(cand.median_ms > 0)) return 0;
+      const synth = Object.assign({}, cellRow, { median_ms: cand.median_ms });
+      return FLASH_DESCRIPTOR.tflops(synth);
+    },
+  },
+
+  // Audit one candidate against the per-(test_case, tensor) thresholds.
+  // Mirrors v3python/tune/pq/compute_best_results.evaluate_group's per-row
+  // gating (kernel mode; op-mode early-reject not used here).
+  //   adiffs[tc][tensor] = [target_fudge, abs_err, ref_err]
+  //   threshold[tc][tensor] = absolute_error  (from most_accurate_*)
+  // Returns true if the candidate passes the accuracy gate.
+  passesAccuracy(cand, threshold) {
+    const skip = FLASH_DESCRIPTOR.cellDetail.skipTestCases;
+    const mult = FLASH_DESCRIPTOR.cellDetail.accuracyMultiplier;
+    const adiffs = cand.adiffs || {};
+    for (const [tc, tensors] of Object.entries(adiffs)) {
+      if (skip.has(tc)) continue;
+      for (const [tname, vals] of Object.entries(tensors)) {
+        if (!vals || !vals.length) continue;                  // inapplicable
+        const ref_err = vals.length > 2 ? vals[2] : null;
+        if (ref_err === null || ref_err === undefined) continue;
+        const abs_err = vals.length > 1 ? vals[1] : null;
+        if (abs_err === null || abs_err === undefined) return false;  // broken
+        const min_err = threshold[tc] && threshold[tc][tname];
+        if (min_err !== undefined && min_err !== null
+            && abs_err > mult * min_err) {
+          return false;
+        }
+      }
+    }
+    return true;
+  },
+
   tflops(row) {
     const batch   = row.batch   || 1;
     const n_heads = row.n_heads || 1;

--- a/.tune/webui/static/js/vis_descriptors/flash.js
+++ b/.tune/webui/static/js/vis_descriptors/flash.js
@@ -47,6 +47,10 @@ const FLASH_DESCRIPTOR = {
   defaultRowDims: ['hdim'],
   defaultFixed:   {},
 
+  // Kernels and ops exposed in the UI's Kernel/Op dropdown.
+  // Declared in display order; ops uses a Set elsewhere for mode inference.
+  kernels: ['attn_fwd', 'bwd_kernel_dk_dv', 'bwd_kernel_dq', 'bwd_kernel_fuse'],
+  opsList: ['attn_fwd_op', 'attn_bwd_op'],
   ops: new Set(['attn_fwd_op', 'attn_bwd_op']),
 
   // kernel names that use the forward FLOPs formula

--- a/.tune/webui/static/js/vis_descriptors/flash.js
+++ b/.tune/webui/static/js/vis_descriptors/flash.js
@@ -45,6 +45,8 @@ const FLASH_DESCRIPTOR = {
   defaultRowDims: ['hdim'],
   defaultFixed:   {},
 
+  ops: new Set(['attn_fwd_op', 'attn_bwd_op']),
+
   // kernel names that use the forward FLOPs formula
   fwdKernels: new Set(['attn_fwd', 'attn_fwd_op']),
 

--- a/.tune/webui/static/js/vis_descriptors/flash.js
+++ b/.tune/webui/static/js/vis_descriptors/flash.js
@@ -41,9 +41,9 @@ const FLASH_DESCRIPTOR = {
 
   matrixAxes: { row: 'seqlen_q', col: 'seqlen_k' },
 
-  defaultColDims: ['dtype', 'bias_type', 'causal'],
+  defaultColDims: ['dtype', 'bias_type', 'causal', 'dropout'],
   defaultRowDims: ['hdim'],
-  defaultFixed:   { dropout: 0 },
+  defaultFixed:   {},
 
   // kernel names that use the forward FLOPs formula
   fwdKernels: new Set(['attn_fwd', 'attn_fwd_op']),

--- a/.tune/webui/static/js/vis_descriptors/flash.js
+++ b/.tune/webui/static/js/vis_descriptors/flash.js
@@ -4,7 +4,9 @@
 // Flash attention TFLOPS formulas.
 // Source: ROCm/triton perf-kernels/flash-attention.py @ 0ec280cf, bench_flash_attention()
 // Counts only the two matmuls (QK^T and PV); excludes softmax, LSE, dropout.
-// BATCH=1, N_HEADS=1 for kernel-mode tuning (single-head benchmark).
+// BATCH and N_HEADS are read from each row (provided by the DB); they
+// default to 1 when absent (e.g. older kernel-mode rows from single-head
+// benchmarks).
 
 function _attnValidElements(seqlen_q, seqlen_k, causal) {
   if (causal) {
@@ -79,10 +81,10 @@ const FLASH_DESCRIPTOR = {
     },
 
     // Skipped test cases — must match v3python/tune/pq/compute_best_results.SKIP_TEST_CASES.
-    skipTestCases: new Set([]),
+    skipTestCases: new Set(['01_gqa']),
 
     // Accuracy gate: must match compute_best_results.ACCURACY_MULTIPLIER.
-    accuracyMultiplier: 10.0,
+    accuracyMultiplier: 3.0,
 
     // TFLOPS for one psel/copt candidate, given its median_ms and the
     // level-1 row context (so we know seqlen_q/seqlen_k/hdim/causal/etc).

--- a/.tune/webui/static/js/vis_descriptors/flash.js
+++ b/.tune/webui/static/js/vis_descriptors/flash.js
@@ -1,0 +1,78 @@
+// Copyright © 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Flash attention TFLOPS formulas.
+// Source: ROCm/triton perf-kernels/flash-attention.py @ 0ec280cf, bench_flash_attention()
+// Counts only the two matmuls (QK^T and PV); excludes softmax, LSE, dropout.
+// BATCH=1, N_HEADS=1 for kernel-mode tuning (single-head benchmark).
+
+function _attnValidElements(seqlen_q, seqlen_k, causal) {
+  if (causal) {
+    return seqlen_q <= seqlen_k
+      ? seqlen_q * seqlen_k - (seqlen_q * seqlen_q - seqlen_q) / 2
+      : (seqlen_k * seqlen_k + seqlen_k) / 2;
+  }
+  return seqlen_q * seqlen_k;
+}
+
+function attnFwdTflops(seqlen_q, seqlen_k, hdim, causal, median_ms, batch, n_heads) {
+  const valid = _attnValidElements(seqlen_q, seqlen_k, causal);
+  const flops_per_matmul = 2 * valid * hdim;
+  const total_flops = 2 * flops_per_matmul * batch * n_heads;
+  return total_flops / (median_ms * 1e-3) / 1e12;
+}
+
+function attnBwdTflops(seqlen_q, seqlen_k, hdim, causal, median_ms, batch, n_heads) {
+  // backward = 2.5x forward FLOPs (2.0 bwd matmuls + 0.5 recompute)
+  return attnFwdTflops(seqlen_q, seqlen_k, hdim, causal, median_ms / 2.5, batch, n_heads);
+}
+
+const FLASH_DESCRIPTOR = {
+  id: 'flash',
+  label: 'Flash Attention',
+
+  dims: [
+    { key: 'dtype',     label: 'dtype',   values: ['float16', 'bfloat16', 'float32'] },
+    { key: 'hdim',      label: 'hdim',    values: [16, 32, 48, 64, 80, 96, 128, 160, 192, 256] },
+    { key: 'causal',    label: 'causal',  values: [0, 1], valueLabels: ['F', 'T'] },
+    { key: 'bias_type', label: 'bias',    values: [0, 1] },
+    { key: 'dropout',   label: 'dropout', values: [0, 1] },
+  ],
+
+  matrixAxes: { row: 'seqlen_q', col: 'seqlen_k' },
+
+  defaultColDims: ['dtype', 'bias_type', 'causal'],
+  defaultRowDims: ['hdim'],
+  defaultFixed:   { dropout: 0 },
+
+  // kernel names that use the forward FLOPs formula
+  fwdKernels: new Set(['attn_fwd', 'attn_fwd_op']),
+
+  tflops(row) {
+    const batch   = row.batch   || 1;
+    const n_heads = row.n_heads || 1;
+    const isBwd = !this.fwdKernels.has(row._kernel);
+    if (isBwd) {
+      return attnBwdTflops(row.seqlen_q, row.seqlen_k, row.hdim, row.causal, row.median_ms, batch, n_heads);
+    }
+    return attnFwdTflops(row.seqlen_q, row.seqlen_k, row.hdim, row.causal, row.median_ms, batch, n_heads);
+  },
+
+  tooltip(row) {
+    const batch   = row.batch   || 1;
+    const n_heads = row.n_heads || 1;
+    const valid = _attnValidElements(row.seqlen_q, row.seqlen_k, row.causal);
+    const fpm   = 2 * valid * row.hdim;
+    const total = 2 * fpm * batch * n_heads;
+    return [
+      `${row.seqlen_q}×${row.seqlen_k} sq×sk, hdim=${row.hdim}, ${row.dtype}`,
+      `causal=${row.causal ? 'T' : 'F'}, median=${row.median_ms.toFixed(3)} ms`,
+      `─── FLOPs breakdown ───`,
+      `BATCH=${batch}, N_HEADS=${n_heads}`,
+      `valid elements: ${valid.toLocaleString()}`,
+      `flops/matmul = 2×valid×hdim = ${fpm.toLocaleString()}`,
+      `total = 2×matmuls×BATCH×N_HEADS = ${total.toLocaleString()}`,
+      `TFLOPS = ${total.toLocaleString()}/(${row.median_ms.toFixed(4)}ms×1e-3)/1e12`,
+    ];
+  },
+};

--- a/.tune/webui/static/js/vis_descriptors/flash.js
+++ b/.tune/webui/static/js/vis_descriptors/flash.js
@@ -60,21 +60,21 @@ const FLASH_DESCRIPTOR = {
     // Ops use a single backend_index so a psel×copt matrix is degenerate.
     kernels: {
       attn_fwd: {
-        psels: ['PERSISTENT_TYPE', 'GRID_CU_MULTIP',
-                'BLOCK_M', 'BLOCK_N', 'PRE_LOAD_V', 'NUM_XCDS'],
-        copts: ['num_warps', 'num_stages', 'waves_per_eu'],
+        psels: ['NUM_XCDS', 'PERSISTENT_TYPE', 'GRID_CU_MULTIP',
+                'BLOCK_M', 'BLOCK_N', 'PRE_LOAD_V'],
+        copts: ['num_stages', 'num_warps', 'waves_per_eu'],
       },
       bwd_kernel_dk_dv: {
-        psels: ['BLOCK_M', 'BLOCK_N', 'NUM_XCDS'],
-        copts: ['num_warps', 'num_stages', 'waves_per_eu'],
+        psels: ['NUM_XCDS', 'BLOCK_M', 'BLOCK_N'],
+        copts: ['num_stages', 'num_warps', 'waves_per_eu'],
       },
       bwd_kernel_dq: {
-        psels: ['BLOCK_M', 'BLOCK_N', 'NUM_XCDS'],
-        copts: ['num_warps', 'num_stages', 'waves_per_eu'],
+        psels: ['NUM_XCDS', 'BLOCK_M', 'BLOCK_N'],
+        copts: ['num_stages', 'num_warps', 'waves_per_eu'],
       },
       bwd_kernel_fuse: {
-        psels: ['BLOCK_M', 'BLOCK_N', 'NUM_XCDS'],
-        copts: ['num_warps', 'num_stages', 'waves_per_eu'],
+        psels: ['NUM_XCDS', 'BLOCK_M', 'BLOCK_N'],
+        copts: ['num_stages', 'num_warps', 'waves_per_eu'],
       },
     },
 

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -1960,18 +1960,21 @@ def query_perf_cell_detail(workdir: str, task_id: int, kernel: str,
 
 
 def build_perf_export_html(col_filters: dict, url_params: dict,
-                           workdir: str) -> str:
+                           workdir: str, descriptor_id: str = 'flash') -> str:
     """Build a self-contained autozoom HTML string for all arches and kernels/ops.
 
     col_filters: {dim: [allowed_values]} — empty list means include all values.
     url_params:  forwarded into the static bootstrap as the initial URL state.
     """
+    desc = DESCRIPTORS.get(descriptor_id)
+    if desc is None:
+        raise ValueError(f"Unknown descriptor_id {descriptor_id!r}")
+
     conn_params = get_db_connection_params(Path(workdir))
     with psycopg.connect(**conn_params, autocommit=True) as conn:
-        all_data = query_all_best_results(conn)
+        all_data = query_all_best_results(conn, descriptor_id=descriptor_id)
 
     if col_filters:
-        desc = DESCRIPTORS.get('flash')
 
         def _row_allowed(r: dict) -> bool:
             for dim, allowed in col_filters.items():

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -32,7 +32,7 @@ from v3python.tune.flash.module import FlashEntry
 from .pytest_entry_parser import parse_pytest_node_id, entry_to_sql_clauses
 from v3python.tune.pq.visperf import (
     query_best_results, query_all_best_results, get_available_archs,
-    _build_axes, query_cell_detail,
+    build_axes, query_cell_detail,
 )
 from v3python.tune.pq.vis_descriptors import DESCRIPTORS
 from v3python.tune.pq.export_visperf import export_visperf as _do_export_visperf, build_export_html
@@ -1967,6 +1967,6 @@ def build_perf_export_html(col_filters: dict, url_params: dict,
         for arch_data in all_data.values():
             for kdata in arch_data.values():
                 kdata['rows'] = [r for r in kdata['rows'] if _row_allowed(r)]
-                kdata['axes'] = _build_axes(kdata['rows'], desc)
+                kdata['axes'] = build_axes(kdata['rows'], desc)
 
     return build_export_html(all_data, url_params)

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -30,7 +30,10 @@ sys.path.insert(0, AOTRITON_ROOT.as_posix())
 from v3python.tune.utils import get_db_connection_params
 from v3python.tune.flash.module import FlashEntry
 from .pytest_entry_parser import parse_pytest_node_id, entry_to_sql_clauses
-from v3python.tune.pq.visperf import query_best_results, query_all_best_results, get_available_archs, _build_axes
+from v3python.tune.pq.visperf import (
+    query_best_results, query_all_best_results, get_available_archs,
+    _build_axes, query_cell_detail,
+)
 from v3python.tune.pq.vis_descriptors import DESCRIPTORS
 from v3python.tune.pq.export_visperf import export_visperf as _do_export_visperf, build_export_html
 
@@ -1941,6 +1944,18 @@ def export_visperf(workdir: str, dry_run: bool = False) -> dict:
     except Exception as e:
         logger.error('export_visperf failed: %s', e)
         return {'status': 'error', 'message': str(e)}
+
+
+def query_perf_cell_detail(workdir: str, task_id: int, kernel: str,
+                           mode: str = 'kernel') -> dict:
+    """Fetch psel/copt-level candidates for one (task_id, kernel) cell."""
+    conn_params = get_db_connection_params(Path(workdir))
+    try:
+        with psycopg.connect(**conn_params, autocommit=True) as conn:
+            return query_cell_detail(conn, task_id, kernel, mode)
+    except Exception as e:
+        logger.error('query_perf_cell_detail failed: %s', e)
+        return {'error': str(e)}
 
 
 def build_perf_export_html(col_filters: dict, url_params: dict,

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -1904,7 +1904,8 @@ def _ensure_plotly_cache(workdir: str) -> None:
         return
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     logger.info('Downloading Plotly.js to %s', cache_path)
-    urllib.request.urlretrieve(PLOTLY_CDN_URL, cache_path)
+    with urllib.request.urlopen(PLOTLY_CDN_URL, timeout=30) as resp:
+        cache_path.write_bytes(resp.read())
     logger.info('Plotly.js cached (%d bytes)', cache_path.stat().st_size)
 
 

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -1891,24 +1891,6 @@ def get_scheduled_workers(workdir):
 # Performance visualization
 # ---------------------------------------------------------------------------
 
-PLOTLY_CDN_URL = (
-    'https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js'
-)
-
-
-def _ensure_plotly_cache(workdir: str) -> None:
-    """Download Plotly.js to scratch/webcache/ if not already present."""
-    import urllib.request
-    cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.min.js'
-    if cache_path.exists():
-        return
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    logger.info('Downloading Plotly.js to %s', cache_path)
-    with urllib.request.urlopen(PLOTLY_CDN_URL, timeout=30) as resp:
-        cache_path.write_bytes(resp.read())
-    logger.info('Plotly.js cached (%d bytes)', cache_path.stat().st_size)
-
-
 def get_perf_archs(workdir: str) -> list[str]:
     """Return sorted list of arches with best_tuning_results data."""
     try:

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -1892,14 +1892,14 @@ def get_scheduled_workers(workdir):
 # ---------------------------------------------------------------------------
 
 PLOTLY_CDN_URL = (
-    'https://cdn.jsdelivr.net/npm/plotly.js-basic-dist@2.35.2/plotly.basic.min.js'
+    'https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js'
 )
 
 
 def _ensure_plotly_cache(workdir: str) -> None:
     """Download Plotly.js to scratch/webcache/ if not already present."""
     import urllib.request
-    cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.basic.min.js'
+    cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.min.js'
     if cache_path.exists():
         return
     cache_path.parent.mkdir(parents=True, exist_ok=True)

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -28,6 +28,8 @@ sys.path.insert(0, AOTRITON_ROOT.as_posix())
 from v3python.tune.utils import get_db_connection_params
 from v3python.tune.flash.module import FlashEntry
 from .pytest_entry_parser import parse_pytest_node_id, entry_to_sql_clauses
+from v3python.tune.pq.visperf import query_best_results, get_available_archs
+from v3python.tune.pq.export_visperf import export_visperf as _do_export_visperf
 
 def run_command(cmd, cwd, workdir, description=None, dry_run: bool = False):
     """
@@ -1877,3 +1879,62 @@ def get_scheduled_workers(workdir):
     except Exception as e:
         logger.error(f"Error getting scheduled workers: {e}")
         return {}
+
+
+# ---------------------------------------------------------------------------
+# Performance visualization
+# ---------------------------------------------------------------------------
+
+PLOTLY_CDN_URL = (
+    'https://cdn.jsdelivr.net/npm/plotly.js-basic-dist@2.35.2/plotly.basic.min.js'
+)
+
+
+def _ensure_plotly_cache(workdir: str) -> None:
+    """Download Plotly.js to scratch/webcache/ if not already present."""
+    import urllib.request
+    cache_path = Path(workdir) / 'scratch' / 'webcache' / 'plotly.basic.min.js'
+    if cache_path.exists():
+        return
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info('Downloading Plotly.js to %s', cache_path)
+    urllib.request.urlretrieve(PLOTLY_CDN_URL, cache_path)
+    logger.info('Plotly.js cached (%d bytes)', cache_path.stat().st_size)
+
+
+def get_perf_archs(workdir: str) -> list[str]:
+    """Return sorted list of arches with best_tuning_results data."""
+    try:
+        conn_params = get_db_connection_params(Path(workdir))
+        with psycopg.connect(**conn_params, autocommit=True) as conn:
+            return get_available_archs(conn)
+    except Exception as e:
+        logger.error('get_perf_archs failed: %s', e)
+        return []
+
+
+def query_perf_data(workdir: str, arch: str, kernel: str, mode: str = 'kernel',
+                    seqlen_min: int = 0, seqlen_max: int = 65536) -> dict:
+    """Query best results for the Perf tab API endpoint."""
+    try:
+        conn_params = get_db_connection_params(Path(workdir))
+        with psycopg.connect(**conn_params, autocommit=True) as conn:
+            return query_best_results(conn, arch, kernel, mode, seqlen_min, seqlen_max)
+    except Exception as e:
+        logger.error('query_perf_data failed: %s', e)
+        return {'error': str(e), 'rows': [], 'axes': {}}
+
+
+def export_visperf(workdir: str, dry_run: bool = False) -> dict:
+    """Export self-contained perf.html to <workdir>/perf.html."""
+    if dry_run:
+        return {'status': 'dry_run', 'message': '[DRY RUN] Would export perf.html'}
+    output = Path(workdir) / 'perf.html'
+    try:
+        conn_params = get_db_connection_params(Path(workdir))
+        with psycopg.connect(**conn_params, autocommit=True) as conn:
+            _do_export_visperf(conn, output)
+        return {'status': 'ok', 'message': f'Exported to {output}'}
+    except Exception as e:
+        logger.error('export_visperf failed: %s', e)
+        return {'status': 'error', 'message': str(e)}

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -30,8 +30,9 @@ sys.path.insert(0, AOTRITON_ROOT.as_posix())
 from v3python.tune.utils import get_db_connection_params
 from v3python.tune.flash.module import FlashEntry
 from .pytest_entry_parser import parse_pytest_node_id, entry_to_sql_clauses
-from v3python.tune.pq.visperf import query_best_results, get_available_archs
-from v3python.tune.pq.export_visperf import export_visperf as _do_export_visperf
+from v3python.tune.pq.visperf import query_best_results, get_available_archs, _build_axes
+from v3python.tune.pq.vis_descriptors import DESCRIPTORS
+from v3python.tune.pq.export_visperf import export_visperf as _do_export_visperf, build_export_html
 
 def run_command(cmd, cwd, workdir, description=None, dry_run: bool = False):
     """
@@ -1940,3 +1941,30 @@ def export_visperf(workdir: str, dry_run: bool = False) -> dict:
     except Exception as e:
         logger.error('export_visperf failed: %s', e)
         return {'status': 'error', 'message': str(e)}
+
+
+def build_perf_export_html(arch: str, kernel: str, mode: str,
+                           col_filters: dict, url_params: dict,
+                           workdir: str) -> str:
+    """Build a self-contained autozoom HTML string for the given arch+kernel.
+
+    col_filters: {dim: [allowed_values]} — empty list means include all values.
+    url_params:  forwarded into the static bootstrap as the initial URL state.
+    """
+    conn_params = get_db_connection_params(Path(workdir))
+    with psycopg.connect(**conn_params, autocommit=True) as conn:
+        data = query_best_results(conn, arch, kernel, mode)
+
+    # Filter rows to only include col-dim combos that are checked (not filtered).
+    if col_filters:
+        def _row_allowed(r: dict) -> bool:
+            for dim, allowed in col_filters.items():
+                if allowed and str(r.get(dim)) not in allowed:
+                    return False
+            return True
+        data['rows'] = [r for r in data['rows'] if _row_allowed(r)]
+        # Recompute axes for the filtered rows.
+        desc = DESCRIPTORS.get('flash')
+        data['axes'] = _build_axes(data['rows'], desc)
+
+    return build_export_html({arch: {kernel: data}}, url_params)

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -30,7 +30,7 @@ sys.path.insert(0, AOTRITON_ROOT.as_posix())
 from v3python.tune.utils import get_db_connection_params
 from v3python.tune.flash.module import FlashEntry
 from .pytest_entry_parser import parse_pytest_node_id, entry_to_sql_clauses
-from v3python.tune.pq.visperf import query_best_results, get_available_archs, _build_axes
+from v3python.tune.pq.visperf import query_best_results, query_all_best_results, get_available_archs, _build_axes
 from v3python.tune.pq.vis_descriptors import DESCRIPTORS
 from v3python.tune.pq.export_visperf import export_visperf as _do_export_visperf, build_export_html
 
@@ -1943,28 +1943,29 @@ def export_visperf(workdir: str, dry_run: bool = False) -> dict:
         return {'status': 'error', 'message': str(e)}
 
 
-def build_perf_export_html(arch: str, kernel: str, mode: str,
-                           col_filters: dict, url_params: dict,
+def build_perf_export_html(col_filters: dict, url_params: dict,
                            workdir: str) -> str:
-    """Build a self-contained autozoom HTML string for the given arch+kernel.
+    """Build a self-contained autozoom HTML string for all arches and kernels/ops.
 
     col_filters: {dim: [allowed_values]} — empty list means include all values.
     url_params:  forwarded into the static bootstrap as the initial URL state.
     """
     conn_params = get_db_connection_params(Path(workdir))
     with psycopg.connect(**conn_params, autocommit=True) as conn:
-        data = query_best_results(conn, arch, kernel, mode)
+        all_data = query_all_best_results(conn)
 
-    # Filter rows to only include col-dim combos that are checked (not filtered).
     if col_filters:
+        desc = DESCRIPTORS.get('flash')
+
         def _row_allowed(r: dict) -> bool:
             for dim, allowed in col_filters.items():
                 if allowed and str(r.get(dim)) not in allowed:
                     return False
             return True
-        data['rows'] = [r for r in data['rows'] if _row_allowed(r)]
-        # Recompute axes for the filtered rows.
-        desc = DESCRIPTORS.get('flash')
-        data['axes'] = _build_axes(data['rows'], desc)
 
-    return build_export_html({arch: {kernel: data}}, url_params)
+        for arch_data in all_data.values():
+            for kdata in arch_data.values():
+                kdata['rows'] = [r for r in kdata['rows'] if _row_allowed(r)]
+                kdata['axes'] = _build_axes(kdata['rows'], desc)
+
+    return build_export_html(all_data, url_params)

--- a/.tune/webui/tasks.py
+++ b/.tune/webui/tasks.py
@@ -17,6 +17,8 @@ import re
 import logging
 from flask import current_app
 
+logger = logging.getLogger(__name__)
+
 # Global constant for aotriton root directory
 AOTRITON_ROOT = Path(__file__).parent.parent.parent.resolve()
 

--- a/.tune/webui/templates/base.html
+++ b/.tune/webui/templates/base.html
@@ -99,6 +99,7 @@
             <a href="/slurm">SLURM</a>
             <a href="/commands">Commands</a>
             <a href="/debug">Debug</a>
+            <a href="/perf">Perf</a>
         </nav>
     </header>
 

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -69,6 +69,7 @@
     </label>
 
     <button id="perf-refresh">Load</button>
+    <button id="perf-export" style="margin-left:0.5rem;" disabled title="Load data first">Download .zip</button>
   </div>
 
   <div style="margin-top:0.5rem;">

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -13,10 +13,11 @@
   #perf-layout-panel summary { cursor:pointer; font-weight:bold; }
   .dim-assignment { display:flex; gap:2rem; margin-top:0.5rem; flex-wrap:wrap; }
   .dim-assignment > div > strong { display:block; margin-bottom:0.3rem; }
-  .dim-chip { display:inline-flex; align-items:center; gap:0.3rem; margin:0.15rem;
+  .dim-chip { display:inline-flex; align-items:flex-start; gap:0.3rem; margin:0.15rem;
               padding:0.2rem 0.5rem; border:1px solid var(--border); border-radius:3px;
-              cursor:grab; user-select:none; }
-  .dim-chip input[type=checkbox] { margin:0; cursor:pointer; }
+              user-select:none; }
+  .dim-chip input[type=checkbox] { margin:0.2rem 0 0; cursor:pointer; flex-shrink:0; }
+  .dim-chip select[multiple] { font-size:0.9em; min-width:6rem; }
   .dim-chip.dragging { opacity:0.4; }
   .dim-drop-target { min-height:2rem; padding:0.2rem; border:1px dashed var(--border);
                      border-radius:3px; display:flex; flex-wrap:wrap; align-items:center; }

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -23,6 +23,7 @@
   .dim-drop-target.drag-over { outline:2px solid; }
   #perf-fixed-filters { margin-top:0.5rem; }
   #perf-grid { overflow-x:auto; }
+  #perf-grid > table { border-collapse:separate; border-spacing:4px; margin:0; }
   #perf-grid table { border-collapse:separate; border-spacing:4px; }
   #perf-grid th { font-size:1em; white-space:nowrap; }
   #perf-status { font-size:1em; margin-top:0.4rem; }

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -1,0 +1,128 @@
+{% extends "base.html" %}
+
+{% block title %}Performance{% endblock %}
+
+{% block content %}
+<h2>Performance Visualization</h2>
+
+<style>
+  #perf-config { border:1px solid var(--border); border-radius:4px; padding:1rem; margin-bottom:1rem; }
+  #perf-config label { margin-right:0.8rem; }
+  #perf-config select { margin-right:0.4rem; }
+  #perf-layout-panel { margin-top:0.75rem; }
+  #perf-layout-panel summary { cursor:pointer; font-weight:bold; }
+  .dim-assignment { display:flex; gap:2rem; margin-top:0.5rem; flex-wrap:wrap; }
+  .dim-assignment > div > strong { display:block; margin-bottom:0.3rem; }
+  .dim-chip { display:inline-flex; align-items:center; gap:0.3rem; margin:0.15rem;
+              padding:0.2rem 0.5rem; border:1px solid var(--border); border-radius:3px;
+              cursor:grab; user-select:none; }
+  .dim-chip input[type=checkbox] { margin:0; cursor:pointer; }
+  .dim-chip.dragging { opacity:0.4; }
+  .dim-drop-target { min-height:2rem; padding:0.2rem; border:1px dashed var(--border);
+                     border-radius:3px; display:flex; flex-wrap:wrap; align-items:center; }
+  .dim-drop-target.drag-over { outline:2px solid; }
+  #perf-fixed-filters { margin-top:0.5rem; }
+  #perf-grid { overflow-x:auto; }
+  #perf-grid table { border-collapse:separate; border-spacing:4px; }
+  #perf-grid th { font-size:1em; white-space:nowrap; }
+  #perf-status { font-size:1em; margin-top:0.4rem; }
+  .scale-user-input { display:none; margin-left:0.3rem; width:6rem; }
+</style>
+
+<section id="perf-config">
+  <div>
+    <label>Arch:
+      <select id="perf-arch">
+        {% for arch in archs %}
+        <option value="{{ arch }}">{{ arch }}</option>
+        {% endfor %}
+      </select>
+    </label>
+
+    <label>Mode:
+      <select id="perf-mode">
+        <option value="kernel">Kernel</option>
+        <option value="op">Op</option>
+      </select>
+    </label>
+
+    <label>Kernel / Op:
+      <select id="perf-kernel">
+        <optgroup label="Kernels">
+          <option value="attn_fwd">attn_fwd</option>
+          <option value="bwd_kernel_dk_dv">bwd_kernel_dk_dv</option>
+          <option value="bwd_kernel_dq">bwd_kernel_dq</option>
+          <option value="bwd_kernel_fuse">bwd_kernel_fuse</option>
+        </optgroup>
+        <optgroup label="Ops">
+          <option value="attn_fwd_op">attn_fwd_op</option>
+          <option value="attn_bwd_op">attn_bwd_op</option>
+        </optgroup>
+      </select>
+    </label>
+
+    <label>Display:
+      <select id="perf-display">
+        <option value="heatmap">Heatmap</option>
+        <option value="3d">3-D bars</option>
+      </select>
+    </label>
+
+    <button id="perf-refresh">Load</button>
+  </div>
+
+  <div style="margin-top:0.5rem;">
+    <label>Scale:
+      <select id="perf-scale">
+        <option value="max_observed">Max observed (default)</option>
+        <option value="theoretical">Theoretical peak</option>
+        <option value="user">User-defined</option>
+      </select>
+    </label>
+    <input id="perf-scale-value" class="scale-user-input" type="number" min="0" step="1"
+           placeholder="TFLOPS" title="Absolute TFLOPS anchor">
+  </div>
+
+  <details id="perf-layout-panel">
+    <summary>Dimension layout</summary>
+    <div class="dim-assignment">
+      <div>
+        <strong>Column dims</strong>
+        <div id="perf-col-dims" class="dim-drop-target" data-role="col"></div>
+      </div>
+      <div>
+        <strong>Row dims</strong>
+        <div id="perf-row-dims" class="dim-drop-target" data-role="row"></div>
+      </div>
+      <div>
+        <strong>Fixed filters</strong>
+        <div id="perf-fixed-filters" class="dim-drop-target" data-role="fixed"></div>
+      </div>
+    </div>
+  </details>
+
+  <div id="perf-status"></div>
+</section>
+
+<div id="perf-grid">
+  <p>Select arch and kernel, then click Load.</p>
+</div>
+
+<!-- Load Plotly from CDN; falls back to locally cached copy if CDN fails. -->
+<script
+  src="https://cdn.jsdelivr.net/npm/plotly.js-basic-dist@2.35.2/plotly.basic.min.js"
+  crossorigin="anonymous"
+  onerror="loadFallbackPlotly()">
+</script>
+<script>
+function loadFallbackPlotly() {
+  var s = document.createElement('script');
+  s.src = '/static/cache/plotly.basic.min.js';
+  document.head.appendChild(s);
+}
+</script>
+
+<script src="{{ url_for('static', filename='js/perf.js') }}"></script>
+<script src="{{ url_for('static', filename='js/vis_descriptors/flash.js') }}"></script>
+<script>registerDescriptor(FLASH_DESCRIPTOR);</script>
+{% endblock %}

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -39,13 +39,6 @@
       </select>
     </label>
 
-    <label>Mode:
-      <select id="perf-mode">
-        <option value="kernel">Kernel</option>
-        <option value="op">Op</option>
-      </select>
-    </label>
-
     <label>Kernel / Op:
       <select id="perf-kernel">
         <optgroup label="Kernels">

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -21,7 +21,6 @@
   .dim-drop-target { min-height:2rem; padding:0.2rem; border:1px dashed var(--border);
                      border-radius:3px; display:flex; flex-wrap:wrap; align-items:center; }
   .dim-drop-target.drag-over { outline:2px solid; }
-  #perf-fixed-filters { margin-top:0.5rem; }
   #perf-grid { overflow-x:auto; }
   #perf-grid table { border-collapse:separate; border-spacing:4px; margin:0; width:auto; }
   #perf-grid th { font-size:1em; white-space:nowrap; }
@@ -87,10 +86,6 @@
       <div>
         <strong>Row dims</strong>
         <div id="perf-row-dims" class="dim-drop-target" data-role="row"></div>
-      </div>
-      <div>
-        <strong>Fixed filters</strong>
-        <div id="perf-fixed-filters" class="dim-drop-target" data-role="fixed"></div>
       </div>
     </div>
   </details>

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -106,7 +106,7 @@
 
 <!-- Load Plotly from CDN; falls back to locally cached copy if CDN fails. -->
 <script
-  src="https://cdn.jsdelivr.net/npm/plotly.js-basic-dist@2.35.2/plotly.basic.min.js"
+  src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js"
   crossorigin="anonymous"
   onerror="loadFallbackPlotly()">
 </script>

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -39,18 +39,8 @@
     </label>
 
     <label>Kernel / Op:
-      <select id="perf-kernel">
-        <optgroup label="Kernels">
-          <option value="attn_fwd">attn_fwd</option>
-          <option value="bwd_kernel_dk_dv">bwd_kernel_dk_dv</option>
-          <option value="bwd_kernel_dq">bwd_kernel_dq</option>
-          <option value="bwd_kernel_fuse">bwd_kernel_fuse</option>
-        </optgroup>
-        <optgroup label="Ops">
-          <option value="attn_fwd_op">attn_fwd_op</option>
-          <option value="attn_bwd_op">attn_bwd_op</option>
-        </optgroup>
-      </select>
+      <!-- Populated at runtime from the active descriptor (see populateKernelSelect in perf.js). -->
+      <select id="perf-kernel"></select>
     </label>
 
     <label>Display:

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -58,6 +58,7 @@
       <select id="perf-display">
         <option value="heatmap">Heatmap</option>
         <option value="3d">3-D bars</option>
+        <option value="autozoom">Autozoom</option>
       </select>
     </label>
 

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -56,9 +56,9 @@
 
     <label>Display:
       <select id="perf-display">
+        <option value="autozoom" selected>Autozoom</option>
         <option value="heatmap">Heatmap</option>
         <option value="3d">3-D bars</option>
-        <option value="autozoom">Autozoom</option>
       </select>
     </label>
 

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -61,6 +61,13 @@
       </select>
     </label>
 
+    <label id="perf-az-mode-label">Autozoom TFLOPS:
+      <select id="perf-az-mode">
+        <option value="max_load">Max load (default)</option>
+        <option value="max_tflops">Max TFLOPS</option>
+      </select>
+    </label>
+
     <button id="perf-refresh">Load</button>
   </div>
 

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -109,7 +109,7 @@
 <script
   src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js"
   crossorigin="anonymous"
-  onerror="(function(){var s=document.createElement('script');s.src='/static/cache/plotly.basic.min.js';document.head.appendChild(s);})()">
+  onerror="(function(){var s=document.createElement('script');s.src='/static/cache/plotly.min.js';document.head.appendChild(s);})()">
 </script>
 
 <script src="{{ url_for('static', filename='js/perf.js') }}"></script>

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -104,18 +104,11 @@
   <p>Select arch and kernel, then click Load.</p>
 </div>
 
-<!-- Load Plotly from CDN; falls back to locally cached copy if CDN fails. -->
+<!-- Plotly for 3-D bars; falls back to locally cached copy if CDN is unreachable. -->
 <script
   src="https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js"
   crossorigin="anonymous"
-  onerror="loadFallbackPlotly()">
-</script>
-<script>
-function loadFallbackPlotly() {
-  var s = document.createElement('script');
-  s.src = '/static/cache/plotly.basic.min.js';
-  document.head.appendChild(s);
-}
+  onerror="(function(){var s=document.createElement('script');s.src='/static/cache/plotly.basic.min.js';document.head.appendChild(s);})()">
 </script>
 
 <script src="{{ url_for('static', filename='js/perf.js') }}"></script>

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -23,8 +23,7 @@
   .dim-drop-target.drag-over { outline:2px solid; }
   #perf-fixed-filters { margin-top:0.5rem; }
   #perf-grid { overflow-x:auto; }
-  #perf-grid > table { border-collapse:separate; border-spacing:4px; margin:0; }
-  #perf-grid table { border-collapse:separate; border-spacing:4px; }
+  #perf-grid table { border-collapse:separate; border-spacing:4px; margin:0; width:auto; }
   #perf-grid th { font-size:1em; white-space:nowrap; }
   #perf-status { font-size:1em; margin-top:0.4rem; }
   .scale-user-input { display:none; margin-left:0.3rem; width:6rem; }

--- a/.tune/webui/templates/perf.html
+++ b/.tune/webui/templates/perf.html
@@ -17,7 +17,6 @@
               padding:0.2rem 0.5rem; border:1px solid var(--border); border-radius:3px;
               user-select:none; }
   .dim-chip input[type=checkbox] { margin:0.2rem 0 0; cursor:pointer; flex-shrink:0; }
-  .dim-chip select[multiple] { font-size:0.9em; min-width:6rem; }
   .dim-chip.dragging { opacity:0.4; }
   .dim-drop-target { min-height:2rem; padding:0.2rem; border:1px dashed var(--border);
                      border-radius:3px; display:flex; flex-wrap:wrap; align-items:center; }

--- a/v3python/tune/pq/export_visperf.py
+++ b/v3python/tune/pq/export_visperf.py
@@ -1,0 +1,89 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Export a self-contained performance visualization HTML file.
+
+The output is a single .html file with all chart data inlined as JSON and
+all JS logic inlined from perf.js / vis_descriptors/flash.js.  Plotly.js is
+loaded from CDN (no fallback — the file is intended for online use or GitHub
+Pages).
+
+Usage:
+    python -m v3python.tune.pq.export_visperf --workdir <workdir> --output perf.html
+"""
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import psycopg
+
+from .visperf import query_all_best_results
+from ..utils import get_db_connection_params
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s',
+                    datefmt='%H:%M:%S')
+logger = logging.getLogger(__name__)
+
+# Paths to JS sources (relative to this file's parent = v3python/tune/pq/).
+_HERE = Path(__file__).parent
+_WEBUI_JS = _HERE.parent.parent.parent / '.tune' / 'webui' / 'static' / 'js'
+_FLASH_JS = _WEBUI_JS / 'vis_descriptors' / 'flash.js'
+_PERF_JS  = _WEBUI_JS / 'perf.js'
+_TEMPLATE = _HERE / 'visperf_template.html'
+
+# CDN URL with exact semver pin.
+PLOTLY_CDN = (
+    'https://cdn.jsdelivr.net/npm/plotly.js-basic-dist@2.35.2/plotly.basic.min.js'
+)
+
+
+def export_visperf(conn, output_path: Path) -> None:
+    """Generate self-contained perf.html from live database."""
+    logger.info('Querying all best results (all arches, all kernels)…')
+    data = query_all_best_results(conn)
+    total = sum(len(kd['rows']) for ad in data.values() for kd in ad.values())
+    logger.info('Fetched %d rows across %d arches', total, len(data))
+
+    flash_js = _FLASH_JS.read_text()
+    perf_js  = _PERF_JS.read_text()
+    template = _TEMPLATE.read_text()
+
+    html = (template
+            .replace('__PERF_DATA__', json.dumps(data, separators=(',', ':')))
+            .replace('__PLOTLY_CDN__', PLOTLY_CDN)
+            .replace('// __FLASH_JS__', flash_js)
+            .replace('// __PERF_JS__', perf_js))
+
+    output_path.write_text(html, encoding='utf-8')
+    logger.info('Written %d bytes to %s', len(html), output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument('--workdir', help='Project workdir containing config.rc')
+    src.add_argument('--host', help='PostgreSQL host')
+    parser.add_argument('--port', type=int, default=5432)
+    parser.add_argument('--user')
+    parser.add_argument('--password')
+    parser.add_argument('--output', required=True, type=Path,
+                        help='Output HTML file path (e.g. perf.html)')
+    args = parser.parse_args()
+
+    if args.workdir:
+        conn_params = get_db_connection_params(Path(args.workdir))
+    else:
+        conn_params = {'host': args.host, 'port': args.port}
+        if args.user:     conn_params['user'] = args.user
+        if args.password: conn_params['password'] = args.password
+
+    with psycopg.connect(**conn_params, autocommit=True) as conn:
+        export_visperf(conn, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/v3python/tune/pq/export_visperf.py
+++ b/v3python/tune/pq/export_visperf.py
@@ -5,9 +5,14 @@
 Export a self-contained performance visualization HTML file.
 
 The output is a single .html file with all chart data inlined as JSON and
-all JS logic inlined from perf.js / vis_descriptors/flash.js.  Plotly.js is
-loaded from CDN (no fallback — the file is intended for online use or GitHub
-Pages).
+all JS logic inlined from perf.js / vis_descriptors/flash.js. The 2-D
+heatmap and level-1 drilldown work fully offline; the 3-D mesh3d view
+requires Plotly.js, which is loaded from CDN (no inlined copy — Plotly is
+~4.5 MB and would bloat the export). Level-2 (psel × copt) drilldown is
+not included; it queries the live PostgreSQL backend.
+
+Also packaged as a .zip download by the /api/perf/export_zip route in
+.tune/webui/routes.py.
 
 Usage:
     python -m v3python.tune.pq.export_visperf --workdir <workdir> --output perf.html

--- a/v3python/tune/pq/export_visperf.py
+++ b/v3python/tune/pq/export_visperf.py
@@ -72,9 +72,9 @@ def build_export_html(data: dict, url_params: dict | None = None) -> str:
     url_params: optional dict of URL search params to pre-set on first load
                 (e.g. arch, kernel, display, scale, az_mode, col_dims, row_dims).
     """
-    flash_js = _FLASH_JS.read_text()
-    perf_js  = _PERF_JS.read_text()
-    template = _TEMPLATE.read_text()
+    flash_js = _FLASH_JS.read_text(encoding='utf-8')
+    perf_js  = _PERF_JS.read_text(encoding='utf-8')
+    template = _TEMPLATE.read_text(encoding='utf-8')
 
     initial_params = json.dumps(url_params or {}, separators=(',', ':'))
     data = _to_column_store(data)

--- a/v3python/tune/pq/export_visperf.py
+++ b/v3python/tune/pq/export_visperf.py
@@ -40,6 +40,27 @@ PLOTLY_CDN = (
 )
 
 
+def build_export_html(data: dict, url_params: dict | None = None) -> str:
+    """Build a self-contained HTML string from pre-fetched data.
+
+    data:       {arch: {kernel: {arch, kernel, axes, rows}}}
+    url_params: optional dict of URL search params to pre-set on first load
+                (e.g. arch, kernel, display, scale, az_mode, col_dims, row_dims).
+    """
+    flash_js = _FLASH_JS.read_text()
+    perf_js  = _PERF_JS.read_text()
+    template = _TEMPLATE.read_text()
+
+    initial_params = json.dumps(url_params or {}, separators=(',', ':'))
+
+    return (template
+            .replace('__PERF_DATA__', json.dumps(data, separators=(',', ':')))
+            .replace('__INITIAL_PARAMS__', initial_params)
+            .replace('__PLOTLY_CDN__', PLOTLY_CDN)
+            .replace('// __FLASH_JS__', flash_js)
+            .replace('// __PERF_JS__', perf_js))
+
+
 def export_visperf(conn, output_path: Path) -> None:
     """Generate self-contained perf.html from live database."""
     logger.info('Querying all best results (all arches, all kernels)…')
@@ -47,16 +68,7 @@ def export_visperf(conn, output_path: Path) -> None:
     total = sum(len(kd['rows']) for ad in data.values() for kd in ad.values())
     logger.info('Fetched %d rows across %d arches', total, len(data))
 
-    flash_js = _FLASH_JS.read_text()
-    perf_js  = _PERF_JS.read_text()
-    template = _TEMPLATE.read_text()
-
-    html = (template
-            .replace('__PERF_DATA__', json.dumps(data, separators=(',', ':')))
-            .replace('__PLOTLY_CDN__', PLOTLY_CDN)
-            .replace('// __FLASH_JS__', flash_js)
-            .replace('// __PERF_JS__', perf_js))
-
+    html = build_export_html(data)
     output_path.write_text(html, encoding='utf-8')
     logger.info('Written %d bytes to %s', len(html), output_path)
 

--- a/v3python/tune/pq/export_visperf.py
+++ b/v3python/tune/pq/export_visperf.py
@@ -36,7 +36,7 @@ _TEMPLATE = _HERE / 'visperf_template.html'
 
 # CDN URL with exact semver pin.
 PLOTLY_CDN = (
-    'https://cdn.jsdelivr.net/npm/plotly.js-basic-dist@2.35.2/plotly.basic.min.js'
+    'https://cdn.jsdelivr.net/npm/plotly.js-dist-min@2.35.2/plotly.min.js'
 )
 
 

--- a/v3python/tune/pq/export_visperf.py
+++ b/v3python/tune/pq/export_visperf.py
@@ -40,6 +40,26 @@ PLOTLY_CDN = (
 )
 
 
+def _to_column_store(data: dict) -> dict:
+    """Convert per-kernel rows from list-of-dicts to a column-store form.
+
+    Each {arch, kernel, axes, rows: [{col: val, ...}]} becomes
+         {arch, kernel, axes, cols: [...], rows: [[...]]}.
+    Rehydrated client-side in visperf_template.html's fetchData override.
+    """
+    for arch_data in data.values():
+        for kdata in arch_data.values():
+            rows = kdata.get('rows') or []
+            if not rows:
+                kdata['cols'] = []
+                kdata['rows'] = []
+                continue
+            cols = list(rows[0].keys())
+            kdata['cols'] = cols
+            kdata['rows'] = [[r.get(c) for c in cols] for r in rows]
+    return data
+
+
 def build_export_html(data: dict, url_params: dict | None = None) -> str:
     """Build a self-contained HTML string from pre-fetched data.
 
@@ -52,6 +72,7 @@ def build_export_html(data: dict, url_params: dict | None = None) -> str:
     template = _TEMPLATE.read_text()
 
     initial_params = json.dumps(url_params or {}, separators=(',', ':'))
+    data = _to_column_store(data)
 
     return (template
             .replace('__PERF_DATA__', json.dumps(data, separators=(',', ':')))

--- a/v3python/tune/pq/export_visperf.py
+++ b/v3python/tune/pq/export_visperf.py
@@ -21,6 +21,7 @@ Usage:
 import argparse
 import json
 import logging
+import re
 from pathlib import Path
 
 import psycopg
@@ -65,6 +66,23 @@ def _to_column_store(data: dict) -> dict:
     return data
 
 
+def _json_for_script(obj) -> str:
+    """json.dumps suitable for embedding directly inside <script>...</script>.
+
+    The HTML parser ends a <script> element at the first ``</`` (followed by
+    a valid tag name) — most importantly ``</script>``, but also ``<!--`` and
+    ``<script`` open new parsing states. ``json.dumps`` leaves ``/`` and
+    ``<`` untouched, so a string value containing ``</script>`` would break
+    out of the tag.
+
+    Replacing ``<`` with the JSON-equivalent ``\\u003c`` is the canonical
+    fix: it neutralizes all three problem sequences, the JSON parser
+    decodes the escape back to ``<`` transparently, and it requires no
+    changes on the consuming JS side (vs. e.g. base64).
+    """
+    return json.dumps(obj, separators=(',', ':')).replace('<', '\\u003c')
+
+
 def build_export_html(data: dict, url_params: dict | None = None) -> str:
     """Build a self-contained HTML string from pre-fetched data.
 
@@ -76,15 +94,19 @@ def build_export_html(data: dict, url_params: dict | None = None) -> str:
     perf_js  = _PERF_JS.read_text(encoding='utf-8')
     template = _TEMPLATE.read_text(encoding='utf-8')
 
-    initial_params = json.dumps(url_params or {}, separators=(',', ':'))
     data = _to_column_store(data)
-
-    return (template
-            .replace('__PERF_DATA__', json.dumps(data, separators=(',', ':')))
-            .replace('__INITIAL_PARAMS__', initial_params)
-            .replace('__PLOTLY_CDN__', PLOTLY_CDN)
-            .replace('// __FLASH_JS__', flash_js)
-            .replace('// __PERF_JS__', perf_js))
+    substitutions = {
+        '__PERF_DATA__':     _json_for_script(data),
+        '__INITIAL_PARAMS__': _json_for_script(url_params or {}),
+        '__PLOTLY_CDN__':    PLOTLY_CDN,
+        '// __FLASH_JS__':   flash_js,
+        '// __PERF_JS__':    perf_js,
+    }
+    # Single-pass substitution so a value that happens to contain another
+    # placeholder token (e.g. inlined JS mentioning `__PERF_DATA__`) cannot
+    # be re-substituted in a later step.
+    pattern = re.compile('|'.join(re.escape(k) for k in substitutions))
+    return pattern.sub(lambda m: substitutions[m.group(0)], template)
 
 
 def export_visperf(conn, output_path: Path) -> None:

--- a/v3python/tune/pq/vis_descriptors/__init__.py
+++ b/v3python/tune/pq/vis_descriptors/__init__.py
@@ -1,0 +1,9 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from .flash import FLASH_DESCRIPTOR
+
+# Registry: id -> descriptor dict
+DESCRIPTORS: dict[str, dict] = {
+    FLASH_DESCRIPTOR['id']: FLASH_DESCRIPTOR,
+}

--- a/v3python/tune/pq/vis_descriptors/flash.py
+++ b/v3python/tune/pq/vis_descriptors/flash.py
@@ -1,0 +1,40 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Python-side descriptor for flash attention kernels/ops.
+# Drives query construction in visperf.py.
+#
+# dims entries: (sql_expression, alias, cast)
+#   sql_expression: fragment used in SELECT and GROUP BY
+#   alias: column name in result rows and JS descriptor
+#   cast: SQL cast for type safety (informational; applied in sql_expression)
+
+FLASH_DESCRIPTOR: dict = {
+    'id': 'flash',
+    'label': 'Flash Attention',
+
+    # kernel-mode: best_tuning_results
+    'kernels': ['attn_fwd', 'bwd_kernel_dk_dv', 'bwd_kernel_dq', 'bwd_kernel_fuse'],
+    'kernel_table': 'best_tuning_results',
+    'kernel_name_col': 'kernel_name',
+
+    # op-mode: best_optune_results
+    'ops': ['attn_fwd_op', 'attn_bwd_op'],
+    'op_table': 'best_optune_results',
+    'op_name_col': 'op_name',
+
+    # Dimensions extracted from task_config->entry.
+    # Each entry: (sql_expression, alias)
+    # seqlen_q and seqlen_k are always included as the matrix axes.
+    'dims': [
+        ("task_config->'entry'->>'dtype'",                                               'dtype'),
+        ("(task_config->'entry'->>'hdim')::int",                                         'hdim'),
+        ("(task_config->'entry'->>'seqlen_q')::int",                                     'seqlen_q'),
+        ("(task_config->'entry'->>'seqlen_k')::int",                                     'seqlen_k'),
+        ("CASE WHEN (task_config->'entry'->>'causal')::bool THEN 1 ELSE 0 END",         'causal'),
+        ("(task_config->'entry'->>'bias_type')::int",                                    'bias_type'),
+        ("CASE WHEN (task_config->'entry'->>'dropout_p')::float > 0 THEN 1 ELSE 0 END", 'dropout'),
+    ],
+
+    'matrix_axes': ('seqlen_q', 'seqlen_k'),
+}

--- a/v3python/tune/pq/vis_descriptors/flash.py
+++ b/v3python/tune/pq/vis_descriptors/flash.py
@@ -4,10 +4,9 @@
 # Python-side descriptor for flash attention kernels/ops.
 # Drives query construction in visperf.py.
 #
-# dims entries: (sql_expression, alias, cast)
-#   sql_expression: fragment used in SELECT and GROUP BY
-#   alias: column name in result rows and JS descriptor
-#   cast: SQL cast for type safety (informational; applied in sql_expression)
+# dims entries: (sql_expression, alias)
+#   sql_expression: fragment used in SELECT and GROUP BY (cast inline if needed)
+#   alias: column name in result rows and the JS descriptor
 
 FLASH_DESCRIPTOR: dict = {
     'id': 'flash',

--- a/v3python/tune/pq/visperf.py
+++ b/v3python/tune/pq/visperf.py
@@ -24,7 +24,7 @@ def _build_query(desc: dict, arch: str, kernel_or_op: str, mode: str,
     if mode == 'op':
         table = desc['op_table']
         name_col = desc['op_name_col']
-        dim_selects = ',\n    '.join(f'b.{expr} AS {alias}' for expr, alias in desc['dims'])
+        dim_selects = ',\n    '.join(f'{expr} AS {alias}' for expr, alias in desc['dims'])
         dim_groups  = ', '.join(alias for _, alias in desc['dims'])
         # Join optune_results on the winning backend_index to get bim BATCH/N_HEADS.
         sql = f"""

--- a/v3python/tune/pq/visperf.py
+++ b/v3python/tune/pq/visperf.py
@@ -31,6 +31,7 @@ def _build_query(desc: dict, arch: str, kernel_or_op: str, mode: str,
             SELECT
                 {dim_selects},
                 b.median_time AS median_ms,
+                b.task_id     AS task_id,
                 (r.result_data->'bim'->>'BATCH')::int AS batch,
                 CASE
                     WHEN jsonb_typeof(r.result_data->'bim'->'N_HEADS') = 'array'
@@ -66,6 +67,7 @@ def _build_query(desc: dict, arch: str, kernel_or_op: str, mode: str,
         SELECT
             {dim_selects},
             b.median_time AS median_ms,
+            b.task_id     AS task_id,
             (r.result_data->'bim'->>'BATCH')::int AS batch,
             CASE
                 WHEN jsonb_typeof(r.result_data->'bim'->'N_HEADS') = 'array'
@@ -164,6 +166,91 @@ def query_all_best_results(conn, descriptor_id: str = 'flash') -> dict:
                 result[arch][op] = data
 
     return result
+
+
+def query_cell_detail(conn, task_id: int, kernel: str, mode: str = 'kernel') -> dict:
+    """
+    Fetch all candidate tuning_results / optune_results rows for a single
+    (task_id, kernel) cell, plus the per-(test_case, tensor_name) accuracy
+    threshold from most_accurate_tuning_results / most_accurate_optune_results.
+
+    Returns:
+        {
+          'task_id': int,
+          'kernel': str,
+          'mode': str,                # 'kernel' | 'op'
+          'candidates': [
+            {
+              'index': int,           # hsaco_index or backend_index
+              'median_ms': float|None,
+              'times': [float, ...],
+              'psels': {key: val, ...},
+              'copts': {key: val, ...},
+              'adiffs': {test_case: {tensor: [target, abs_err, ref_err], ...}, ...},
+              'result': str,          # OK/NotOK/crash/ERROR
+            },
+            ...
+          ],
+          'thresholds': [
+            {'test_case': str, 'tensor': str, 'absolute_error': float},
+            ...
+          ],
+        }
+    """
+    if mode == 'op':
+        results_table = 'optune_results'
+        accuracy_table = 'most_accurate_optune_results'
+        name_col = 'op_name'
+        idx_col = 'backend_index'
+    else:
+        results_table = 'tuning_results'
+        accuracy_table = 'most_accurate_tuning_results'
+        name_col = 'kernel_name'
+        idx_col = 'hsaco_index'
+
+    candidates: list[dict] = []
+    with conn.cursor() as cur:
+        cur.execute(f"""
+            SELECT {idx_col}, result, result_data
+              FROM {results_table}
+             WHERE task_id = %s AND {name_col} = %s
+             ORDER BY {idx_col}
+        """, (task_id, kernel))
+        for index, result, rd in cur:
+            rd = rd or {}
+            impl = rd.get('impl_desc') or {}
+            times = rd.get('times') or []
+            candidates.append({
+                'index': index,
+                'median_ms': float(times[0]) if times else None,
+                'times': [float(t) for t in times],
+                'psels': impl.get('psels') or {},
+                'copts': impl.get('copts') or {},
+                'adiffs': rd.get('adiffs') or {},
+                'result': result,
+            })
+
+    thresholds: list[dict] = []
+    with conn.cursor() as cur:
+        cur.execute(f"""
+            SELECT test_case, tensor_name, absolute_error
+              FROM {accuracy_table}
+             WHERE task_id = %s AND {name_col} = %s
+        """, (task_id, kernel))
+        for tc, tn, ae in cur:
+            thresholds.append({
+                'test_case': tc,
+                'tensor': tn,
+                'absolute_error': float(ae) if ae is not None else None,
+            })
+
+    return {
+        'task_id': task_id,
+        'kernel': kernel,
+        'mode': mode,
+        'candidates': candidates,
+        'thresholds': thresholds,
+    }
 
 
 _ARCH_ORDER = ['gfx942', 'gfx950', 'gfx1201', 'gfx90a', 'gfx1100']

--- a/v3python/tune/pq/visperf.py
+++ b/v3python/tune/pq/visperf.py
@@ -265,7 +265,12 @@ def query_cell_detail(conn, task_id: int, kernel: str, mode: str = 'kernel') -> 
 _ARCH_ORDER = ['gfx942', 'gfx950', 'gfx1201', 'gfx90a', 'gfx1100']
 
 def get_available_archs(conn, descriptor_id: str = 'flash') -> list[str]:
-    """Return arches present in best_tuning_results in preferred display order."""
+    """Return arches present in the descriptor's kernel_table, in display order.
+
+    Every operator in AOTriton is backed by one or more Triton kernels, so
+    querying kernel_table alone yields the complete set of arches the
+    library has been built for. There is no op-only arch to recover.
+    """
     desc = DESCRIPTORS[descriptor_id]
     with conn.cursor() as cur:
         cur.execute(f"SELECT DISTINCT arch FROM {desc['kernel_table']}")

--- a/v3python/tune/pq/visperf.py
+++ b/v3python/tune/pq/visperf.py
@@ -159,9 +159,13 @@ def query_all_best_results(conn, descriptor_id: str = 'flash') -> dict:
     return result
 
 
+_ARCH_ORDER = ['gfx942', 'gfx950', 'gfx1201', 'gfx90a', 'gfx1100']
+
 def get_available_archs(conn, descriptor_id: str = 'flash') -> list[str]:
-    """Return sorted list of arches present in best_tuning_results."""
+    """Return arches present in best_tuning_results in preferred display order."""
     desc = DESCRIPTORS[descriptor_id]
     with conn.cursor() as cur:
-        cur.execute(f"SELECT DISTINCT arch FROM {desc['kernel_table']} ORDER BY arch")
-        return [r[0] for r in cur.fetchall()]
+        cur.execute(f"SELECT DISTINCT arch FROM {desc['kernel_table']}")
+        archs = [r[0] for r in cur.fetchall()]
+    priority = {a: i for i, a in enumerate(_ARCH_ORDER)}
+    return sorted(archs, key=lambda a: (priority.get(a, len(_ARCH_ORDER)), a))

--- a/v3python/tune/pq/visperf.py
+++ b/v3python/tune/pq/visperf.py
@@ -17,30 +17,37 @@ def _build_query(desc: dict, arch: str, kernel_or_op: str, mode: str,
                  seqlen_min: int, seqlen_max: int) -> tuple[str, list]:
     """Build the SELECT query for a single kernel/op using the descriptor.
 
-    Joins tuning_results to retrieve BATCH and N_HEADS from result_data->'bim',
-    so the TFLOPS formula accounts for the actual benchmark dimensions.
-    For op-mode, result_data is not available; batch/n_heads default to 1.
+    Joins tuning_results (kernel mode) or optune_results (op mode) to retrieve
+    BATCH and N_HEADS from result_data->'bim', so the TFLOPS formula accounts
+    for the actual benchmark dimensions.
     """
     if mode == 'op':
         table = desc['op_table']
         name_col = desc['op_name_col']
-        # best_optune_results has no matching tuning_results join; use 1/1.
-        dim_selects = ',\n    '.join(f'{expr} AS {alias}' for expr, alias in desc['dims'])
+        dim_selects = ',\n    '.join(f'b.{expr} AS {alias}' for expr, alias in desc['dims'])
         dim_groups  = ', '.join(alias for _, alias in desc['dims'])
+        # Join optune_results on the winning backend_index to get bim BATCH/N_HEADS.
         sql = f"""
             SELECT
                 {dim_selects},
-                MIN(median_time) AS median_ms,
-                1 AS batch,
-                1 AS n_heads
-            FROM {table}
-            WHERE arch = %s
-              AND {name_col} = %s
-              AND (task_config->'entry'->>'seqlen_q')::int >= %s
-              AND (task_config->'entry'->>'seqlen_q')::int <= %s
-              AND (task_config->'entry'->>'seqlen_k')::int >= %s
-              AND (task_config->'entry'->>'seqlen_k')::int <= %s
-            GROUP BY {dim_groups}
+                b.median_time AS median_ms,
+                (r.result_data->'bim'->>'BATCH')::int AS batch,
+                CASE
+                    WHEN jsonb_typeof(r.result_data->'bim'->'N_HEADS') = 'array'
+                    THEN (r.result_data->'bim'->'N_HEADS'->0)::int
+                    ELSE (r.result_data->'bim'->>'N_HEADS')::int
+                END AS n_heads
+            FROM {table} b
+            JOIN optune_results r
+              ON r.task_id = b.task_id
+             AND r.{name_col} = b.{name_col}
+             AND r.backend_index = b.backend_index
+            WHERE b.arch = %s
+              AND b.{name_col} = %s
+              AND (b.task_config->'entry'->>'seqlen_q')::int >= %s
+              AND (b.task_config->'entry'->>'seqlen_q')::int <= %s
+              AND (b.task_config->'entry'->>'seqlen_k')::int >= %s
+              AND (b.task_config->'entry'->>'seqlen_k')::int <= %s
             ORDER BY {dim_groups}
         """
         params = [arch, kernel_or_op, seqlen_min, seqlen_max, seqlen_min, seqlen_max]

--- a/v3python/tune/pq/visperf.py
+++ b/v3python/tune/pq/visperf.py
@@ -91,7 +91,7 @@ def _build_query(desc: dict, arch: str, kernel_or_op: str, mode: str,
     return sql, params
 
 
-def _build_axes(rows: list[dict], desc: dict) -> dict:
+def build_axes(rows: list[dict], desc: dict) -> dict:
     """Compute sorted unique values for each dimension from the result rows."""
     axes: dict[str, list] = {}
     for _, alias in desc['dims']:
@@ -122,7 +122,7 @@ def query_best_results(conn, arch: str, kernel: str, mode: str = 'kernel',
         rows = cur.fetchall()
 
     rows = [dict(r) for r in rows]
-    axes = _build_axes(rows, desc)
+    axes = build_axes(rows, desc)
 
     return {
         'arch': arch,

--- a/v3python/tune/pq/visperf.py
+++ b/v3python/tune/pq/visperf.py
@@ -95,7 +95,7 @@ def _build_axes(rows: list[dict], desc: dict) -> dict:
     """Compute sorted unique values for each dimension from the result rows."""
     axes: dict[str, list] = {}
     for _, alias in desc['dims']:
-        vals = sorted({r[alias] for r in rows if r[alias] is not None})
+        vals = sorted({r.get(alias) for r in rows if r.get(alias) is not None})
         axes[alias] = vals
     return axes
 
@@ -145,10 +145,18 @@ def query_all_best_results(conn, descriptor_id: str = 'flash') -> dict:
     """
     desc = DESCRIPTORS[descriptor_id]
 
-    # Enumerate all arches
+    # Enumerate all arches. Union across kernel_table and op_table so
+    # descriptors that expose only ops (no kernel_table) still appear.
+    arch_tables = [t for t in (desc.get('kernel_table'), desc.get('op_table')) if t]
+    archs: list[str] = []
+    seen: set[str] = set()
     with conn.cursor() as cur:
-        cur.execute(f"SELECT DISTINCT arch FROM {desc['kernel_table']} ORDER BY arch")
-        archs = [r[0] for r in cur.fetchall()]
+        for tbl in arch_tables:
+            cur.execute(f"SELECT DISTINCT arch FROM {tbl} ORDER BY arch")
+            for (a,) in cur.fetchall():
+                if a not in seen:
+                    seen.add(a)
+                    archs.append(a)
 
     result: dict[str, dict[str, dict]] = {}
     for arch in archs:
@@ -197,6 +205,7 @@ def query_cell_detail(conn, task_id: int, kernel: str, mode: str = 'kernel') -> 
           ],
         }
     """
+    assert mode in ('kernel', 'op'), f"query_cell_detail: invalid mode {mode!r}"
     if mode == 'op':
         results_table = 'optune_results'
         accuracy_table = 'most_accurate_optune_results'

--- a/v3python/tune/pq/visperf.py
+++ b/v3python/tune/pq/visperf.py
@@ -1,0 +1,167 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Database query functions for performance visualization.
+
+All functions accept a psycopg connection object (caller manages lifecycle).
+Returns dicts ready for JSON serialization by the webui or export script.
+"""
+
+from psycopg.rows import dict_row
+
+from .vis_descriptors import DESCRIPTORS
+
+
+def _build_query(desc: dict, arch: str, kernel_or_op: str, mode: str,
+                 seqlen_min: int, seqlen_max: int) -> tuple[str, list]:
+    """Build the SELECT query for a single kernel/op using the descriptor.
+
+    Joins tuning_results to retrieve BATCH and N_HEADS from result_data->'bim',
+    so the TFLOPS formula accounts for the actual benchmark dimensions.
+    For op-mode, result_data is not available; batch/n_heads default to 1.
+    """
+    if mode == 'op':
+        table = desc['op_table']
+        name_col = desc['op_name_col']
+        # best_optune_results has no matching tuning_results join; use 1/1.
+        dim_selects = ',\n    '.join(f'{expr} AS {alias}' for expr, alias in desc['dims'])
+        dim_groups  = ', '.join(alias for _, alias in desc['dims'])
+        sql = f"""
+            SELECT
+                {dim_selects},
+                MIN(median_time) AS median_ms,
+                1 AS batch,
+                1 AS n_heads
+            FROM {table}
+            WHERE arch = %s
+              AND {name_col} = %s
+              AND (task_config->'entry'->>'seqlen_q')::int >= %s
+              AND (task_config->'entry'->>'seqlen_q')::int <= %s
+              AND (task_config->'entry'->>'seqlen_k')::int >= %s
+              AND (task_config->'entry'->>'seqlen_k')::int <= %s
+            GROUP BY {dim_groups}
+            ORDER BY {dim_groups}
+        """
+        params = [arch, kernel_or_op, seqlen_min, seqlen_max, seqlen_min, seqlen_max]
+        return sql, params
+
+    table = desc['kernel_table']
+    name_col = desc['kernel_name_col']
+
+    # Qualify column references with table alias to avoid ambiguity after JOIN.
+    dim_selects = ',\n    '.join(f'{expr} AS {alias}' for expr, alias in desc['dims'])
+    dim_groups  = ', '.join(alias for _, alias in desc['dims'])
+
+    # Join tuning_results on the exact winning row to get bim BATCH/N_HEADS.
+    # N_HEADS may be a JSON array (GQA); take the first element in that case.
+    sql = f"""
+        SELECT
+            {dim_selects},
+            b.median_time AS median_ms,
+            (r.result_data->'bim'->>'BATCH')::int AS batch,
+            CASE
+                WHEN jsonb_typeof(r.result_data->'bim'->'N_HEADS') = 'array'
+                THEN (r.result_data->'bim'->'N_HEADS'->0)::int
+                ELSE (r.result_data->'bim'->>'N_HEADS')::int
+            END AS n_heads
+        FROM {table} b
+        JOIN tuning_results r
+          ON r.task_id = b.task_id
+         AND r.kernel_name = b.kernel_name
+         AND r.hsaco_index = b.hsaco_index
+        WHERE b.arch = %s
+          AND b.{name_col} = %s
+          AND (b.task_config->'entry'->>'seqlen_q')::int >= %s
+          AND (b.task_config->'entry'->>'seqlen_q')::int <= %s
+          AND (b.task_config->'entry'->>'seqlen_k')::int >= %s
+          AND (b.task_config->'entry'->>'seqlen_k')::int <= %s
+        ORDER BY {dim_groups}
+    """
+    params = [arch, kernel_or_op, seqlen_min, seqlen_max, seqlen_min, seqlen_max]
+    return sql, params
+
+
+def _build_axes(rows: list[dict], desc: dict) -> dict:
+    """Compute sorted unique values for each dimension from the result rows."""
+    axes: dict[str, list] = {}
+    for _, alias in desc['dims']:
+        vals = sorted({r[alias] for r in rows if r[alias] is not None})
+        axes[alias] = vals
+    return axes
+
+
+def query_best_results(conn, arch: str, kernel: str, mode: str = 'kernel',
+                       seqlen_min: int = 0, seqlen_max: int = 65536,
+                       descriptor_id: str = 'flash') -> dict:
+    """
+    Query best tuning results for one arch+kernel (or op) combination.
+
+    Returns:
+        {
+          'arch': str,
+          'kernel': str,
+          'axes': {dim: [sorted unique values], ...},
+          'rows': [{dim: value, ..., 'median_ms': float}, ...]
+        }
+    """
+    desc = DESCRIPTORS[descriptor_id]
+    sql, params = _build_query(desc, arch, kernel, mode, seqlen_min, seqlen_max)
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+
+    rows = [dict(r) for r in rows]
+    axes = _build_axes(rows, desc)
+
+    return {
+        'arch': arch,
+        'kernel': kernel,
+        'axes': axes,
+        'rows': rows,
+    }
+
+
+def query_all_best_results(conn, descriptor_id: str = 'flash') -> dict:
+    """
+    Query best tuning results for ALL arches and kernels (for static export).
+
+    Returns:
+        {
+          arch: {
+            kernel: {arch, kernel, axes, rows}
+          }
+        }
+    """
+    desc = DESCRIPTORS[descriptor_id]
+
+    # Enumerate all arches
+    with conn.cursor() as cur:
+        cur.execute(f"SELECT DISTINCT arch FROM {desc['kernel_table']} ORDER BY arch")
+        archs = [r[0] for r in cur.fetchall()]
+
+    result: dict[str, dict[str, dict]] = {}
+    for arch in archs:
+        result[arch] = {}
+        for kernel in desc['kernels']:
+            data = query_best_results(conn, arch, kernel, mode='kernel',
+                                      descriptor_id=descriptor_id)
+            if data['rows']:
+                result[arch][kernel] = data
+
+        for op in desc['ops']:
+            data = query_best_results(conn, arch, op, mode='op',
+                                      descriptor_id=descriptor_id)
+            if data['rows']:
+                result[arch][op] = data
+
+    return result
+
+
+def get_available_archs(conn, descriptor_id: str = 'flash') -> list[str]:
+    """Return sorted list of arches present in best_tuning_results."""
+    desc = DESCRIPTORS[descriptor_id]
+    with conn.cursor() as cur:
+        cur.execute(f"SELECT DISTINCT arch FROM {desc['kernel_table']} ORDER BY arch")
+        return [r[0] for r in cur.fetchall()]

--- a/v3python/tune/pq/visperf_template.html
+++ b/v3python/tune/pq/visperf_template.html
@@ -96,11 +96,26 @@ const ALL_PERF_DATA = __PERF_DATA__;
 
 <script>
 // Static-export bootstrap: populate arch dropdown from inlined data,
-// then override fetchData to serve from ALL_PERF_DATA instead of the API.
+// restore any pre-set URL params, then override fetchData to serve from
+// ALL_PERF_DATA instead of the HTTP API.
 
 registerDescriptor(FLASH_DESCRIPTOR);
 
 (function() {
+  // Pre-set URL params injected at export time (empty object for full exports).
+  const INITIAL_PARAMS = __INITIAL_PARAMS__;
+
+  // Merge INITIAL_PARAMS into the URL if not already present so that
+  // restoreFromURL() in perf.js picks them up before initPerf() runs.
+  if (Object.keys(INITIAL_PARAMS).length) {
+    const p = new URLSearchParams(location.search);
+    let changed = false;
+    for (const [k, v] of Object.entries(INITIAL_PARAMS)) {
+      if (!p.has(k)) { p.set(k, v); changed = true; }
+    }
+    if (changed) history.replaceState(null, '', '?' + p);
+  }
+
   const archSel = document.getElementById('perf-arch');
   const archs = Object.keys(ALL_PERF_DATA).sort();
   archs.forEach(arch => {

--- a/v3python/tune/pq/visperf_template.html
+++ b/v3python/tune/pq/visperf_template.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AOTriton Performance Visualization</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: system-ui, sans-serif; max-width: none; margin: 0; padding: 1rem 2rem; }
+  h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+  #perf-config { border:1px solid; border-radius:4px; padding:1rem; margin-bottom:1rem; opacity:0.95; }
+  #perf-config label { margin-right:0.8rem; }
+  #perf-config select, #perf-config input { margin-right:0.4rem; }
+  #perf-fixed-filters { margin-top:0.5rem; }
+  #perf-grid { overflow-x:auto; }
+  #perf-grid table { border-collapse:separate; border-spacing:4px; }
+  #perf-grid th { font-size:0.82em; white-space:nowrap; }
+  #perf-status { font-size:0.85em; opacity:0.75; margin-top:0.4rem; }
+  .scale-user-input { display:none; width:6rem; }
+</style>
+</head>
+<body>
+
+<h1>AOTriton Performance Visualization</h1>
+
+<section id="perf-config">
+  <div>
+    <label>Arch:
+      <select id="perf-arch"></select>
+    </label>
+
+    <label>Mode:
+      <select id="perf-mode">
+        <option value="kernel">Kernel</option>
+        <option value="op">Op</option>
+      </select>
+    </label>
+
+    <label>Kernel / Op:
+      <select id="perf-kernel">
+        <optgroup label="Kernels">
+          <option value="attn_fwd">attn_fwd</option>
+          <option value="bwd_kernel_dk_dv">bwd_kernel_dk_dv</option>
+          <option value="bwd_kernel_dq">bwd_kernel_dq</option>
+          <option value="bwd_kernel_fuse">bwd_kernel_fuse</option>
+        </optgroup>
+        <optgroup label="Ops">
+          <option value="attn_fwd_op">attn_fwd_op</option>
+          <option value="attn_bwd_op">attn_bwd_op</option>
+        </optgroup>
+      </select>
+    </label>
+
+    <label>Display:
+      <select id="perf-display">
+        <option value="heatmap">Heatmap</option>
+        <option value="3d">3-D bars</option>
+      </select>
+    </label>
+
+    <button id="perf-refresh">Load</button>
+  </div>
+
+  <div style="margin-top:0.5rem;">
+    <label>Scale:
+      <select id="perf-scale">
+        <option value="max_observed">Max observed (default)</option>
+        <option value="theoretical">Theoretical peak</option>
+        <option value="user">User-defined</option>
+      </select>
+    </label>
+    <input id="perf-scale-value" class="scale-user-input" type="number" min="0" step="1"
+           placeholder="TFLOPS">
+  </div>
+
+  <div id="perf-fixed-filters"></div>
+  <div id="perf-status"></div>
+</section>
+
+<div id="perf-grid">
+  <p>Select arch and kernel, then click Load.</p>
+</div>
+
+<!-- Plotly CDN (exact semver pin) -->
+<script src="__PLOTLY_CDN__" crossorigin="anonymous"></script>
+
+<script>
+// Flash attention descriptor — auto-injected by export_visperf.py
+// __FLASH_JS__
+</script>
+
+<script>
+// Inlined data from PostgreSQL best_tuning_results / best_optune_results.
+// Keys: data[arch][kernel] = {arch, kernel, axes, rows}
+const ALL_PERF_DATA = __PERF_DATA__;
+</script>
+
+<script>
+// perf.js rendering engine — auto-injected by export_visperf.py
+// __PERF_JS__
+</script>
+
+<script>
+// Static-export bootstrap: populate arch dropdown from inlined data,
+// then override fetchData to serve from ALL_PERF_DATA instead of the API.
+
+registerDescriptor(FLASH_DESCRIPTOR);
+
+(function() {
+  const archSel = document.getElementById('perf-arch');
+  const archs = Object.keys(ALL_PERF_DATA).sort();
+  archs.forEach(arch => {
+    const opt = document.createElement('option');
+    opt.value = opt.textContent = arch;
+    archSel.appendChild(opt);
+  });
+
+  // Override fetchData so it reads from inlined JSON instead of HTTP.
+  window.fetchData = async function(arch, kernel, mode) {
+    const archData = ALL_PERF_DATA[arch] || {};
+    const d = archData[kernel] || { arch, kernel, axes: {}, rows: [] };
+    d.rows.forEach(r => { r._kernel = kernel; });
+    return d;
+  };
+})();
+</script>
+
+</body>
+</html>

--- a/v3python/tune/pq/visperf_template.html
+++ b/v3python/tune/pq/visperf_template.html
@@ -124,12 +124,29 @@ registerDescriptor(FLASH_DESCRIPTOR);
     archSel.appendChild(opt);
   });
 
+  // Rehydrate column-store rows (cols + rows[][]) into list-of-dicts the
+  // first time a (arch, kernel) is requested; cache the result in place.
+  function rehydrate(d, kernel) {
+    if (d._hydrated) return d;
+    const cols = d.cols || [];
+    if (cols.length && d.rows.length && Array.isArray(d.rows[0])) {
+      d.rows = d.rows.map(r => {
+        const o = { _kernel: kernel };
+        for (let i = 0; i < cols.length; i++) o[cols[i]] = r[i];
+        return o;
+      });
+    } else {
+      d.rows.forEach(r => { r._kernel = kernel; });
+    }
+    d._hydrated = true;
+    return d;
+  }
+
   // Override fetchData so it reads from inlined JSON instead of HTTP.
   window.fetchData = async function(arch, kernel, mode) {
     const archData = ALL_PERF_DATA[arch] || {};
-    const d = archData[kernel] || { arch, kernel, axes: {}, rows: [] };
-    d.rows.forEach(r => { r._kernel = kernel; });
-    return d;
+    const d = archData[kernel] || { arch, kernel, axes: {}, rows: [], cols: [] };
+    return rehydrate(d, kernel);
   };
 })();
 </script>

--- a/v3python/tune/pq/visperf_template.html
+++ b/v3python/tune/pq/visperf_template.html
@@ -29,13 +29,6 @@
       <select id="perf-arch"></select>
     </label>
 
-    <label>Mode:
-      <select id="perf-mode">
-        <option value="kernel">Kernel</option>
-        <option value="op">Op</option>
-      </select>
-    </label>
-
     <label>Kernel / Op:
       <select id="perf-kernel">
         <optgroup label="Kernels">

--- a/v3python/tune/pq/visperf_template.html
+++ b/v3python/tune/pq/visperf_template.html
@@ -46,9 +46,9 @@
 
     <label>Display:
       <select id="perf-display">
+        <option value="autozoom" selected>Autozoom</option>
         <option value="heatmap">Heatmap</option>
         <option value="3d">3-D bars</option>
-        <option value="autozoom">Autozoom</option>
       </select>
     </label>
 

--- a/v3python/tune/pq/visperf_template.html
+++ b/v3python/tune/pq/visperf_template.html
@@ -48,6 +48,7 @@
       <select id="perf-display">
         <option value="heatmap">Heatmap</option>
         <option value="3d">3-D bars</option>
+        <option value="autozoom">Autozoom</option>
       </select>
     </label>
 

--- a/v3python/tune/pq/visperf_template.html
+++ b/v3python/tune/pq/visperf_template.html
@@ -35,18 +35,8 @@
     </label>
 
     <label>Kernel / Op:
-      <select id="perf-kernel">
-        <optgroup label="Kernels">
-          <option value="attn_fwd">attn_fwd</option>
-          <option value="bwd_kernel_dk_dv">bwd_kernel_dk_dv</option>
-          <option value="bwd_kernel_dq">bwd_kernel_dq</option>
-          <option value="bwd_kernel_fuse">bwd_kernel_fuse</option>
-        </optgroup>
-        <optgroup label="Ops">
-          <option value="attn_fwd_op">attn_fwd_op</option>
-          <option value="attn_bwd_op">attn_bwd_op</option>
-        </optgroup>
-      </select>
+      <!-- Populated at runtime from the active descriptor (see populateKernelSelect in perf.js). -->
+      <select id="perf-kernel"></select>
     </label>
 
     <label>Display:

--- a/v3python/tune/pq/visperf_template.html
+++ b/v3python/tune/pq/visperf_template.html
@@ -17,6 +17,11 @@
   #perf-grid th { font-size:0.82em; white-space:nowrap; }
   #perf-status { font-size:0.85em; opacity:0.75; margin-top:0.4rem; }
   .scale-user-input { display:none; width:6rem; }
+  /* Match live webui (base.html): enforce a readable minimum on the monospace
+     perf table cells, which perf.js styles at 0.8em. */
+  code, pre, kbd, samp, var,
+  *[style*="monospace"],
+  .monospace { font-size: max(12pt, 1em) !important; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
# Overview

This PR adds a Performance Visualization (`visperf`) tab at `/perf` with a
multi-level drilldown heatmap, and a Download `.zip` button that emits a single
self-contained HTML for GitHub Pages / offline review.

## Major Changes

* [webui] New `/perf` page: nested feature-grid heatmap with three
  drilldown levels — autozoom overview → seqlen heatmap → `psel × copt`.
  + Color scale anchors: per-dtype `max_observed` (default, scoped to
    visible rows), theoretical peak, or user TFLOPS. Hue fraction is
    log-scaled across the red→blue palette.
  + Autozoom picks one representative cell per inner heatmap by `max_load` or
    `max_tflops`.
  + Level-2 marks accuracy-gate failures with a black `✕` over a white halo.
  + Row and column dim chips are reorderable by drag-and-drop, and each
    chip can be pinned to a single value to slice the grid instead of
    expanding all combinations.
  + 3-D display mode renders the autozoom grid as a single Plotly `mesh3d`
    figure — bar **height** encodes TFLOPS in addition to color, so under-
    performing cells are visible at a glance even when hues are close.
      - Based on `plotly.basic.min.js`, cached in `<workdir>/scratch/webcache/`
        to reduce CDN access for LAN environment.
  + View URLs are bookmarkable: the current arch, kernel, display mode,
    color scale, dim layout, and active filters all round-trip through
    the URL, so reloading or sharing a link reproduces the exact view.

* [webui] Download `.zip` button (`POST /api/perf/export_zip`) emits a
  self-contained autozoom HTML covering **every** arch and kernel/op in
  the database, regardless of toolbar selection.
  + Row payload is column-store (`cols: [...], rows: [[...]]`) and
    rehydrated client-side, shrinking the export from ~82 MB to ~22 MB.
  + Also runnable as `python -m v3python.tune.pq.export_visperf`.

* [pq] Add `query_best_results` to pull the real `BATCH` and `N_HEADS` from
  `result_data->'bim'`, so TFLOPS reflects the benchmarked workload instead of
  assuming 1×1.

## Note

The visualization framework is designed to be extensible. New kernel
families (e.g. GEMM, conv) — or new kernels within the same family —
are onboarded by adding a descriptor; the rendering, drilldown, and
export pipeline stay untouched. The current flash descriptors at
`v3python/tune/pq/vis_descriptors/flash.py` (SQL side) and
`.tune/webui/static/js/vis_descriptors/flash.js` (JS side) serve as
the reference implementation.

# Known Limitations

* Level-2 (`psel × copt`) drilldown is **not** included in the Download
  `.zip` export — inlining all Level-2 data would balloon the file to ~30 GB.
