### PR TITLE
test/attn_torch_function: reset persistent atomic tile counter between is_testing pre-flight and real attn_fwd

### DIFF
--- a/test/attn_torch_function.py
+++ b/test/attn_torch_function.py
@@ -174,6 +174,14 @@ class _attention(torch.autograd.Function):
             if PROBE_UNSUPPORTED and ret == hipError_t.hipErrorPeerAccessUnsupported:
                 raise NotImplementedError()
             assert ret == hipError_t.hipSuccess, ret
+            # Reset the persistent atomic tile counter between the pre-flight
+            # probe call and the real call. Without this, the second attn_fwd
+            # sees the counter already at num_tiles_total + Num_WG and the
+            # persistent loop body never executes -- the real call becomes a
+            # no-op, and any NaN-prefilled cells in o/M survive into the
+            # is_testing assert below.
+            if causal:
+                atomic.zero_()
 
         ret = attn_fwd(q, k, v, b, sm_scale, M, o,
                        dropout_p, philox_seed, philox_offset1, philox_offset2,


### PR DESCRIPTION
## Summary

When `attn_extra_args.is_testing` is True (always under the pytest suite), `_attention.forward()` calls `attn_fwd` twice back-to-back &mdash; once as a pre-flight probe (to verify the kernel accepts nullptr `philox_*_output`), then the real call. Both calls share the `persistent_atomic_counter` (`atomic`) tensor that is zero-initialised only once before the first call.

The persistent FA-forward kernel draws tile ids via `atomic_add(1)` and loops `while tile_id < num_tiles_total`. After the pre-flight call, `atomic[0]` sits at `num_tiles_total + Num_WG`. On entry to the real call, every workgroup's first `atomic_add` returns a value `>= num_tiles_total`, so the `while` loop body never executes &mdash; **the real call is a no-op**. The wrapper allocates `o`/`M` once and (with `fillnan=True`, set by `_core_test_backward.py`) pre-fills them with NaN. Call #1 writes valid values; call #2 leaves them untouched. Any cell call #1 didn't overwrite still contains its NaN sentinel and trips the `assert not torch.isnan(M).any()` check at line ~215.

## Fix

One-line `atomic.zero_()` between the two `attn_fwd` calls, guarded by `if causal:` to mirror the allocation-site guard a few lines above (`atomic` is `torch.zeros(...)` only when `causal=True`; otherwise it's an empty tensor).

## Verification

Reran a stratified subset of 19 originally-failing test IDs (covering both `test_regular_bwd` and `test_irregulars`, hdim=80 and hdim=24, seqlen_q from 16 to 8192, both `Storage` flips, both `BiasOff`/`BiasOn`) &times; 10 reruns each = **190/190 PASS** with the patched wrapper.