### PR TITLE
v3python/rules/flash/attn_fwd: disable PERSISTENT_TYPE=2 for fp32 hdim=80 causal on RDNA3.5

### DIFF
--- a/v3python/rules/flash/attn_fwd.py
+++ b/v3python/rules/flash/attn_fwd.py
@@ -33,6 +33,22 @@ class attn_fwd(FlashKernel):
     # Note: There is no other FWD metro kernel right now so the arguments are shared
     ARGUMENTS = OpAttnFwd.ARGUMENTS
 
+    def translate_dataframe(self, f, df):
+        '''
+        Workaround for gfx1150 (RDNA3.5) persistent-scheduler race on
+        fp32 hdim=80 causal kernels (F_F_3_0 family). The persistent_atomic_counter
+        handoff between WGs produces L=NaN / out=NaN at rates of 250-400/500
+        on affected shapes. gfx1151 (also RDNA3.5) is unaffected. Force
+        PERSISTENT_TYPE=0 (non-persistent grid) post-DB-lookup. The launcher
+        in v3src/flash/attn_fwd.cc already handles PT=0 correctly.
+        '''
+        dtype = check_value(f, ['Q'])
+        HEAD_DIM = check_value(f, ['BLOCK_DMODEL'])
+        if f.arch == 'gfx1150' and ('*fp32' in dtype) and HEAD_DIM == 80:
+            df = df.copy()
+            df['tuned_kernel$PERSISTENT_TYPE'] = 0
+        return super().translate_dataframe(f, df)
+
     def is_functional_disabled(self, functional):
         # FIXME: check if compiler fixes this at every release
         # gfx950 compiler has known numerical error on hdim == 16


### PR DESCRIPTION
## Summary

Workaround for a persistent-scheduler race on gfx1150 (RDNA3.5) silicon
on the fp32 hdim=80 causal attention forward kernel
(F_F_3_0 / F_T_3_0 / T_F_3_0 / T_T_3_0 families). The persistent_atomic_counter
inter-WG handoff is racy on this chip, leaving destination tensors unwritten
on a fraction of tiles. In our probes the output `o` and the LSE `L`
keep their pre-launch contents (NaN-prefilled in the probe; whatever was
allocated in production) on 50-80% of trials for `(3,5,256,32,80)` and 6-36%
for `(3,5,64,32,80)` / `(3,5,64,64,80)`.

## Diagnosis

- The persistent path uses `persistent_atomic_counter.atomic_add(1)` to draw the next tile id and a smaller-than-grid launch `min(NUM_CU * GRID_CU_MULTIP, num_tiles)`. On gfx1150 the cross-workgroup counter handoff is racy when multiple tiles iterate, so some tiles are never executed.
- gfx1151 silicon with the **same** compiled HSACO is bit-clean, so this is a chip-specific issue, not a kernel/codegen bug.
- JIT-compiled equivalents are also clean (Phase 7), so this is not a compiler bug either.
- Smaller-grid shapes that the persistent path nonetheless handles in a single iteration per WG (e.g. `(3,5,8192,128,80)`) stay clean. The race scales with the number of inter-WG counter exchanges, consistent with a handoff problem.

## Fix

Override `translate_dataframe` on `attn_fwd` to force `PERSISTENT_TYPE=0`
post-DB-lookup, only for `arch==gfx1150 AND fp32 AND hdim==80`. The
launcher in `v3src/flash/attn_fwd.cc` already supports `PERSISTENT_TYPE==0`
and dispatches a regular `dim3{S, H, B}` grid with no atomic counter, so no
C++ change is needed.

## Verification (N=500 per shape, two seed bases)

| shape                  | role     | before    | after run A | after run B |
| ---------------------- | -------- | --------- | ----------- | ----------- |
| `(3,5,256,32,80)`      | racy     | ~325/500  | 0/500       | 0/500       |
| `(3,5,64,64,80)`       | racy     | ~105/500  | 0/500       | 0/500       |
| `(3,5,64,32,80)`       | racy     | ~80/500   | 0/500       | 0/500       |
| `(3,5,8192,128,80)`    | control  | 0/500     | 0/500       | 0/500       |
| `(3,5,128,32,80)`      | control  | 0/500     | 0/500       | 0/500       |

## Scope and performance

The workaround is intentionally tight:
- Only `gfx1150` triggers it. `gfx1151` / `gfx1152` / `gfx1153` (which share the `gfx115x` binaries) continue to use the default PT=2 persistent grid.
- Only fp32 AND hdim==80 triggers it. Other dtypes (fp16, bf16) and other hdims are unaffected.
- fp32 attention is uncommon in production workloads, so the performance impact is minimal even for the affected combination.

## Test plan
- [x] N=500 probe on five shapes, two seed bases, all clean
- [ ] Re-tune the disabled persistent rows so the non-persistent autotune choices are well-tuned for `gfx1150`
- [ ] Long-term: root-cause the silicon-level race so the workaround can be retired or scoped further
