### PR TITLE
[Tech Preview] Initial GFX1250 support Rev.2

### DIFF
--- a/.ci/0.12.50b.yaml
+++ b/.ci/0.12.50b.yaml
@@ -1,5 +1,5 @@
 venvs:
-  gfx1250: ea7ab5f9c0ff5745706bae25f39dc79f870a9daa
+  gfx1250: 62e7ab2012114facfbec892fa8d646e0fa08a61f
 rules:
   - matches:  # String matches (identical)
       arch: gfx1250

--- a/.ci/releasesuite-git-head.sh
+++ b/.ci/releasesuite-git-head.sh
@@ -35,8 +35,7 @@ Options:
  --triton_origin <url>: Override the Triton git origin for wheel builds.
                         Accepts a fork URL or a local checkout via file:///abs/path
                         (default: https://github.com/ROCm/triton)
-By default both GPU images and runtimes are built.
-If either --image or --runtime is specified, the missing one will not be built.
+Either --image, --runtime, or both must be specified explicitly.
 
 The YAML configuration file follows the format shown in docs/AltWheelExample.yaml.
 However it accepts GIT SHA1 for Triton wheels instead.
@@ -57,11 +56,10 @@ fi
 
 eval set -- "$TEMP"
 
-SUITE_SELECT_IMAGE=-1
-SUITE_SELECT_RUNTIME=-1
+SUITE_SELECT_IMAGE=0
+SUITE_SELECT_RUNTIME=0
 SUITE_RUNTIME_LIST=(6.4.4 7.0.3 7.1.1 7.2.3)
 CMDLIST=()
-SUITE_DEFAULT_SELECTION=1
 SUITE_YAML=""
 SUITE_ORIGIN=""
 SUITE_TRITON_ORIGIN=""
@@ -75,11 +73,9 @@ while true; do
       ;;
     --image)
       SUITE_SELECT_IMAGE=1
-      SUITE_DEFAULT_SELECTION=0
       ;;
     --runtime)
       SUITE_SELECT_RUNTIME=1
-      SUITE_DEFAULT_SELECTION=0
       ;;
     --debug)
       SUITE_DEBUG=1
@@ -125,22 +121,14 @@ if [ "$#" -ne 1 ]; then
   help 1
 fi
 
-if [ ${#CMDLIST[@]} -gt 0 ] && [ ${SUITE_SELECT_IMAGE} -lt 0 ] && [ ${SUITE_SELECT_RUNTIME} -lt 0 ]; then
-  echo "Error: -r <ROCM ver> requires --runtime, --image, or both to be specified." >&2
+if [ ${SUITE_SELECT_IMAGE} -eq 0 ] && [ ${SUITE_SELECT_RUNTIME} -eq 0 ]; then
+  echo "Error: specify --runtime, --image, or both." >&2
   help 1
 fi
 
 if [ ${SUITE_DEBUG} -gt 0 ] && [ ${#SUITE_RUNTIME_LIST[@]} -ne 1 ]; then
   echo "Error: --debug requires exactly one runtime version via -r <ROCM ver>." >&2
   help 1
-fi
-
-if [ ${SUITE_SELECT_IMAGE} -lt 0 ]; then
-  SUITE_SELECT_IMAGE=${SUITE_DEFAULT_SELECTION}
-fi
-
-if [ ${SUITE_SELECT_RUNTIME} -lt 0 ]; then
-  SUITE_SELECT_RUNTIME=${SUITE_DEFAULT_SELECTION}
 fi
 
 echo "SUITE_RUNTIME_LIST ${SUITE_RUNTIME_LIST[@]}"

--- a/.ci/releasesuite-git-head.sh
+++ b/.ci/releasesuite-git-head.sh
@@ -27,6 +27,9 @@ Options:
                         forwarded to cmake as AOTRITON_TARGET_ARCH. Defaults
                         to ALL (every arch in the CMakeLists default list).
                         Useful to shorten debug builds.
+              --debug: Debug mode: require exactly one runtime version (-r),
+                        and leave the build container running after the build
+                        so the contents can be inspected interactively.
          --yaml <.yml>: Use yml config file to build the release
         --origin <url>: Override the git HTTPS origin URL (default: auto-detected from remote)
  --triton_origin <url>: Override the Triton git origin for wheel builds.
@@ -45,7 +48,7 @@ EOF
   exit $1
 }
 
-TEMP=$(getopt -o hr: --longoptions image,runtime,arch:,yaml:,origin:,triton_origin: -- "$@")
+TEMP=$(getopt -o hr: --longoptions image,runtime,debug,arch:,yaml:,origin:,triton_origin: -- "$@")
 
 if [ $? -ne 0 ]; then
   echo "Error: Invalid option." >&2
@@ -63,6 +66,7 @@ SUITE_YAML=""
 SUITE_ORIGIN=""
 SUITE_TRITON_ORIGIN=""
 SUITE_ARCH="ALL"
+SUITE_DEBUG=0
 
 while true; do
   case "$1" in
@@ -76,6 +80,9 @@ while true; do
     --runtime)
       SUITE_SELECT_RUNTIME=1
       SUITE_DEFAULT_SELECTION=0
+      ;;
+    --debug)
+      SUITE_DEBUG=1
       ;;
     --arch)
       shift
@@ -114,6 +121,11 @@ fi
 if [ "$#" -ne 1 ]; then
   echo "$@"
   echo 'Missing argument <output directory>.' >&2
+  help 1
+fi
+
+if [ ${SUITE_DEBUG} -gt 0 ] && [ ${#SUITE_RUNTIME_LIST[@]} -ne 1 ]; then
+  echo "Error: --debug requires exactly one runtime version via -r <ROCM ver>." >&2
   help 1
 fi
 
@@ -238,19 +250,33 @@ function build_inside() {
   fi
   # Cache pip downloads under <output>/.cache/pip on the host.
   mkdir -p "${CACHE_DIR}/pip"
+  # In debug mode allocate a tty so runc-manylinux-build-tar.sh can drop into
+  # an interactive shell after the build. Container is always removed on exit.
+  DEBUG_FLAGS=()
+  if [ ${SUITE_DEBUG} -gt 0 ]; then
+    DEBUG_FLAGS=(-t -e SUITE_DEBUG=1)
+  fi
   set -x
+  # Always bind-mount the build script from the host so the working-tree
+  # version is used without requiring a commit. In debug mode also allocate a
+  # TTY so the interactive shell at the end of the script works; the script is
+  # run by path (not piped via stdin) so stdin stays attached to the terminal.
+  TTY_FLAGS=()
+  [ ${SUITE_DEBUG} -gt 0 ] && TTY_FLAGS=(-t -e SUITE_DEBUG=1)
   docker run --network=host -i --rm \
     -v ${SOURCE_VOLUME}:/src:ro \
+    -v "$(realpath ${SCRIPT_DIR}/runc-manylinux-build-tar.sh)":/tmp/runc-manylinux-build-tar.sh:ro \
     --mount "type=bind,source=$(realpath ${OUTPUT_DIR}),target=/output" \
     --mount "type=bind,source=$(realpath ${CACHE_DIR}),target=/cache" \
     --tmpfs "/scratch:exec" \
     -e AOTRITON_BUILD_PATH=/scratch/build/aotriton \
     -e AOTRITON_INSTALL_PREFIX=/scratch/install \
     -e PIP_CACHE_DIR=/cache/pip \
+    "${TTY_FLAGS[@]}" \
     -w / \
     ${DOCKER_IMAGE} \
-    bash -l -s "${NOIMAGE_MODE}" "${WHEEL_CFG}" "${ARCH_LIST}" \
-    < "${SCRIPT_DIR}/runc-manylinux-build-tar.sh"
+    bash -l /tmp/runc-manylinux-build-tar.sh \
+    "${NOIMAGE_MODE}" "${WHEEL_CFG}" "${ARCH_LIST}"
 }
 
 if [ ${SUITE_SELECT_RUNTIME} -gt 0 ]; then

--- a/.ci/releasesuite-git-head.sh
+++ b/.ci/releasesuite-git-head.sh
@@ -126,8 +126,8 @@ if [ ${SUITE_SELECT_IMAGE} -eq 0 ] && [ ${SUITE_SELECT_RUNTIME} -eq 0 ]; then
   help 1
 fi
 
-if [ ${SUITE_DEBUG} -gt 0 ] && [ ${#SUITE_RUNTIME_LIST[@]} -ne 1 ]; then
-  echo "Error: --debug requires exactly one runtime version via -r <ROCM ver>." >&2
+if [ ${SUITE_DEBUG} -gt 0 ] && [ ${#CMDLIST[@]} -ne 1 ]; then
+  echo "Error: --debug requires exactly one runtime version specified via -r <ROCM ver>." >&2
   help 1
 fi
 
@@ -253,7 +253,7 @@ function build_inside() {
   set -x
   docker run --network=host -i --rm \
     -v ${SOURCE_VOLUME}:/src:ro \
-    -v "$(realpath ${SCRIPT_DIR}/runc-manylinux-build-tar.sh)":/tmp/runc-manylinux-build-tar.sh:ro \
+    --mount "type=bind,source=$(realpath ${SCRIPT_DIR}/runc-manylinux-build-tar.sh),target=/tmp/runc-manylinux-build-tar.sh,readonly" \
     --mount "type=bind,source=$(realpath ${OUTPUT_DIR}),target=/output" \
     --mount "type=bind,source=$(realpath ${CACHE_DIR}),target=/cache" \
     --tmpfs "/scratch:exec" \

--- a/.ci/releasesuite-git-head.sh
+++ b/.ci/releasesuite-git-head.sh
@@ -89,10 +89,11 @@ while true; do
       SUITE_ARCH="$1"
       ;;
     -r)
-      SUITE_SELECT_RUNTIME=1
-      SUITE_DEFAULT_SELECTION=0
       shift
       CMDLIST+=("$1")
+      # -r specifies the ROCm version list only; component selection (runtime
+      # vs image) is governed solely by --runtime / --image.  When neither is
+      # given, both components build (default behaviour unchanged).
       ;;
     --yaml)
       shift
@@ -121,6 +122,11 @@ fi
 if [ "$#" -ne 1 ]; then
   echo "$@"
   echo 'Missing argument <output directory>.' >&2
+  help 1
+fi
+
+if [ ${#CMDLIST[@]} -gt 0 ] && [ ${SUITE_SELECT_IMAGE} -lt 0 ] && [ ${SUITE_SELECT_RUNTIME} -lt 0 ]; then
+  echo "Error: -r <ROCM ver> requires --runtime, --image, or both to be specified." >&2
   help 1
 fi
 

--- a/.ci/releasesuite-git-head.sh
+++ b/.ci/releasesuite-git-head.sh
@@ -20,7 +20,8 @@ function help() {
 Usage: releasesuite-git-head.sh [-h] [options..] <output directory>
 Options:
                     -h: show help and exit.
-         -r <ROCM ver>: build ROCM runtime image
+         -r <ROCM ver>: override the ROCm version list (does not select a
+                        component; use with --runtime, --image, or both)
                --image: build GPU images.
              --runtime: build all C++ runtimes.
        --arch <list>: ';'-separated GPU arch list (e.g. 'gfx942;gfx950'),
@@ -87,9 +88,8 @@ while true; do
     -r)
       shift
       CMDLIST+=("$1")
-      # -r specifies the ROCm version list only; component selection (runtime
-      # vs image) is governed solely by --runtime / --image.  When neither is
-      # given, both components build (default behaviour unchanged).
+      # -r specifies the ROCm version list only; component selection is
+      # governed solely by --runtime / --image.  Omitting both is an error.
       ;;
     --yaml)
       shift
@@ -244,19 +244,13 @@ function build_inside() {
   fi
   # Cache pip downloads under <output>/.cache/pip on the host.
   mkdir -p "${CACHE_DIR}/pip"
-  # In debug mode allocate a tty so runc-manylinux-build-tar.sh can drop into
-  # an interactive shell after the build. Container is always removed on exit.
-  DEBUG_FLAGS=()
-  if [ ${SUITE_DEBUG} -gt 0 ]; then
-    DEBUG_FLAGS=(-t -e SUITE_DEBUG=1)
-  fi
-  set -x
   # Always bind-mount the build script from the host so the working-tree
   # version is used without requiring a commit. In debug mode also allocate a
   # TTY so the interactive shell at the end of the script works; the script is
   # run by path (not piped via stdin) so stdin stays attached to the terminal.
   TTY_FLAGS=()
   [ ${SUITE_DEBUG} -gt 0 ] && TTY_FLAGS=(-t -e SUITE_DEBUG=1)
+  set -x
   docker run --network=host -i --rm \
     -v ${SOURCE_VOLUME}:/src:ro \
     -v "$(realpath ${SCRIPT_DIR}/runc-manylinux-build-tar.sh)":/tmp/runc-manylinux-build-tar.sh:ro \

--- a/.ci/runc-manylinux-build-tar.sh
+++ b/.ci/runc-manylinux-build-tar.sh
@@ -85,6 +85,10 @@ fi
 # Debug: drop into interactive shell after everything is done so the full
 # build and install tree can be inspected. Requires -t from the caller.
 if [[ "${SUITE_DEBUG:-0}" == "1" ]]; then
-  echo "=== DEBUG MODE: build complete. Dropping into interactive shell. ===" >&2
-  bash -i </dev/tty >/dev/tty 2>&1 || true
+  if [ -t 0 ]; then
+    echo "=== DEBUG MODE: build complete. Dropping into interactive shell. ===" >&2
+    bash -i </dev/tty >/dev/tty 2>&1 || true
+  else
+    echo "=== DEBUG MODE: build complete, but no TTY available. Skipping interactive shell. ===" >&2
+  fi
 fi

--- a/.ci/runc-manylinux-build-tar.sh
+++ b/.ci/runc-manylinux-build-tar.sh
@@ -81,3 +81,10 @@ else
   tarfile=aotriton-${GIT_SHORT}-manylinux_2_28_x86_64-rocm${hipver}-shared.tar.gz
   cd "${AOTRITON_INSTALL_PREFIX}" && tar cz aotriton > /output/${tarfile}
 fi
+
+# Debug: drop into interactive shell after everything is done so the full
+# build and install tree can be inspected. Requires -t from the caller.
+if [[ "${SUITE_DEBUG:-0}" == "1" ]]; then
+  echo "=== DEBUG MODE: build complete. Dropping into interactive shell. ===" >&2
+  bash -i </dev/tty >/dev/tty 2>&1 || true
+fi

--- a/.ci/runc-manylinux-build-tar.sh
+++ b/.ci/runc-manylinux-build-tar.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Runs inside the AlmaLinux 8 ROCm Docker container (manylinux_2_28 environment).
-# Fed via stdin by build_inside() in releasesuite-git-head.sh; no bind mount needed.
+# Bind-mounted by build_inside() in releasesuite-git-head.sh at /tmp/runc-manylinux-build-tar.sh
+# and invoked as: bash -l /tmp/runc-manylinux-build-tar.sh <args>
 # Positional args: $1=NOIMAGE_MODE $2=WHEEL_CFG $3=ARCH_LIST
 #   ARCH_LIST: "ALL" (default) or a ';'-separated GPU arch list forwarded
 #   to build-release.sh as its arch_list arg (becomes AOTRITON_TARGET_ARCH).

--- a/v3src/util.cc
+++ b/v3src/util.cc
@@ -59,6 +59,7 @@ std::unordered_map<std::string, GpuClassifier> LazyGpu::string_to_classifier = {
   {"gfx1153", DummyClassifier<GPU_AMD_ARCH_GFX1153_MOD0>() },
   {"gfx1200", DummyClassifier<GPU_AMD_ARCH_GFX1200_MOD0>() },
   {"gfx1201", DummyClassifier<GPU_AMD_ARCH_GFX1201_MOD0>() },
+  {"gfx1250", DummyClassifier<GPU_AMD_ARCH_GFX1250_MOD0>() },
 };
 
 Gpu


### PR DESCRIPTION
# Overview

Follow-on to PR #185 (gfx1250 initial tech preview). Fixes a missing
gfx1250 runtime-detection entry, bumps the gfx1250 Triton compiler commit,

## Major Changes

* [gfx1250] Fix missing runtime GPU detection: `"gfx1250"` was absent from
  `LazyGpu::string_to_classifier`, causing gfx1250 devices to be
  unrecognized at runtime despite being in the build target list.
* [compiler] Bump gfx1250 Triton venv in `.ci/0.12.50b.yaml` to `62e7ab2`
  (from `ea7ab5f`, Jun 22).

## Minor Changes

CI ergonomics found while exercising the gfx1250 release build end-to-end:

* [ci] Add `--debug` to `releasesuite-git-head.sh`: requires exactly one
  `-r <rocmver>`, allocates a TTY, and drops into an interactive `bash -i`
  inside the container after all build/packaging steps complete.
  + Always bind-mounts `runc-manylinux-build-tar.sh` from the host (no
    commit required to pick up working-tree changes) and invokes it by path
    instead of piping via stdin.
* [ci] Decouple `-r` from component selection: `-r <ver>` now only
  populates the version list; `--runtime`/`--image` are the sole selectors.
  Omitting both now errors out instead of silently building everything.

# Known Issues

* [gfx1250] Tech preview only — no tuning DB, correctness/perf not yet
  validated across the full kernel suite.
* [ci] Tech preview only — uses an internal TheRock build for the ROCm
  7.14.0 runtime.
