### PR TITLE
Modularization Step 3: Relocate flash attention API bindings to modules/flash/bindings

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -5,8 +5,15 @@ aux_source_directory(. PYAOTRITON_SRC)
 if(AOTRITON_USE_TORCH)
   aux_source_directory(lazy_tensor PYAOTRITON_SRC)
 endif(AOTRITON_USE_TORCH)
+# Per-family API bindings: modules/<family>/bindings/*.cc self-register their
+# submodules via SubmoduleRegistrar (submodule_registry.h). Convention over
+# hardcoding — a new family drops in modules/<fam>/bindings, no edit here.
+file(GLOB MODULE_BINDING_SRC CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/modules/*/bindings/*.cc")
+list(APPEND PYAOTRITON_SRC ${MODULE_BINDING_SRC})
 # find_package(hip REQUIRED)
 pybind11_add_module(pyaotriton ${PYAOTRITON_SRC})
+# Family binding TUs #include "submodule_registry.h" from the core bindings dir.
+target_include_directories(pyaotriton PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 # target_link_libraries(pyaotriton PRIVATE hip::device)
 target_compile_features(pyaotriton PRIVATE cxx_std_20)
 target_link_libraries(pyaotriton PUBLIC aotriton)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -8,7 +8,7 @@ endif(AOTRITON_USE_TORCH)
 # Per-family API bindings: modules/<family>/bindings/*.cc self-register their
 # submodules via SubmoduleRegistrar (submodule_registry.h). Convention over
 # hardcoding — a new family drops in modules/<fam>/bindings, no edit here.
-file(GLOB MODULE_BINDING_SRC CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/modules/*/bindings/*.cc")
+file(GLOB MODULE_BINDING_SRC CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/modules/*/bindings/*.cc")
 list(APPEND PYAOTRITON_SRC ${MODULE_BINDING_SRC})
 # find_package(hip REQUIRED)
 pybind11_add_module(pyaotriton ${PYAOTRITON_SRC})

--- a/bindings/module.cc
+++ b/bindings/module.cc
@@ -11,6 +11,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/gil.h>
 #include <string>
+#include "submodule_registry.h"
 
 namespace py = pybind11;
 #if AOTRITON_ENABLE_SUFFIX
@@ -18,17 +19,13 @@ namespace aotriton = AOTRITON_NS;
 #endif
 
 namespace pyaotriton {
-  namespace v2 {
-    void setup_module(py::module_& m); // Impl. goes into v2.cc
-  } // namespace v2
-
-  namespace v3 {
-    void setup_module(py::module_& m); // Impl. goes into v3.cc
-  } // namespace v3
+  // Family API submodules (v2, v3, …) live in modules/<family>/bindings/ and
+  // self-register via SubmoduleRegistrar; setup_registered_submodules() below
+  // instantiates them. No per-family names are hardcoded here.
 
 #if AOTRITON_USE_TORCH
   namespace lazy_tensor {
-    void setup_module(py::module_& m); // Impl. goes into lazy_tensor.cc
+    void setup_module(py::module_& m); // Impl. goes into lazy_tensor.cc (core: common to all families)
   } // namespace lazy_tensor
 #endif
 
@@ -100,10 +97,9 @@ namespace pyaotriton {
           []() -> std::string { return ""; }
 #endif
          );
-    py::module_ mod_v2api = m.def_submodule("v2", "v2 API namespace");
-    v2::setup_module(mod_v2api);
-    py::module_ mod_v3api = m.def_submodule("v3", "v3 API namespace");
-    v3::setup_module(mod_v3api);
+    // Family API submodules (v2, v3, …) register themselves from
+    // modules/*/bindings/ and are instantiated here.
+    setup_registered_submodules(m);
 #if AOTRITON_USE_TORCH
     py::module_ mod_lazy_tensor = m.def_submodule("lazy_tensor", "lazy_tensor API namespace");
     lazy_tensor::setup_module(mod_lazy_tensor);

--- a/bindings/submodule_registry.cc
+++ b/bindings/submodule_registry.cc
@@ -1,0 +1,41 @@
+// Copyright © 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "submodule_registry.h"
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace py = pybind11;
+
+namespace pyaotriton {
+
+namespace {
+struct Entry {
+  std::string name;
+  std::string doc;
+  SubmoduleSetup fn;
+};
+
+// Function-local static so registration during other TUs' static init is safe
+// regardless of initialization order.
+std::vector<Entry>& registry() {
+  static std::vector<Entry> r;
+  return r;
+}
+} // namespace
+
+SubmoduleRegistrar::SubmoduleRegistrar(const char* name, const char* doc, SubmoduleSetup fn) {
+  registry().push_back(Entry{name, doc ? doc : "", std::move(fn)});
+}
+
+void setup_registered_submodules(py::module_& m) {
+  for (auto& e : registry()) {
+    // def_submodule is get-or-create: if two TUs register the same name, they
+    // contribute to the same submodule instead of clobbering it.
+    py::module_ sub = m.def_submodule(e.name.c_str(), e.doc.c_str());
+    e.fn(sub);
+  }
+}
+
+} // namespace pyaotriton

--- a/bindings/submodule_registry.cc
+++ b/bindings/submodule_registry.cc
@@ -26,7 +26,7 @@ std::vector<Entry>& registry() {
 } // namespace
 
 SubmoduleRegistrar::SubmoduleRegistrar(const char* name, const char* doc, SubmoduleSetup fn) {
-  registry().push_back(Entry{name, doc ? doc : "", std::move(fn)});
+  registry().emplace_back(name, doc ? doc : "", std::move(fn));
 }
 
 void setup_registered_submodules(py::module_& m) {

--- a/bindings/submodule_registry.h
+++ b/bindings/submodule_registry.h
@@ -1,0 +1,34 @@
+// Copyright © 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Self-registration hook for per-family pyaotriton submodules.
+//
+// The core module skeleton (module.cc) no longer hardcodes which family
+// submodules exist. Instead, each family's binding translation unit (e.g.
+// modules/flash/bindings/v2.cc) registers its top-level submodule via a static
+// SubmoduleRegistrar, and module.cc calls setup_registered_submodules() to
+// instantiate them all. Adding a family's bindings needs no edit to the core.
+//
+// All binding TUs are compiled directly into the pyaotriton module, so the
+// static registrars run at module load, before PYBIND11_MODULE's setup body.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <functional>
+
+namespace pyaotriton {
+
+using SubmoduleSetup = std::function<void(pybind11::module_&)>;
+
+// Registering the same submodule name from multiple TUs is allowed: the
+// submodule is get-or-created, so several families may share one version
+// namespace (e.g. both flash and a future family under "v2").
+struct SubmoduleRegistrar {
+  SubmoduleRegistrar(const char* name, const char* doc, SubmoduleSetup fn);
+};
+
+// Instantiate every registered submodule under m and run its setup.
+void setup_registered_submodules(pybind11::module_& m);
+
+} // namespace pyaotriton

--- a/modules/flash/bindings/v2.cc
+++ b/modules/flash/bindings/v2.cc
@@ -13,6 +13,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/gil.h>
 #include <string>
+#include "submodule_registry.h"
 
 namespace py = pybind11;
 #if AOTRITON_ENABLE_SUFFIX
@@ -42,4 +43,9 @@ namespace pyaotriton {
       flash::setup_module(mod_flash);
     }
   } // namespace v2
+
+  namespace {
+    // Self-register the v2 API submodule (see submodule_registry.h).
+    const SubmoduleRegistrar _v2_registrar("v2", "v2 API namespace", &v2::setup_module);
+  } // namespace
 } // namespace pyaotriton

--- a/modules/flash/bindings/v3.cc
+++ b/modules/flash/bindings/v3.cc
@@ -10,6 +10,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/gil.h>
+#include "submodule_registry.h"
 
 namespace py = pybind11;
 #if AOTRITON_ENABLE_SUFFIX
@@ -177,3 +178,10 @@ the original KernelControl instance or its backing resources are destroyed.)")
   }
 
 } // namespace pyaotriton::v3
+
+namespace pyaotriton {
+  namespace {
+    // Self-register the v3 API submodule (see submodule_registry.h).
+    const SubmoduleRegistrar _v3_registrar("v3", "v3 API namespace", &v3::setup_module);
+  } // namespace
+} // namespace pyaotriton


### PR DESCRIPTION
Move `bindings/v2.cc`,`v3.cc` to `modules/flash/bindings/` and replace `module.cc`'s hardcoded v2/v3 wiring with a submodule self-registration hook; CMake globs `modules/*/bindings` and `lazy_tensor` stays core.
Pure refactor, no behavior change: codegen golden byte-identical (2057 files), python unit suite 192 passed; C++/GPU gates deferred to CI hardware.

Stacked on #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)