### PR TITLE
Implement partial database support through GPU priority lists

### DIFF
--- a/python/database/sqlite.py
+++ b/python/database/sqlite.py
@@ -43,6 +43,7 @@ class Factory(object):
         log(lambda : f'sqlite3.connect({path / self.SIGNATURE_FILE})')
         self._conn = sqlite3.connect(path / self.SIGNATURE_FILE)
         self._conn.set_trace_callback(log) # Debug
+        self._input_config_cols_cache = {} # Cache "inputs$" columns in database
         for schema, bn in self.SECONDARY_DATABASES.items():
             fn = path / bn
             if fn.is_file():
@@ -51,32 +52,106 @@ class Factory(object):
             else:
                 assert False, f'{fn} is not a file, {path}'
 
+    def _get_input_config_cols(self, table_name):
+        """
+        Retrieves 'inputs$' columns with caching.
+
+        These columns identify kernel input parameters (dtype, head dimension, causal
+        type, etc.). Cached per table since schema doesn't change during build.
+        """
+        if table_name not in self._input_config_cols_cache:
+            try:
+                cursor = self._conn.cursor()
+                cursor.execute(f'SELECT * FROM "{table_name}" LIMIT 0')
+                cols = [desc[0] for desc in cursor.description if desc[0].startswith('inputs$')]
+                self._input_config_cols_cache[table_name] = cols
+            except sqlite3.OperationalError:
+                # Table doesn't exist - return empty list, will be caught later
+                self._input_config_cols_cache[table_name] = []
+        return self._input_config_cols_cache[table_name]
+
     def create_view(self, functional):
         log(lambda : f'{functional=}')
         meta = functional.meta_object
         pfx = 'op.' if getattr(meta, 'CODEGEN_MODULE', None) == 'op' else ''
         table_name = pfx + meta.FAMILY.upper() + '$' + meta.NAME
-        # TODO: Incremental changes:
-        # 1. load database_gpus first
-        # 2. then override entries with optimized_for gpus
-        def build_sql(choice_dict):
-            wheres = {
-                'gpu' : functional.database_gpus,
-            }
+
+        # Get all target GPUs and their priority chains
+        target_priority_map = functional.database_gpus  # dict[str, list[str]]
+
+        def build_sql_with_window_functions(choice_dict):
+            """Build UNION ALL query with window functions for each target GPU."""
+
+            # Build WHERE conditions for choices
+            choice_conditions = []
+            choice_params = []
             for key, value in choice_dict.items():
-                if isinstance(value, TC.TypedChoice) and value.is_tensor:
-                    wheres[f'inputs${key}_dtype'] = value
-                else:
-                    wheres[f'inputs${key}'] = value
-            return create_select_stmt(table_name, wheres)
-        stmt, params = build_sql(functional.compact_choices)
+                col = f'inputs${key}_dtype' if isinstance(value, TC.TypedChoice) and value.is_tensor else f'inputs${key}'
+                choice_conditions.append(f'{col} = ?')
+                choice_params.append(value.sql_value if isinstance(value, TC.TypedChoice) else value)
+
+            # Get partition columns (cached)
+            input_cols_joined = ', '.join(self._get_input_config_cols(table_name))
+
+            # Build UNION branches for each target GPU
+            union_parts = []
+            gpu_params = []
+
+            for target_gpu, priority_chain in target_priority_map.items():
+                # Build CASE statement for priority order
+                case_stmt = ' '.join(f"WHEN '{gpu}' THEN {idx}"
+                                    for idx, gpu in enumerate(priority_chain, 1)) + ' ELSE 99'
+                gpu_placeholders = ','.join(['?'] * len(priority_chain))
+
+                union_parts.append(f"""
+    SELECT *, '{target_gpu}' as target_gpu,
+           ROW_NUMBER() OVER (
+               PARTITION BY {input_cols_joined}
+               ORDER BY CASE gpu {case_stmt} END
+           ) AS rn
+    FROM {{base_table}}
+    WHERE gpu IN ({gpu_placeholders})""")
+                gpu_params.extend(priority_chain)
+
+            # Build final query - use filtered_base CTE if we have choice conditions
+            if choice_conditions:
+                choice_where = ' AND '.join(choice_conditions)
+                base_table_def = f'filtered_base AS (\n    SELECT * FROM "{table_name}"\n    WHERE {choice_where}\n)'
+                base_ref = 'filtered_base'
+                all_params = choice_params + gpu_params
+            else:
+                base_table_def = None
+                base_ref = f'"{table_name}"'
+                all_params = gpu_params
+
+            # Format union_parts with actual base table reference
+            formatted_unions = '\n UNION ALL '.join(part.format(base_table=base_ref) for part in union_parts)
+
+            if base_table_def:
+                full_query = f"""
+WITH {base_table_def},
+all_targets AS (
+{formatted_unions}
+)
+SELECT * FROM all_targets WHERE rn = 1
+"""
+            else:
+                full_query = f"""
+WITH all_targets AS (
+{formatted_unions}
+)
+SELECT * FROM all_targets WHERE rn = 1
+"""
+            return full_query, all_params
+
+        stmt, params = build_sql_with_window_functions(functional.compact_choices)
         try:
             log(lambda : f'select stmt: {stmt} params {params}')
             df = pd.read_sql_query(stmt, self._conn, params=params)
             if not df.empty:
                 return df, format_sql(stmt, params)
             # Downgrade
-            stmt, params = build_sql(functional.fallback_choices)
+            stmt, params = build_sql_with_window_functions(functional.fallback_choices)
             df = pd.read_sql_query(stmt, self._conn, params=params)
             return df, format_sql(stmt, params)
         except pd.errors.DatabaseError:

--- a/python/gpu_targets.py
+++ b/python/gpu_targets.py
@@ -22,18 +22,17 @@ AOTRITON_SUPPORTED_GPUS = (
     'gfx1250_mod0',
 )
 
-# TODO: AOTRITON_TUNING_DATABASE_REUSE -> AOTRITON_TUNING_DATABASE_FALLBACK
 # Load fallback entries first, and override with "patching" entries from real GPU
 AOTRITON_TUNING_DATABASE_REUSE = {
-    'gfx1101_mod0' : 'gfx1100_mod0',
-    'gfx1102_mod0' : 'gfx1100_mod0',
-    'gfx1103_mod0' : 'gfx1100_mod0',
-    'gfx1200_mod0' : 'gfx1201_mod0',
-    'gfx1150_mod0' : 'gfx1100_mod0',
-    'gfx1151_mod0' : 'gfx1100_mod0',
-    'gfx1152_mod0' : 'gfx1100_mod0',
-    'gfx1153_mod0' : 'gfx1100_mod0',
-    'gfx1250_mod0' : 'gfx942_mod0',
+    'gfx1101_mod0': ['gfx1101_mod0', 'gfx1100_mod0'],
+    'gfx1102_mod0': ['gfx1102_mod0', 'gfx1100_mod0'],
+    'gfx1103_mod0': ['gfx1103_mod0', 'gfx1100_mod0'],
+    'gfx1200_mod0': ['gfx1200_mod0', 'gfx1201_mod0'],
+    'gfx1150_mod0': ['gfx1150_mod0', 'gfx1100_mod0'],
+    'gfx1151_mod0': ['gfx1151_mod0', 'gfx1100_mod0'],
+    'gfx1152_mod0': ['gfx1152_mod0', 'gfx1100_mod0'],
+    'gfx1153_mod0': ['gfx1153_mod0', 'gfx1100_mod0'],
+    'gfx1250_mod0': ['gfx1250_mod0', 'gfx942_mod0'],
 }
 
 AOTRITON_ARCH_TO_PACK = {

--- a/python/template_instantiation/ir/functional.py
+++ b/python/template_instantiation/ir/functional.py
@@ -139,7 +139,10 @@ class Functional:
     @property
     def database_gpus(self):
         from aotriton.gpu_targets import AOTRITON_TUNING_DATABASE_REUSE
-        return [AOTRITON_TUNING_DATABASE_REUSE.get(g, g) for g in self._optimized_for]
+        return {
+            g: AOTRITON_TUNING_DATABASE_REUSE.get(g, [g])
+            for g in self._optimized_for
+        }
 
     # --- compact / fallback choices (multi-choice axes only) ---
 

--- a/python/template_instantiation/ir/kdesc.py
+++ b/python/template_instantiation/ir/kdesc.py
@@ -198,10 +198,10 @@ class KernelDescription(Interface):
             def discretization(v, bucket=bucket):
                 return bucket.index(v)
             df[f'$$ind_{i}'] = df[ind_key].apply(discretization)
-        for i, gpu in enumerate(f.database_gpus):
+        for i, gpu in enumerate(f.optimized_for):
             if i > 0:
                 lut_tensor[i] = lut_tensor[0]
-            df_i = df[df['gpu'] == gpu]
+            df_i = df[df['target_gpu'] == gpu]
             inds = tuple([df_i[f'$$ind_{j}'] for j in range(nkeys)])
             lut_tensor[i][inds] = df_i['$$sig_num']
         # Downcast the LUT dtype (int8 usually suffices).

--- a/python/template_instantiation/ir/operator.py
+++ b/python/template_instantiation/ir/operator.py
@@ -159,10 +159,10 @@ class Operator(Interface):
             def discretization(v, bucket=bucket):
                 return bucket.index(v)
             df[f'$$ind_{i}'] = df[ind_key].apply(discretization)
-        for i, gpu in enumerate(f.database_gpus):
+        for i, gpu in enumerate(f.optimized_for):
             if i > 0:
                 lut_tensor[i] = lut_tensor[0]
-            df_i = df[df['gpu'] == gpu]
+            df_i = df[df['target_gpu'] == gpu]
             inds = tuple([df_i[f'$$ind_{j}'] for j in range(nkeys)])
             lut_tensor[i][inds] = df_i[backend_key]
         backend_inds = np.unique(lut_tensor).tolist()


### PR DESCRIPTION


## Motivation

Implement the TODO in sqlite.py (lines 59-61) to enable partial tuning databases where each GPU target constructs a tuning LUT based on a prioritized list of GPU databases to draw from.

This allows targets with incomplete tuning databases to use their partial results, while falling back to a complete, reliable database for shapes not yet tuned, enabling incremental deployment of tuning results.

e.g. - gfx1151 has [gfx1151_mod0, gfx1100_mod0] as its list, so for each data configuration, it will check the gfx1151 tuning database for a kernel mapping and use it. If there is no entry for the config, it will fall back to the next priority (gfx1100 database). Lists can contain any number of entries.

Different variants of the same target can also be requested, e.g. (gfx942mod2, gfx942mod1, gfx942mod0) for gfx942.

## Technical Details

Changes:
- Define AOTRITON_TUNING_DATABASE_REUSE as dict[str, list[str]] mapping target GPU → priority chain (e.g., 'gfx1151_mod0': ['gfx1151_mod0', 'gfx1100_mod0']) in gpu_targets.py
- Change database_gpus property to return dict[str, list[str]] with per-target priority chains (functional.py)
- Implement SQL-based priority selection in sqlite.py:
  - Build UNION ALL query with one branch per target GPU
  - Each branch uses ROW_NUMBER() OVER (PARTITION BY inputs$* ORDER BY CASE gpu ...) to select highest-priority row per config
    * Add target_gpu column to identify which target each row serves
    * Factor choice WHERE conditions into filtered_base CTE to evaluate once
    * Cache inputs$ column names per table (_input_config_cols_cache)
  - Update LUT generation to filter DataFrame by target_gpu column
    (kdesc.py, operator.py)

## Test Plan

- Local build of AOTriton with the changes in place (targeting gfx1151 + 1150)
- Manual verification that generated LUTs map to expected gfx1151/1150-tuned kernel parameters, where present
- Similar for gfx942 with different _mod* suffix

## Test Result

gfx1150 + gfx1151 build:
- New LUTs generated with the expected contents/format
- LUT entries match expected kernel parameters (including gfx1100 fallback for missing shapes)

gfx942 multi-mod build:
- Build targets: gfx942_mod0;gfx942_mod1
- Temporary _mod1 database used containing a subset of _mod0 input shapes, with different kernel parameters
- Temporary priority list of `'gfx942_mod1': ['gfx942_mod0']`
- Correct LUT generated with working DB fallback for input shapes missing from _mod1