### PR TITLE
Harden AKS2 packed-kernel parser against malformed input

### DIFF
--- a/include/aotriton/_internal/packed_kernel.h
+++ b/include/aotriton/_internal/packed_kernel.h
@@ -65,9 +65,11 @@ private:
   // Note: do NOT drop the decompressed directory, its content is used by
   //       the unordered_map directory_
   std::vector<uint8_t> decompressed_content_;
-  hipError_t final_status_;
+  // Default to the failed state so an early return from the constructor can
+  // never leave these indeterminate.
+  hipError_t final_status_ = hipErrorInvalidSource;
 
-  const uint8_t* kernel_start_;
+  const uint8_t* kernel_start_ = nullptr;
   // Note: again, AKS2_Metadata points to directory at decompressed_content_
   std::unordered_map<std::string_view, const AKS2_Metadata*> directory_;
 };

--- a/v3src/packed_kernel_common.cc
+++ b/v3src/packed_kernel_common.cc
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <cstring>
 #include <cassert>
+#include <new>
 #if defined(_WIN32)
 #include <windows.h>
 #else
@@ -25,6 +26,14 @@ namespace fs = std::filesystem;
 static const std::string_view KERNEL_STORAGE_V2_BASE = "aotriton.images";
 static const std::string AKS2_MAGIC = "AKS2";
 constexpr int AOTRITON_LZMA_BUFSIZ = 64 * 1024;
+// Upper bound on the decompressed size of a single AKS2 entry. Shipped entries
+// are a few MiB; this only stops a corrupt header from requesting a multi-GiB
+// allocation before any of its content has been validated.
+constexpr uint64_t AOTRITON_AKS2_MAX_UNCOMPRESSED = 1ull << 30; // 1 GiB
+// Memory budget for the LZMA decoder. The largest dictionary xz selects at -9
+// is 64 MiB, so this leaves generous headroom while still bounding the
+// allocation a crafted stream header can request.
+constexpr uint64_t AOTRITON_LZMA_MEMLIMIT = 256ull << 20; // 256 MiB
 
 namespace {
 
@@ -222,16 +231,45 @@ PackedKernel::PackedKernel(fd_t fd, size_t offset, size_t size) {
     final_status_ = hipErrorInvalidSource; // Broken at XZ level
     return;
   }
-  decompressed_content_.resize(header.uncompressed_size);
+  // Establish the header invariants the parser below relies on. The payload is
+  // the directory followed by the kernel images, so uncompressed_size must
+  // cover directory_size, and every directory entry costs at least
+  // sizeof(AKS2_Metadata) plus the trailing '\0' of its name, which bounds
+  // number_of_kernels. See python/aks2.py for the writer side.
+  if (header.uncompressed_size == 0
+      || header.uncompressed_size > AOTRITON_AKS2_MAX_UNCOMPRESSED
+      || header.directory_size > header.uncompressed_size
+      || header.number_of_kernels > header.directory_size / (sizeof(AKS2_Metadata) + 1)) {
+    AOTRITON_LOG(LOG_DEBUG, "AKS2 header failed validation: uncompressed_size=%u"
+                 " directory_size=%u number_of_kernels=%u",
+                 unsigned(header.uncompressed_size), unsigned(header.directory_size),
+                 unsigned(header.number_of_kernels));
+    final_status_ = hipErrorInvalidSource;
+    return;
+  }
+  try {
+    decompressed_content_.resize(header.uncompressed_size);
+  } catch (const std::bad_alloc&) {
+    // Otherwise this escapes the constructor through make_shared() in open()
+    // and terminates the process.
+    final_status_ = hipErrorOutOfMemory;
+    return;
+  }
   directory_.clear();
 
   lzma_stream strm = LZMA_STREAM_INIT;
-  lzma_ret ret = lzma_stream_decoder(&strm, UINT64_MAX, 0);
+  lzma_ret ret = lzma_stream_decoder(&strm, AOTRITON_LZMA_MEMLIMIT, 0);
   if (ret != LZMA_OK) {
     AOTRITON_LOG(LOG_DEBUG, "lzma_stream_decoder error: %d", static_cast<int>(ret));
     final_status_ = hipErrorInvalidSource; // Broken at XZ level
     return;
   }
+  // lzma_stream_decoder allocates decoder state that has to be released on
+  // every exit path below; without this each AKS2 load leaks it.
+  struct LzmaGuard {
+    lzma_stream* stream;
+    ~LzmaGuard() { lzma_end(stream); }
+  } lzma_guard{ &strm };
   uint8_t inbuf[AOTRITON_LZMA_BUFSIZ];
   strm.next_in = nullptr;
   strm.avail_in = 0;
@@ -263,11 +301,50 @@ PackedKernel::PackedKernel(fd_t fd, size_t offset, size_t size) {
   }
   AOTRITON_LOG(LOG_DEBUG, "PackedKernel decompressed to %p",
                static_cast<const void*>(decompressed_content_.data()));
-  const uint8_t* parse_ptr = decompressed_content_.data();
+  auto reject = [this](hipError_t status) {
+    decompressed_content_.clear();
+    directory_.clear();
+    final_status_ = status;
+  };
+  // A short stream would leave the tail of the buffer zero-filled and parsed as
+  // if it were real directory content.
+  if (strm.total_out != header.uncompressed_size) {
+    AOTRITON_LOG(LOG_DEBUG, "AKS2 payload is %llu bytes, header declares %u",
+                 static_cast<unsigned long long>(strm.total_out),
+                 unsigned(header.uncompressed_size));
+    reject(hipErrorIllegalState);
+    return;
+  }
+  const uint8_t* const content_begin = decompressed_content_.data();
+  // The directory occupies the first directory_size bytes; the images follow.
+  const uint8_t* const dir_end = content_begin + header.directory_size;
+  const size_t image_region_size = header.uncompressed_size - header.directory_size;
+  const uint8_t* parse_ptr = content_begin;
   for (uint32_t i = 0; i < header.number_of_kernels; i++) {
+    if (static_cast<size_t>(dir_end - parse_ptr) < sizeof(AKS2_Metadata)) {
+      reject(hipErrorInvalidSource); // Entry header runs past the directory
+      return;
+    }
     auto metadata = reinterpret_cast<const AKS2_Metadata*>(parse_ptr);
     parse_ptr += sizeof(*metadata);
-    std::string_view filename(reinterpret_cast<const char*>(parse_ptr));
+    // filename_length counts the trailing '\0', so the name must be non-empty,
+    // fit inside the directory, and actually be NUL-terminated before it is
+    // handed to std::string_view.
+    if (metadata->filename_length == 0
+        || static_cast<size_t>(dir_end - parse_ptr) < metadata->filename_length
+        || parse_ptr[metadata->filename_length - 1] != '\0') {
+      reject(hipErrorInvalidSource); // Name runs past the directory or is unterminated
+      return;
+    }
+    // Bound the image here, so filter() can never hand an out-of-range pointer
+    // to hipModuleLoadDataEx(). Written to avoid overflowing the addition.
+    if (metadata->offset > image_region_size
+        || metadata->image_size > image_region_size - metadata->offset) {
+      reject(hipErrorInvalidSource); // Image runs past the payload
+      return;
+    }
+    std::string_view filename(reinterpret_cast<const char*>(parse_ptr),
+                              metadata->filename_length - 1);
     directory_.emplace(filename, metadata);
     AOTRITON_LOG(LOG_DEBUG, "Add kernel %u: %.*s offset: %u",
                  unsigned(i), int(filename.size()), filename.data(), unsigned(metadata->offset));
@@ -275,11 +352,9 @@ PackedKernel::PackedKernel(fd_t fd, size_t offset, size_t size) {
   }
   kernel_start_ = parse_ptr;
   AOTRITON_LOG(LOG_DEBUG, "PackedKernel.kernel_start_ = %p", static_cast<const void*>(kernel_start_));
-  if (kernel_start_ - decompressed_content_.data() != header.directory_size) {
-    decompressed_content_.clear();
-    directory_.clear();
-    // Directory size not matching
-    final_status_ = hipErrorIllegalAddress;
+  if (parse_ptr != dir_end) {
+    // Directory size not matching: the entries did not consume it exactly.
+    reject(hipErrorIllegalAddress);
     return;
   }
   AOTRITON_LOG(LOG_DEBUG, "PackedKernel.kernel_start_ sanity check passed");
@@ -304,6 +379,8 @@ PackedKernel::filter(std::string_view stem_name) const {
     assert(meta->number_of_threads == 0);
     return { nullptr, 0, 0, 0 };
   }
+  // offset/image_size were bounded against the payload when the directory was
+  // parsed, so this stays inside decompressed_content_.
   return { kernel_start_ + meta->offset,
            meta->image_size,
            static_cast<int>(meta->shared_memory),

--- a/v3src/packed_kernel_common.cc
+++ b/v3src/packed_kernel_common.cc
@@ -247,15 +247,16 @@ PackedKernel::PackedKernel(fd_t fd, size_t offset, size_t size) {
     final_status_ = hipErrorInvalidSource;
     return;
   }
+  std::vector<uint8_t> decompressed_content;
   try {
-    decompressed_content_.resize(header.uncompressed_size);
+    decompressed_content.resize(header.uncompressed_size);
   } catch (const std::bad_alloc&) {
     // Otherwise this escapes the constructor through make_shared() in open()
     // and terminates the process.
     final_status_ = hipErrorOutOfMemory;
     return;
   }
-  directory_.clear();
+  std::unordered_map<std::string_view, const AKS2_Metadata*> directory;
 
   lzma_stream strm = LZMA_STREAM_INIT;
   lzma_ret ret = lzma_stream_decoder(&strm, AOTRITON_LZMA_MEMLIMIT, 0);
@@ -273,8 +274,8 @@ PackedKernel::PackedKernel(fd_t fd, size_t offset, size_t size) {
   uint8_t inbuf[AOTRITON_LZMA_BUFSIZ];
   strm.next_in = nullptr;
   strm.avail_in = 0;
-  strm.next_out = (uint8_t*)decompressed_content_.data();
-  strm.avail_out = decompressed_content_.size();
+  strm.next_out = decompressed_content.data();
+  strm.avail_out = decompressed_content.size();
   lzma_action action = LZMA_RUN;
   // Track remaining bytes when size is bounded (reading AKS2 from inside a ZIP).
   size_t remaining = (size == SIZE_MAX) ? SIZE_MAX : (size - sizeof(AKS2_Header));
@@ -293,36 +294,29 @@ PackedKernel::PackedKernel(fd_t fd, size_t offset, size_t size) {
     }
     lzma_ret ret = lzma_code(&strm, action);
     if (ret != LZMA_OK && ret != LZMA_STREAM_END) {
-      decompressed_content_.clear();
-      directory_.clear();
       final_status_ = hipErrorIllegalState; // Content not fully decompressed
       return;
     }
   }
   AOTRITON_LOG(LOG_DEBUG, "PackedKernel decompressed to %p",
-               static_cast<const void*>(decompressed_content_.data()));
-  auto reject = [this](hipError_t status) {
-    decompressed_content_.clear();
-    directory_.clear();
-    final_status_ = status;
-  };
+               static_cast<const void*>(decompressed_content.data()));
   // A short stream would leave the tail of the buffer zero-filled and parsed as
   // if it were real directory content.
   if (strm.total_out != header.uncompressed_size) {
     AOTRITON_LOG(LOG_DEBUG, "AKS2 payload is %llu bytes, header declares %u",
                  static_cast<unsigned long long>(strm.total_out),
                  unsigned(header.uncompressed_size));
-    reject(hipErrorIllegalState);
+    final_status_ = hipErrorIllegalState;
     return;
   }
-  const uint8_t* const content_begin = decompressed_content_.data();
+  const uint8_t* const content_begin = decompressed_content.data();
   // The directory occupies the first directory_size bytes; the images follow.
   const uint8_t* const dir_end = content_begin + header.directory_size;
   const size_t image_region_size = header.uncompressed_size - header.directory_size;
   const uint8_t* parse_ptr = content_begin;
   for (uint32_t i = 0; i < header.number_of_kernels; i++) {
     if (static_cast<size_t>(dir_end - parse_ptr) < sizeof(AKS2_Metadata)) {
-      reject(hipErrorInvalidSource); // Entry header runs past the directory
+      final_status_ = hipErrorInvalidSource; // Entry header runs past the directory
       return;
     }
     auto metadata = reinterpret_cast<const AKS2_Metadata*>(parse_ptr);
@@ -333,31 +327,33 @@ PackedKernel::PackedKernel(fd_t fd, size_t offset, size_t size) {
     if (metadata->filename_length == 0
         || static_cast<size_t>(dir_end - parse_ptr) < metadata->filename_length
         || parse_ptr[metadata->filename_length - 1] != '\0') {
-      reject(hipErrorInvalidSource); // Name runs past the directory or is unterminated
+      final_status_ = hipErrorInvalidSource; // Name runs past the directory or is unterminated
       return;
     }
     // Bound the image here, so filter() can never hand an out-of-range pointer
     // to hipModuleLoadDataEx(). Written to avoid overflowing the addition.
     if (metadata->offset > image_region_size
         || metadata->image_size > image_region_size - metadata->offset) {
-      reject(hipErrorInvalidSource); // Image runs past the payload
+      final_status_ = hipErrorInvalidSource; // Image runs past the payload
       return;
     }
     std::string_view filename(reinterpret_cast<const char*>(parse_ptr),
                               metadata->filename_length - 1);
-    directory_.emplace(filename, metadata);
+    directory.emplace(filename, metadata);
     AOTRITON_LOG(LOG_DEBUG, "Add kernel %u: %.*s offset: %u",
                  unsigned(i), int(filename.size()), filename.data(), unsigned(metadata->offset));
     parse_ptr += metadata->filename_length;
   }
-  kernel_start_ = parse_ptr;
-  AOTRITON_LOG(LOG_DEBUG, "PackedKernel.kernel_start_ = %p", static_cast<const void*>(kernel_start_));
   if (parse_ptr != dir_end) {
     // Directory size not matching: the entries did not consume it exactly.
-    reject(hipErrorIllegalAddress);
+    final_status_ = hipErrorIllegalAddress;
     return;
   }
   AOTRITON_LOG(LOG_DEBUG, "PackedKernel.kernel_start_ sanity check passed");
+  decompressed_content_ = std::move(decompressed_content);
+  directory_ = std::move(directory);
+  kernel_start_ = decompressed_content_.data() + header.directory_size;
+  AOTRITON_LOG(LOG_DEBUG, "PackedKernel.kernel_start_ = %p", static_cast<const void*>(kernel_start_));
   final_status_ = hipSuccess;
 }
 


### PR DESCRIPTION
## Summary

`PackedKernel::PackedKernel()` trusts every field of the AKS2 header and of each directory entry. The per-kernel directory walk is not bounded against the decompressed payload, so `number_of_kernels` / `filename_length` can run `parse_ptr` off the end of `decompressed_content_`, and `filter()` can return `kernel_start_ + offset` pointing outside the buffer — a pointer that goes on to `hipModuleLoadDataEx()` in `v3src/on_device_kernel.cc:84`, which takes no length and parses the ELF from wherever it lands.

The existing trailing check

```cpp
if (kernel_start_ - decompressed_content_.data() != header.directory_size)
```

runs only *after* the walk has already read out of bounds, and `directory_size` is itself an unvalidated header field, so a malformed file can simply be built to satisfy it.

This is reachable today from any corrupt or truncated `.aks2` — a partial download or a bad disk is enough to crash the process rather than fall back cleanly.

## Changes

All in `v3src/packed_kernel_common.cc`, plus two default member initialisers in `include/aotriton/_internal/packed_kernel.h`.

- **Validate the header before allocating.** Reject `uncompressed_size` of zero or above 1 GiB, `directory_size` larger than `uncompressed_size`, and `number_of_kernels` larger than the directory can physically hold. The bounds come from the format itself (see `python/aks2.py`): the payload is the directory followed by the images, and each entry costs at least `sizeof(AKS2_Metadata)` plus its name's trailing `\0`.
- **Catch `bad_alloc` around the `resize`.** It otherwise escapes the constructor through `make_shared()` in `open()` and terminates the process.
- **Require the decompressed stream to be exactly `uncompressed_size` bytes.** A short stream previously left the tail of the buffer zero-filled and parsed it as directory content.
- **Bound every directory entry** against the directory region; require `filename_length` to be non-zero and actually NUL-terminated, and build the `string_view` with an explicit length rather than relying on `strlen` finding a terminator.
- **Validate `offset`/`image_size` against the image region at parse time**, so `filter()` cannot hand an out-of-range pointer to `hipModuleLoadDataEx()`.
- **Give the LZMA decoder a finite memlimit** instead of `UINT64_MAX`.
- **Call `lzma_end()`.** It is currently never called — every AKS2 load leaks decoder state, including successful ones. Handled with a small RAII guard because the constructor has several exit paths.

Valid AKS2 files parse identically. The only behaviour change is that malformed ones are rejected with a status instead of read out of bounds.

## Validation

An ASan+UBSan harness drives the real constructor over a corpus of malformed AKS2 files (the harness links `packed_kernel_common.cc`, `fd_unix.cc` and `log.cc`, stubs `lszip`, and reads every byte `filter()` reports as a loadable image, so an out-of-range `offset`/`image_size` surfaces as an ASan report rather than a silently wild pointer).

| case | before | after |
|---|---|---|
| `valid` | accepted + **leak** | accepted, no findings |
| `bad_magic` | rejected | rejected |
| `nkernels_overflow` | **heap-buffer-overflow** | rejected |
| `unterminated_name` | **heap-buffer-overflow** | rejected |
| `image_size_oob` | **heap-buffer-overflow** | rejected |
| `offset_oob` | **SEGV** | rejected |
| `zero_uncompressed` | **SEGV** | rejected |
| `filename_len_oob` | leak | rejected |
| `dirsize_gt_total` | leak | rejected |
| `truncated_stream` | leak | rejected |
| `huge_uncompressed` | leak (4 GiB alloc) | rejected |

The valid file decodes byte-identically before and after (same image sizes, same checksums).

600 random header/body mutations of a valid file produce no sanitizer findings against this branch; the same mutation run against current `main` hits a heap-buffer-overflow within 11 iterations.

I kept the harness out of the diff since the repo has no C++ test infrastructure and wiring some up is a separate decision — happy to add it (or a `LLVMFuzzerTestOneInput` entry point) if you'd like it in tree.

## Notes for reviewers

- The 1 GiB and 256 MiB constants are deliberately loose — they exist to bound what a corrupt `u32` can request, not to reflect real entry sizes. Say the word if you'd prefer different values or a build-time knob.
- `bad_magic` already fails on `main`; it's in the corpus as a regression guard for the check fixed in d1e09cc (#177).
- Reported internally as SWSPLAT-23886, which was filed against a pre-#177 vendored snapshot and described the magic-check bug as remotely exploitable. That part does not apply to `main` — the image directory is `dirname(libaotriton.so)/aotriton.images`, so writing there already implies the ability to replace the library itself. The bounds issues above are real regardless, which is what this PR addresses.
