### PR TITLE
Restore flash kernel tuning config generators in ATI

### DIFF
--- a/modules/flash/aot/attn_fwd.py
+++ b/modules/flash/aot/attn_fwd.py
@@ -11,12 +11,15 @@ instantiation description onto it. Covers all 74 parameters. Conditional argumen
 the derive fixes the per-functional value (ati+newbinds_rev1.md §6.2).
 """
 
+import itertools
+import os
 from dataclasses import dataclass
 
 import numpy as np
 
 import aotriton.template_instantiation as ati
-from ._common import flash_disabled, block_dmodel_values, MAIN_DTYPES
+from aotriton.gpu_targets import AOTRITON_ARCH_WARPSIZE
+from ._common import flash_disabled, block_dmodel_values, MAIN_DTYPES, check_value
 
 
 @dataclass
@@ -31,19 +34,69 @@ class AttnFwdPerf:
     NUM_XCDS:        np.int8 = 1
 
 
+def _parse_preload_options():
+    val = int(os.getenv('AOTRITON_PRE_LOAD_OPTIONS', default='2'))
+    if val == 0:
+        return [False]
+    if val == 1:
+        return [True]
+    return [False, True]
+
+
+PRE_LOAD_OPTIONS = _parse_preload_options()
+
+
 def gen_autotune_configs(f):
-    """Placeholder generator (real heuristics ported later); the DB-driven path
-    (translate_dataframe) does not use this."""
-    causal = f.choices.CAUSAL_TYPE
-    kw = {
-        'PERSISTENT_TYPE': 2 if causal != 0 else 0,
-        'GRID_CU_MULTIP': 2,
-        'BLOCK_M': 16, 'BLOCK_N': 16,
-        'PRE_LOAD_V': False,
-        'NUM_XCDS': 8 if f.arch in ('gfx942', 'gfx950') else 1,
-        'waves_per_eu': 2,
-    }
-    yield ati.tune.Config(kw, num_warps=4, num_stages=1)
+    """Generate architecture-aware forward tuning configurations."""
+    arch = f.arch
+    dtype = check_value(f, ['Q'])
+    head_dim = f.choices.BLOCK_DMODEL
+    causal_type = f.choices.CAUSAL_TYPE
+    num_xcds = 8 if arch in ('gfx942', 'gfx950') else 1
+    wave64 = AOTRITON_ARCH_WARPSIZE[arch] == 64
+
+    if wave64:
+        block_sizes = [(32, 16), (128, 64), (64, 64), (64, 32), (128, 128)]
+    else:
+        block_sizes = [(64, 32), (32, 32), (32, 16)]
+        if '*fp32' not in dtype:
+            block_sizes.append((16, 16))
+
+    waves_per_eu = [1, 2, 3, 4]
+    num_warps = [2, 4] if wave64 else [4, 8]
+    num_stages = [1]
+
+    if arch == 'gfx950':
+        for waves, pre_load_v in itertools.product(waves_per_eu, PRE_LOAD_OPTIONS):
+            kw = {
+                'PERSISTENT_TYPE': 2 if causal_type != 0 else 0,
+                'GRID_CU_MULTIP': 2,
+                'BLOCK_M': 256,
+                'BLOCK_N': 64,
+                'waves_per_eu': waves,
+                'PRE_LOAD_V': pre_load_v,
+                'NUM_XCDS': num_xcds,
+            }
+            yield ati.tune.Config(kw, num_stages=4, num_warps=8)
+
+    for (block_m, block_n), waves, warps, stages, pre_load_v in itertools.product(
+            block_sizes, waves_per_eu, num_warps, num_stages, PRE_LOAD_OPTIONS):
+        if head_dim >= 512 and block_m == 128 and block_n == 128 and warps == 2:
+            continue  # Timeout
+        if dtype == '*fp32:16':
+            block_m //= 2
+        if block_m < block_n:  # Faulty or duplicate
+            continue
+        kw = {
+            'PERSISTENT_TYPE': 2 if causal_type != 0 else 0,
+            'GRID_CU_MULTIP': 2,
+            'BLOCK_M': block_m,
+            'BLOCK_N': block_n,
+            'waves_per_eu': waves,
+            'PRE_LOAD_V': pre_load_v,
+            'NUM_XCDS': num_xcds,
+        }
+        yield ati.tune.Config(kw, num_stages=stages, num_warps=warps)
 
 
 def _attn_fwd_disabled(f):

--- a/modules/flash/aot/bwd_kernel_dk_dv.py
+++ b/modules/flash/aot/bwd_kernel_dk_dv.py
@@ -12,12 +12,14 @@ but the operator/golden call it `stride_bk`; ATI emits the real name in the cosm
 pp_args comment (the access expression is identical).
 """
 
+import itertools
 from dataclasses import dataclass
 
 import numpy as np
 
 import aotriton.template_instantiation as ati
-from ._common import flash_disabled, block_dmodel_values, MAIN_DTYPES
+from aotriton.gpu_targets import AOTRITON_ARCH_WARPSIZE
+from ._common import flash_disabled, block_dmodel_values, MAIN_DTYPES, check_value
 
 
 @dataclass
@@ -33,11 +35,33 @@ def _bwd_disabled(f):
 
 
 def gen_autotune_configs(f):
-    """Placeholder generator (one valid config); the DB path does not use it."""
-    kw = {'BLOCK_M': 16, 'BLOCK_N': 16,
-          'NUM_XCDS': 8 if f.arch in ('gfx942', 'gfx950') else 1,
-          'waves_per_eu': 1}
-    yield ati.tune.Config(kw, num_warps=4, num_stages=1)
+    """Generate architecture-aware dK/dV tuning configurations."""
+    arch = f.arch
+    dtype = check_value(f, ['Q'])
+    num_xcds = 8 if arch in ('gfx942', 'gfx950') else 1
+    wave64 = AOTRITON_ARCH_WARPSIZE[arch] == 64
+    wave32 = AOTRITON_ARCH_WARPSIZE[arch] == 32
+    block_sizes = [16, 32, 64] if dtype != '*fp32:16' else [16, 32]
+    waves_per_eu = [1, 2, 3, 4]
+    num_warps = [4, 8] if wave32 else [2, 4]
+
+    for block_m, block_n, waves, warps in itertools.product(
+            block_sizes, block_sizes, waves_per_eu, num_warps):
+        if block_m < block_n:
+            continue  # Duplicate
+        if wave64 and block_m == 64 and block_n == 64 and warps == 4:
+            continue  # No optimal kernel according to the 0.8b tuning database
+        if wave32 and block_m * block_n >= 32 * 32 and warps < 4:
+            continue  # Timeout
+        if wave32 and block_m * block_n >= 32 * 16 and warps < 2:
+            continue  # Timeout
+        kw = {
+            'BLOCK_M': block_m,
+            'BLOCK_N': block_n,
+            'NUM_XCDS': num_xcds,
+            'waves_per_eu': waves,
+        }
+        yield ati.tune.Config(kw, num_stages=1, num_warps=warps)
 
 
 @ati.start

--- a/modules/flash/aot/bwd_kernel_dq.py
+++ b/modules/flash/aot/bwd_kernel_dq.py
@@ -12,12 +12,14 @@ but the operator/golden call it `stride_bk`; ATI emits the real name in the cosm
 pp_args comment (the access expression is identical).
 """
 
+import itertools
 from dataclasses import dataclass
 
 import numpy as np
 
 import aotriton.template_instantiation as ati
-from ._common import flash_disabled
+from aotriton.gpu_targets import AOTRITON_ARCH_WARPSIZE
+from ._common import flash_disabled, check_value
 
 
 @dataclass
@@ -33,11 +35,26 @@ def _bwd_disabled(f):
 
 
 def gen_autotune_configs(f):
-    """Placeholder generator (one valid config); the DB path does not use it."""
-    kw = {'BLOCK_M': 16, 'BLOCK_N': 16,
-          'NUM_XCDS': 8 if f.arch in ('gfx942', 'gfx950') else 1,
-          'waves_per_eu': 1}
-    yield ati.tune.Config(kw, num_warps=4, num_stages=1)
+    """Generate architecture-aware dQ/dB tuning configurations."""
+    arch = f.arch
+    dtype = check_value(f, ['Q'])
+    num_xcds = 8 if arch in ('gfx942', 'gfx950') else 1
+    wave32 = AOTRITON_ARCH_WARPSIZE[arch] == 32
+    block_sizes = [16, 32, 64] if dtype != '*fp32:16' else [16, 32]
+    waves_per_eu = [1, 2, 3, 4]
+    num_warps = [4, 8] if wave32 else [2, 4]
+
+    for block_m, block_n, waves, warps in itertools.product(
+            block_sizes, block_sizes, waves_per_eu, num_warps):
+        if block_m < block_n:
+            continue  # Duplicate
+        kw = {
+            'BLOCK_M': block_m,
+            'BLOCK_N': block_n,
+            'NUM_XCDS': num_xcds,
+            'waves_per_eu': waves,
+        }
+        yield ati.tune.Config(kw, num_stages=1, num_warps=warps)
 
 
 # Cite-based form (ati_linker_req acceptance demo): bwd_kernel_dq declares only what

--- a/modules/flash/aot/bwd_kernel_fuse.py
+++ b/modules/flash/aot/bwd_kernel_fuse.py
@@ -12,12 +12,14 @@ from the cited preprocess, rev1 §5), and its own perf (no NUM_XCDS). Stacked-@ 
 over ../kernel/bwd_kernel_fuse.py.
 """
 
+import itertools
 from dataclasses import dataclass
 
 import numpy as np
 
 import aotriton.template_instantiation as ati
-from ._common import block_dmodel_values
+from aotriton.gpu_targets import AOTRITON_ARCH_WARPSIZE
+from ._common import block_dmodel_values, check_value
 
 
 def _block_dmodel_values_capped():
@@ -33,9 +35,29 @@ class BwdKernelFusePerf:
 
 
 def gen_autotune_configs(f):
-    """Placeholder generator (one valid config); the DB path does not use it."""
-    yield ati.tune.Config({'BLOCK_M': 16, 'BLOCK_N': 16, 'waves_per_eu': 1},
-                          num_warps=4, num_stages=1)
+    """Generate architecture-aware fused-backward tuning configurations."""
+    arch = f.arch
+    dtype = check_value(f, ['Q'])
+    wave64 = AOTRITON_ARCH_WARPSIZE[arch] == 64
+    wave32 = AOTRITON_ARCH_WARPSIZE[arch] == 32
+    block_sizes = [16, 32, 64] if dtype != '*fp32:16' else [16, 32]
+    waves_per_eu = [1, 2, 3, 4]
+    num_warps = [4, 8] if wave32 else [2, 4]
+
+    for block_m, block_n, waves, warps in itertools.product(
+            block_sizes, block_sizes, waves_per_eu, num_warps):
+        if block_m < block_n:
+            continue  # Duplicate
+        if wave64 and block_m == 64 and block_n == 64 and warps == 4:
+            continue  # No optimal kernel according to the 0.8b tuning database
+        if wave32 and block_m == 32 and block_n == 32 and warps != 4:
+            continue  # Timeout
+        kw = {
+            'BLOCK_M': block_m,
+            'BLOCK_N': block_n,
+            'waves_per_eu': waves,
+        }
+        yield ati.tune.Config(kw, num_stages=1, num_warps=warps)
 
 
 @ati.start


### PR DESCRIPTION
# Overview

Restore the flash kernel tuning configuration generators left as single-config
placeholders during the ATI migration.


## Changes

* [flash,tune] Restore the release/0.12 candidate spaces and ordering for
`attn_fwd`, `bwd_kernel_dk_dv`, `bwd_kernel_dq`, and `bwd_kernel_fuse`.
* [test] Add CPU-only ordered parity and Config-to-KernelSignature tests using
the real ATI descriptions.

## Testing

* Focused autotune-config suite: 23 passed.
* Full CPU-only self-test: 237 passed, 26 skipped.

## AI Disclosure

* Code was generated with help of Claude Code.
* All of the code was reviewed by human.
