### PR TITLE
Use ROCm version for runtime package names

### DIFF
--- a/.ci/runc-manylinux-build-tar.sh
+++ b/.ci/runc-manylinux-build-tar.sh
@@ -23,7 +23,7 @@
 #   Tools (provided by the ROCm AlmaLinux 8 image):
 #     hipconfig        — to locate ROCM_PATH
 #     gcc-toolset-13   — C++17 compiler via scl enable (non-asan path only)
-#     cpp              — preprocessor used to extract the HIP version number
+#     cpp              — preprocessor used to extract the ROCm version number
 
 set -ex
 
@@ -65,19 +65,23 @@ if [ -n "${PIP_CACHE_DIR}" ] && [ -d "${PIP_CACHE_DIR}" ]; then
   chown -R "$(id -u):$(id -g)" "${PIP_CACHE_DIR}" || true
 fi
 
-# --- Detect ROCm and HIP version ---
+# --- Detect ROCm version ---
 GIT_SHORT=$(git -C /src/aotriton rev-parse --short=12 HEAD)
 export ROCM_PATH=$(hipconfig --rocmpath)
 if [ -z "${ROCM_PATH}" ]; then
   echo "Error: ROCM_PATH is empty. hipconfig --rocmpath failed." >&2
   exit 1
 fi
-printf '#include <hip/hip_version.h>\nHIP_VERSION_MAJOR . HIP_VERSION_MINOR\n' > /tmp/print_hip_version.h
+printf '#include <rocm-core/rocm_version.h>\nROCM_VERSION_MAJOR . ROCM_VERSION_MINOR\n' > /tmp/print_rocm_version.h
 if [[ "${ASAN_MODE}" == "ON" ]]; then
   # No gcc-toolset/cpp in this path; use clang's preprocessor.
-  hipver=$(${ROCM_PATH}/llvm/bin/clang -E -P -x c -I${ROCM_PATH}/include /tmp/print_hip_version.h | tail -n 1 | sed 's/ //g')
+  rocmver=$(${ROCM_PATH}/llvm/bin/clang -E -P -x c -I${ROCM_PATH}/include /tmp/print_rocm_version.h | tail -n 1 | sed 's/ //g')
 else
-  hipver=$(scl enable gcc-toolset-13 "cpp -I${ROCM_PATH}/include /tmp/print_hip_version.h" | tail -n 1 | sed 's/ //g')
+  rocmver=$(scl enable gcc-toolset-13 "cpp -I${ROCM_PATH}/include /tmp/print_rocm_version.h" | tail -n 1 | sed 's/ //g')
+fi
+if [[ ! "${rocmver}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Failed to extract ROCm version from rocm-core/rocm_version.h: '${rocmver}'" >&2
+  exit 1
 fi
 
 # --- Build ---
@@ -123,7 +127,7 @@ if [ ${NOIMAGE_MODE} == "OFF" ]; then
     tar cz "aotriton/lib/aotriton.images/$d" > /output/${tarfile}
   done
 else
-  tarfile=aotriton-${GIT_SHORT}${asan_suffix}-${MANYLINUX_TAG}_x86_64-rocm${hipver}-shared.tar.gz
+  tarfile=aotriton-${GIT_SHORT}${asan_suffix}-${MANYLINUX_TAG}_x86_64-rocm${rocmver}-shared.tar.gz
   cd "${AOTRITON_INSTALL_PREFIX}" && tar cz aotriton > /output/${tarfile}
 fi
 


### PR DESCRIPTION
Read the ROCm product version from `rocm-core` instead of using the independently versioned HIP component, and reject malformed version values before packaging.

## Motivation

HIP and ROCm versions began diverging with ROCm 7.0. Their major versions also diverged after ROCm 7.15, while AOTriton continued deriving `rocm*` package names from `hip_version.h`.

Runtime archive names should use the ROCm product version so they remain consistent with ROCm package consumers and release naming.

The corresponding PyTorch change, [pytorch/pytorch#194196](https://github.com/pytorch/pytorch/pull/194196), updates AOTriton runtime selection to use the ROCm product version and consume the newly named archives.

## Technical Details

- Include `rocm-core/rocm_version.h` instead of `hip/hip_version.h`.
- Extract `ROCM_VERSION_MAJOR` and `ROCM_VERSION_MINOR`.
- Rename the internal `hipver` variable to `rocmver`.
- Use `rocmver` when constructing runtime archive names.
- Preserve both preprocessing paths:
  - Clang for ASAN builds.
  - GCC `cpp` through `scl` for non-ASAN builds.
- Validate the extracted value against `<major>.<minor>` and fail before packaging if it is missing or malformed.

Runtime archives are now named using:

```text
aotriton-<version>-<platform>-rocm<ROCm major.minor>-shared.tar.gz
```

## Related Change

- [pytorch/pytorch#194196 — Use ROCm version for AOTriton runtimes](https://github.com/pytorch/pytorch/pull/194196)

This PR changes AOTriton archive generation; the PyTorch PR changes archive selection. Both changes are required to use ROCm product-version naming end to end.

## Test Plan

- Create a clean development environment using ROCm `10.0.0a20260729`, whose HIP component reports `7.15`.
- Initialize the SDK with `rocm-sdk init`.
- Exercise the Clang/ASAN preprocessing path.
- Exercise the standard `cpp` preprocessing path.
- Compare the detected ROCm version with the HIP component version and `.info/version`.
- Verify the resulting archive suffix.
- Run shell syntax, diff, and lint checks.

## Test Result

Using ROCm `10.0.0a20260729`:

- ROCm product version: `10.0.0`
- HIP component version: `7.15`
- Clang/ASAN detection result: `10.0`
- Standard `cpp` detection result: `10.0`
- Generated archive suffix: `rocm10.0`

This confirms the new logic uses the ROCm product version instead of the independently versioned HIP component.

Shell syntax, diff, and lint checks passed. A complete containerized AOTriton release build was not run locally.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.