### PR TITLE
Widen attn_fwd forward tuning space on gfx1100

### DIFF
--- a/modules/flash/aot/attn_fwd.py
+++ b/modules/flash/aot/attn_fwd.py
@@ -45,6 +45,46 @@ def _parse_preload_options():
 
 PRE_LOAD_OPTIONS = _parse_preload_options()
 
+# Wider forward search space for gfx1100 inference functionals: when
+# _use_extended_search accepts one, these replace the wave32 block sizes/stages
+# below and are the whole candidate space (they include the wave32 tiles).
+EXTENDED_SEARCH_ARCHS = ('gfx1100',)
+EXTENDED_SEARCH_HEAD_DIMS = (64, 80, 128)
+# Tile sizes that are searched in the extended search space.
+EXTENDED_SEARCH_BLOCK_SIZES = [
+    (16, 16), (32, 16), (32, 32),
+    (64, 16), (64, 32), (64, 64),
+    (128, 16), (128, 32), (128, 64), (128, 128),
+    (256, 16), (256, 32), (256, 64),
+]
+EXTENDED_SEARCH_NUM_STAGES = [1, 2]
+# A third pipeline stage is searched on the BLOCK_N=16 tiles only -
+# this is derived from heuristics and experimental tuning results.
+EXTENDED_SEARCH_DEEP_PIPELINE_BLOCK_N = 16
+EXTENDED_SEARCH_DEEP_PIPELINE_NUM_STAGES = [3]
+
+
+def extended_search_grid():
+    """The widened space as ((BLOCK_M, BLOCK_N), num_stages) pairs."""
+    for tile in EXTENDED_SEARCH_BLOCK_SIZES:
+        stages = list(EXTENDED_SEARCH_NUM_STAGES)
+        if tile[1] == EXTENDED_SEARCH_DEEP_PIPELINE_BLOCK_N:
+            stages += EXTENDED_SEARCH_DEEP_PIPELINE_NUM_STAGES
+        for num_stages in stages:
+            yield tile, num_stages
+
+
+def _use_extended_search(f, arch, dtype, head_dim, causal_type):
+    """Whether `f` is one of the inference functionals the wider space targets.
+    """
+    return (arch in EXTENDED_SEARCH_ARCHS
+            and '*fp32' not in dtype
+            and head_dim in EXTENDED_SEARCH_HEAD_DIMS
+            and causal_type == 0
+            and f.choices.BIAS_TYPE == 0
+            and f.choices.ENABLE_DROPOUT is False
+            and f.choices.PADDED_HEAD is False)
+
 
 def gen_autotune_configs(f):
     """Generate architecture-aware forward tuning configurations."""
@@ -66,6 +106,11 @@ def gen_autotune_configs(f):
     num_warps = [2, 4] if wave64 else [4, 8]
     num_stages = [1]
 
+    if _use_extended_search(f, arch, dtype, head_dim, causal_type):
+        tile_stages = list(extended_search_grid())
+    else:
+        tile_stages = [(tile, s) for tile in block_sizes for s in num_stages]
+
     if arch == 'gfx950':
         for waves, pre_load_v in itertools.product(waves_per_eu, PRE_LOAD_OPTIONS):
             kw = {
@@ -79,8 +124,8 @@ def gen_autotune_configs(f):
             }
             yield ati.tune.Config(kw, num_stages=4, num_warps=8)
 
-    for (block_m, block_n), waves, warps, stages, pre_load_v in itertools.product(
-            block_sizes, waves_per_eu, num_warps, num_stages, PRE_LOAD_OPTIONS):
+    for ((block_m, block_n), stages), waves, warps, pre_load_v in itertools.product(
+            tile_stages, waves_per_eu, num_warps, PRE_LOAD_OPTIONS):
         if head_dim >= 512 and block_m == 128 and block_n == 128 and warps == 2:
             continue  # Timeout
         if dtype == '*fp32:16':

--- a/modules/flash/tune/desc.py
+++ b/modules/flash/tune/desc.py
@@ -34,10 +34,6 @@ class FlashTune(TuningDescription):
     ENTRY_CLASS = FlashEntry
     INPUT_METADATA = FlashInputMetadata
 
-    # gfx11 architectures whose tuning tables cover the full seqlen range; see
-    # validate_hw_feature().
-    FULL_SEQLEN_GFX11_ARCHS = ('gfx1100',)
-
     def _provider_for(self, name: str):
         """Resolve the DSL name `name` (e.g. 'attn_fwd' or 'op.attn_fwd') to
         (provider_module, bare_iface_name), lazily importing exactly the
@@ -120,12 +116,6 @@ class FlashTune(TuningDescription):
         if arch.startswith('gfx11') and entry.hdim > 256:
             return False, (f'arch {arch} does not support hdim={entry.hdim} '
                            f'(gfx11xx maximum is 256; larger hdim exceeds LDS/register limits)')
-        # Allowlist rather than denylist: a new gfx11 architecture then
-        # defaults to gated instead of silently tuning the largest entries.
-        if (arch.startswith('gfx11') and arch not in self.FULL_SEQLEN_GFX11_ARCHS
-                and (entry.seqlen_q > 2048 or entry.seqlen_k > 2048)):
-            return False, (f'No {arch} GPUs available for tuning: '
-                           f'only seqlen_q/k <= 2048 entries are tuned')
         return True, ''
 
     def _gen_ref(self, entry: FlashEntry, data_root: Path, extra_ims: list = []):

--- a/modules/flash/tune/desc.py
+++ b/modules/flash/tune/desc.py
@@ -34,6 +34,10 @@ class FlashTune(TuningDescription):
     ENTRY_CLASS = FlashEntry
     INPUT_METADATA = FlashInputMetadata
 
+    # gfx11 architectures whose tuning tables cover the full seqlen range; see
+    # validate_hw_feature().
+    FULL_SEQLEN_GFX11_ARCHS = ('gfx1100',)
+
     def _provider_for(self, name: str):
         """Resolve the DSL name `name` (e.g. 'attn_fwd' or 'op.attn_fwd') to
         (provider_module, bare_iface_name), lazily importing exactly the
@@ -116,8 +120,11 @@ class FlashTune(TuningDescription):
         if arch.startswith('gfx11') and entry.hdim > 256:
             return False, (f'arch {arch} does not support hdim={entry.hdim} '
                            f'(gfx11xx maximum is 256; larger hdim exceeds LDS/register limits)')
-        if arch.startswith('gfx11') and (entry.seqlen_q > 2048 or entry.seqlen_k > 2048):
-            return False, (f'Insufficient number of gfx1100 GPUs available for tuning arch {arch}: '
+        # Allowlist rather than denylist: a new gfx11 architecture then
+        # defaults to gated instead of silently tuning the largest entries.
+        if (arch.startswith('gfx11') and arch not in self.FULL_SEQLEN_GFX11_ARCHS
+                and (entry.seqlen_q > 2048 or entry.seqlen_k > 2048)):
+            return False, (f'No {arch} GPUs available for tuning: '
                            f'only seqlen_q/k <= 2048 entries are tuned')
         return True, ''
 


### PR DESCRIPTION
## What

Widens `attn_fwd`'s forward tuning search space on gfx1100/gfx1201 - 13 tiles x
stages, 496 candidates against the current 64 - and adds
`TuningDescription.select_impl_variants()` so a family can restrict which
candidates a given cell benchmarks. The hook defaults to every index, so it is
inert for any family or architecture that does not opt in.

Affects **6 of 396 functionals** on gfx1100: non-fp32, hdim 64/80/128,
non-causal, no bias, no dropout, `PADDED_HEAD=False`. The other 390 are untouched.

Also exempts gfx1100 from the gfx11 seqlen > 2048 cutoff in
`validate_hw_feature()` - written as `gfx11*` minus an allowlist, so a new gfx11
part defaults to gated, which is the recoverable direction.

## Cost

| measurements on the 6 widened functionals | |
|---|---|
| before this PR | 6 x 100 x 64 = **38,400** |
| widened, no rule | 6 x 100 x 496 = **297,600** (7.8x) |
| widened, with the rule | 6 x (10 x 496 + 90 x 64) = **64,320** (1.7x) |

The rule: off the `seqlen_q == seqlen_k` diagonal, admit only the pre-widening
candidates. Without it the widening is not affordable, which is why the
mechanism lands alongside it. The seqlen change is here for the same reason -
the widened tiles are exactly the ones that pay off at long sequence lengths, so
splitting it out would land a widening whose motivating shapes the entry filter
still rejects. Happy to split if you would rather review separately.

## Decisions not visible from the diff

- The hook returns **indices, not variants**. `impl_index` is the address of an
  HSACO at benchmark time, so returning a filtered list would renumber
  candidates and benchmark the wrong binaries.
- It is the only hook that sees both the candidates and the cell.
  `gen_autotune_configs()` gets a `Functional`, which has no sequence length, so
  the decision cannot live there.
- Rules are restrict-only and AND-ed, so "use the wide space on the diagonal"
  has to be written as "narrow everything off it". An empty table means "measure
  everything".
- `BASELINE_TILES`/`EXTENDED_SEARCH_ARCHS` are duplicated in `search_policy.py`
  rather than imported: the `aot` and `tune` trees load as two unrelated
  synthetic packages. Nothing at runtime notices them drifting, so a test
  asserts they agree.
- `_build_fanout` now runs family code (`TuneDesc()`, `ENTRY_CLASS.from_dict()`,
  the rule predicates) where before it only did dict lookups, so it can raise.
  GPU workers have no `db_conn` and the worker's own fallback is gated on it, so
  an escaping exception leaves the task in `running` forever
  (`generic_worker.py:219-231`); it is caught and returned as `mark_task_failed`.
- An empty fan-out hangs the same way: the `postprocess` blocks on an
  `impl_result` that will never arrive. At op level that is legitimate, so it is
  sent unblocked; at kernel level it is a bug, so the task fails with a message
  naming the cause instead of hanging.

## Reuse 

`AOTRITON_TUNING_DATABASE_REUSE` points gfx1101/1102/1103/1150-1153 at
`gfx1100_mod0` and gfx1200 at `gfx1201_mod0`, so widening exactly these two
covers the whole gfx11/gfx12 line; extending it further would only widen tuning
builds that never run.

The flip side: those parts inherit tiles chosen on hardware they were never
measured on, and gfx1150-1153 are APUs in a different image pack (`gfx115x`)
despite sharing gfx1100's database. They also inherit gfx1100's **seqlen bins**,
which is easier to miss - the fetch is `WHERE gpu = functional.database_gpus`
(`database/sqlite.py:62`) with no seqlen predicate, so a gfx1101 functional gets
gfx1100's 10x10 LUT. At seqlen 4096 they stop clamping into the 2048 bin and use
a config measured at 4096 on a discrete board.

A **follow-up PR**  https://github.com/ROCm/aotriton/pull/221 covers the other half: a winner chosen on gfx1100 may fail to
compile for another part in the group, and the release path
(`translate_dataframe`) applies no compile-success filter - that exists only on
the tuning path (`codegen/autotune.py:45-59`). The LUT entry stays a valid index
pointing at an unusable HSACO. That PR substitutes a config that did compile.
This PR raises how often that can happen: the widened tiles are the largest ones.

## Scope

- **Release builds are unaffected.** The widened grid only applies with
  `--build_for_tuning`; a release build builds signatures from database rows.
- Some large tile/hdim/stage combinations sit near the 64 KiB LDS limit
- `select_impl_variants()` is shaped as the seam a future Bayesian optimizer
  plugs into: list in, indices out, with the rule table surviving underneath as
  the hard-constraint layer. The current rule is a hand-written, zero-data
  version of what such an optimizer would learn - which cells deserve budget.

## Tests

Two CPU-only files, no hardcoded expectations; both drive the real generator and
the real policy. `test_flash_extended_search.py` covers the widened grid and the
rule, `test_tune_infra.py` the hook and the fan-out. Verified by mutation: eleven
single-line changes to the new code are each caught. Suite 297 passed, 2 skipped.

## AI Disclosure
Help of Claude Code was used for writing code.
All code review and testing were done by human