### PR TITLE
Handle failed kernels in tuned builds

### DIFF
--- a/python/codegen/autotune.py
+++ b/python/codegen/autotune.py
@@ -15,11 +15,13 @@ from ..utils import (
 from .common import (
     codegen_struct_cfields,
     MissingLutEntry,
+    NoCompiledKernel,
     hsaco_ondisk_name,
     hsaco_dir,
 )
 from .basetune import BaseTuneCodeGenerator
 import json
+import sys
 import numpy as np
 
 class AutotuneCodeGenerator(BaseTuneCodeGenerator):
@@ -38,25 +40,19 @@ class AutotuneCodeGenerator(BaseTuneCodeGenerator):
         self._sql = sql
         # TODO: support other binning algorithm
         kdesc = self._f.meta_object
+        self._lut_ctype_hint = None
+        inspect_compile_status = args.build_for_tuning_second_pass and not args.noimage_mode
         if args.build_for_tuning or self._df is None or self._df.empty:
             log(lambda : f'translate_empty_dataframe for kernel {kdesc.NAME}')
             self._lut_tensor, self._sigs, self._binning_dict = kdesc.translate_empty_dataframe(f)
             # Replace sigs with configs from KernelDescription.gen_autotune_configs
             if args.build_for_tuning and kdesc.is_tunable:
                 self._sigs = list(kdesc.gen_signatures_for_tuning(f))
-                if args.build_for_tuning_second_pass:
-                    image_path = hsaco_dir(args.build_dir, kdesc)
-                    def hsaco_compile_successful(ksig : KernelSignature):
-                        full = image_path / hsaco_ondisk_name(kdesc, ksig)
-                        if not full.exists():
-                            return False
-                        meta = full.with_suffix('.json')
-                        if not meta.exists():
-                            return False
-                        with open(meta) as f:
-                            j = json.load(f)
-                            return j['compile_status'] == 'Complete'
-                    self._sigs = [ ksig for ksig in self._sigs if hsaco_compile_successful(ksig) ]
+                if inspect_compile_status:
+                    self._sigs = [ ksig for ksig in self._sigs
+                                   if self.hsaco_compile_successful(ksig) ]
+            elif inspect_compile_status:
+                self.warn_if_default_failed()
         else:
             log(lambda : f'translate_dataframe for kernel {kdesc.NAME}')
             self._lut_tensor, self._sigs, self._binning_dict = kdesc.translate_dataframe(f, self._df)
@@ -70,7 +66,68 @@ class AutotuneCodeGenerator(BaseTuneCodeGenerator):
                         print("  SQL:", self._sql)
                         for err in errors:
                             print("    ERROR:", err)
+            if inspect_compile_status:
+                self.repoint_failed_lut_cells()
         assert all(isinstance(k, KernelSignature) for k in self._sigs)
+
+    def hsaco_compile_successful(self, ksig : KernelSignature) -> bool:
+        """Return whether the signature has a nonempty image with Complete status."""
+        kdesc = self._f.meta_object
+        image = hsaco_dir(self._args.build_dir, kdesc) / hsaco_ondisk_name(kdesc, ksig)
+        meta = image.with_suffix('.json')
+        if not image.exists() or not meta.exists():
+            return False
+        try:
+            if image.stat().st_size == 0:
+                return False
+            with open(meta) as fin:
+                return json.load(fin)['compile_status'] == 'Complete'
+        except (OSError, ValueError, KeyError, TypeError) as e:
+            print(f'WARNING: {meta} is unreadable ({e}), treating '
+                  f'{ksig.hsaco_entry_name} as failed', file=sys.stderr)
+            return False
+
+    def repoint_failed_lut_cells(self) -> None:
+        """Redirect failed LUT entries to the most-used compiled signature.
+
+        Keep the signature order unchanged because it determines packed-string
+        offsets in the first-pass shim.<kernel>.cc.
+        """
+        compiled = [self.hsaco_compile_successful(ksig) for ksig in self._sigs]
+        if all(compiled):
+            return
+        f = self._f
+        sigs = self._sigs
+        lut = self._lut_tensor
+        referenced = lut[lut >= 0].ravel()
+        ncells = np.bincount(referenced, minlength=len(sigs))
+        alive = [i for i, good in enumerate(compiled) if good]
+        if not alive:
+            raise NoCompiledKernel(f, [k.hsaco_entry_name for k in sigs])
+        repl = max(alive, key=lambda i: ncells[i])
+        # Pin the LUT type used by the first-pass shim.
+        self._lut_ctype_hint = (int(lut.min()), int(lut.max()))
+        for i, good in enumerate(compiled):
+            if good:
+                continue
+            if ncells[i]:
+                fate = (f'{int(ncells[i])} tuning table cell(s) repointed to '
+                        f'{sigs[repl].hsaco_entry_name}')
+            else:
+                fate = 'no tuning table cell referenced it'
+            print(f'WARNING: {f.arch} {f.meta_object.NAME}: kernel for '
+                  f'{sigs[i].hsaco_entry_name} failed to compile. {fate}',
+                  file=sys.stderr)
+            lut[lut == i] = repl
+
+    def warn_if_default_failed(self) -> None:
+        """Warn when a functional's default kernel failed."""
+        f = self._f
+        failed = [k for k in self._sigs if not self.hsaco_compile_successful(k)]
+        for ksig in failed:
+            print(f'WARNING: {f.arch} {f.meta_object.NAME}: {f.tunecc_signature} '
+                  f'uses only the default kernel {ksig.hsaco_entry_name}, which '
+                  f'failed to compile', file=sys.stderr)
 
     def generate(self):
         # Un "self._" section
@@ -166,9 +223,13 @@ class AutotuneCodeGenerator(BaseTuneCodeGenerator):
         f = self._f
         lut_min = int(np.min(lut_tensor))
         lut_max = int(np.max(lut_tensor))
+        if self._lut_ctype_hint is not None:
+            hint_min, hint_max = self._lut_ctype_hint
+            lut_min = min(lut_min, hint_min)
+            lut_max = max(lut_max, hint_max)
         for dtype in [np.int8, np.int16, np.int32, np.int64]:
             info = np.iinfo(dtype)
-            if info.min <= lut_min and lut_max <= info.max:
+            if info.min <= lut_min and lut_max < info.max:
                 break
         ctype =  f'int{np.iinfo(dtype).bits}_t'
         cshape = ''.join([f'[{s}]' for s in lut_tensor.shape])

--- a/python/codegen/basetune.py
+++ b/python/codegen/basetune.py
@@ -29,8 +29,9 @@ class BaseTuneCodeGenerator(ABC):
         tune_dir = self._args.build_dir / iface.FAMILY / f'{iface.TUNE_NAME}.{iface.NAME}'
         tune_dir.mkdir(parents=True, exist_ok=True)
         ondisk = tunecc_ondisk_name(f)
-        with open(tune_dir / 'manifest.nsv', 'a', encoding='utf-8') as mf:
-            mf.write(ondisk + '\x00' + f.tunecc_signature + '\x00\n')
+        if not self._args.build_for_tuning_second_pass:
+            with open(tune_dir / 'manifest.nsv', 'a', encoding='utf-8') as mf:
+                mf.write(ondisk + '\x00' + f.tunecc_signature + '\x00\n')
         return tune_dir / ondisk
 
     @property

--- a/python/codegen/common.py
+++ b/python/codegen/common.py
@@ -60,3 +60,16 @@ class MissingLutEntry(Exception):
 
     def __repr__(self):
         return f'{self._functional.tunecc_signature} has broken tuning table:\n{self._lut_tensor}'
+
+class NoCompiledKernel(Exception):
+    """Raised when a tuned functional has no compiled signature to use."""
+    def __init__(self, functional, hsaco_entry_names):
+        self._functional = functional
+        self._hsaco_entry_names = hsaco_entry_names
+
+    def __str__(self):
+        entries = '\n  '.join(self._hsaco_entry_names)
+        return (f'{self._functional.tunecc_signature} has no kernel that compiled '
+                f'for {self._functional.arch}:\n  {entries}')
+
+    __repr__ = __str__

--- a/python/codegen/root.py
+++ b/python/codegen/root.py
@@ -260,6 +260,9 @@ class RootGenerator(object):
         for f in futures:
             f.result()  # re-raise any worker exception
 
+        if args.build_for_tuning_second_pass:
+            return
+
         shard_names = ['Bare.shim', 'Bare.compile', 'Bare.cluster', 'Affine.cluster', 'Bare.flatzip']
         out_files = {name: args.build_dir / name for name in shard_names}
         # Truncate output files before appending

--- a/python/generate.py
+++ b/python/generate.py
@@ -34,7 +34,7 @@ def parse():
     # p.add_argument("--bare_mode", action='store_true', help="Instead of generating a proper Makefile, only generate a list of source files and leave the remaining tasks to cmake.")
     p.add_argument("--noimage_mode", action='store_true', help="Expect the GPU kernel images are built separately.")
     p.add_argument("--build_for_tuning", action='store_true', help="Include all GPU kernels in the dispatcher for performance tuning.")
-    p.add_argument("--build_for_tuning_second_pass", action='store_true', help="Only re-generate autotune files. Ignore HSACO kernels in the autotune files that failed to compile.")
+    p.add_argument("--build_for_tuning_second_pass", action='store_true', help="Regenerate tuning tables after GPU compilation. With --build_for_tuning, drop signatures that failed to compile; otherwise repoint their LUT cells to a compiled signature.")
     p.add_argument("--build_for_tuning_but_skip_kernel", type=str, default='', nargs='*',
                    help="Excluse certain GPU kernels for performance tuning when --build_for_tuning=True.")
     # Always True

--- a/python/test/test_autotune_compile_status.py
+++ b/python/test/test_autotune_compile_status.py
@@ -1,0 +1,324 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for handling failed kernel artifacts during second-pass codegen.
+
+The generator is subclassed to test the status and LUT logic without a GPU,
+compiler, database, or the rest of its construction pipeline.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from aotriton.codegen.autotune import AutotuneCodeGenerator
+from aotriton.codegen.common import (
+    NoCompiledKernel,
+    hsaco_dir,
+    hsaco_ondisk_name,
+)
+
+
+class _Sig:
+    def __init__(self, name):
+        self.hsaco_entry_name = name
+
+    def __repr__(self):
+        return f'_Sig({self.hsaco_entry_name!r})'
+
+
+class _Kdesc:
+    FAMILY = 'fakefamily'
+    NAME = 'fake_kernel'
+    TUNE_NAME = 'autotune'
+
+
+class _Functional:
+    arch = 'gfx1103'
+    name = 'fake_functional'
+    tunecc_signature = 'fake_kernel-fakefunctional'
+    meta_object = _Kdesc()
+    optimized_for = ['gfx1103']  # codegen_format_lut labels one block per GPU
+
+
+class _Args:
+    def __init__(self, build_dir=None, *, second_pass=False):
+        self.build_dir = build_dir
+        self.build_for_tuning_second_pass = second_pass
+
+
+class _Kernel:
+    def __init__(self, unique_path):
+        self.unique_path = Path(unique_path)
+
+
+class _Completed:
+    returncode = 0
+
+
+class _Generator(AutotuneCodeGenerator):
+    def __init__(self, sigs, lut_tensor, compiled):
+        self._sigs = list(sigs)
+        self._lut_tensor = np.asarray(lut_tensor)
+        self._lut_ctype_hint = None
+        self._f = _Functional()
+        self._args = _Args()
+        self._compiled = dict(zip(sigs, compiled))
+
+    def hsaco_compile_successful(self, ksig):
+        return self._compiled[ksig]
+
+
+def _sigs(n):
+    return [_Sig(f'kernel-{i}') for i in range(n)]
+
+
+_COMPLETE = json.dumps({'compile_status': 'Complete'})
+_TIMEOUT = json.dumps({'compile_status': 'Timeout'})
+
+
+@pytest.mark.parametrize('image,status,usable,reported', [
+    # Image and status are required independently. Malformed metadata is reported;
+    # missing artifacts are treated as failed without a corruption warning.
+    (b'\x7fELF', _COMPLETE,           True,  False),
+    (b'\x7fELF', _TIMEOUT,            False, False),
+    (None,       _COMPLETE,           False, False),
+    (b'\x7fELF', None,                False, False),
+    (b'',        _COMPLETE,           False, False),
+    (b'\x7fELF', '{"compile_status":', False, True),  # ValueError
+    (b'\x7fELF', '{}',                False, True),     # KeyError
+])
+def test_a_kernel_is_usable_only_with_an_image_and_a_complete_status(
+        tmp_path, capsys, image, status, usable, reported):
+    """Lay out one kernel the way compile.py does, then read its status back."""
+    sig = _Sig('kernel-under-test')
+    image_dir = hsaco_dir(tmp_path, _Kdesc)
+    image_dir.mkdir(parents=True, exist_ok=True)
+    path = image_dir / hsaco_ondisk_name(_Kdesc, sig)
+    if image is not None:
+        path.write_bytes(image)
+    if status is not None:
+        path.with_suffix('.json').write_text(status)
+
+    gen = _Generator.__new__(_Generator)
+    gen._f = _Functional()
+    gen._args = _Args(tmp_path)
+    assert AutotuneCodeGenerator.hsaco_compile_successful(gen, sig) is usable
+
+    err = capsys.readouterr().err
+    if reported:
+        assert path.with_suffix('.json').name in err
+    else:
+        assert err == '', 'a kernel not built yet is not a corrupt one'
+
+
+def test_only_the_cells_of_a_failed_kernel_move_and_they_move_to_the_busiest_survivor(capsys):
+    """Repoint failed cells without changing unaffected cells or signature order.
+
+    Signature order fixes offsets into the first-pass shim's packed strings.
+    """
+    sigs = _sigs(5)
+    #           0 failed and busiest overall, 4 failed but unreferenced
+    compiled = [False, True, True, True, False]
+    lut = np.array([[-1] * 4 + [0] * 10 + [1] * 2 + [2] * 5 + [3] * 3])
+    gen = _Generator(sigs, lut.copy(), compiled)
+    gen.repoint_failed_lut_cells()
+    new = gen._lut_tensor
+
+    assert len(gen._sigs) == len(sigs)
+    for got, want in zip(gen._sigs, sigs):
+        assert got is want, 'the signature list did not survive the pass untouched'
+
+    failed = [i for i, good in enumerate(compiled) if not good]
+    assert not set(new.ravel().tolist()) & set(failed), 'a failed kernel is still reachable'
+
+    kept = ~np.isin(lut, failed)
+    assert (new[kept] == lut[kept]).all(), 'a cell that did not have to move was moved'
+
+    moved_to = set(new[~kept].tolist())
+    assert len(moved_to) == 1
+    cells = {i: int((lut == i).sum()) for i, good in enumerate(compiled) if good}
+    assert moved_to == {max(cells, key=cells.get)}
+
+    err = capsys.readouterr().err
+    for i in failed:
+        assert sigs[i].hsaco_entry_name in err
+    # Named once, for the one failure that actually cost something.
+    assert err.count(sigs[moved_to.pop()].hsaco_entry_name) == 1
+
+
+
+def test_repointing_does_not_narrow_the_generated_lut_type():
+    """Keep the first-pass LUT type after its highest index is repointed."""
+    sigs = _sigs(128)
+    compiled = [True] * len(sigs)
+    compiled[-1] = False
+    gen = _Generator(sigs, [[0, 1, 2, 3, 4, 5, len(sigs) - 1]], compiled)
+    assert gen.codegen_format_lut(gen._lut_tensor)[0] == 'int16_t'
+    gen.repoint_failed_lut_cells()
+    assert int(gen._lut_tensor.max()) < 127, 'the narrowing this test guards against'
+    assert gen.codegen_format_lut(gen._lut_tensor)[0] == 'int16_t'
+
+
+def test_a_functional_with_nothing_left_to_dispatch_to_fails_the_build():
+    """Fail when no compiled signature remains as a replacement."""
+    sigs = _sigs(3)
+    gen = _Generator(sigs, [[0, 1, 2]], [False] * len(sigs))
+
+    with pytest.raises(NoCompiledKernel) as excinfo:
+        gen.repoint_failed_lut_cells()
+    rendered = str(excinfo.value)
+    assert _Functional.tunecc_signature in rendered
+    assert _Functional.arch in rendered
+    for sig in sigs:
+        assert sig.hsaco_entry_name in rendered
+
+
+def test_a_default_only_functional_reports_a_compile_failure(capsys):
+    """Report a failed default when there is no alternative to select."""
+    only = _sigs(1)
+    gen = _Generator(only, [[0]], [False])
+    gen.warn_if_default_failed()
+
+    warned = capsys.readouterr().err
+    assert _Functional.arch in warned
+    assert _Functional.tunecc_signature in warned
+    assert only[0].hsaco_entry_name in warned
+
+    gen = _Generator(only, [[0]], [True])
+    gen.warn_if_default_failed()
+    assert capsys.readouterr().err == ''
+
+
+def test_second_pass_does_not_append_tuning_manifest(tmp_path):
+    """Only the first pass records generated tuning-table sources."""
+    functional = _Functional()
+    args = _Args(tmp_path, second_pass=False)
+    gen = _Generator.__new__(_Generator)
+    gen._args = args
+    gen._f = functional
+
+    path = gen.get_cc_file(functional)
+    manifest = path.parent / 'manifest.nsv'
+    before = manifest.read_bytes()
+
+    args.build_for_tuning_second_pass = True
+    assert gen.get_cc_file(functional) == path
+    assert manifest.read_bytes() == before
+
+
+@pytest.mark.parametrize('has_df,tuning,second_pass,noimage,expect', [
+    # A tuned build repoints LUT cells; a tuning build drops signatures instead.
+    (True,  False, True,  False, 'repoint'),
+    (True,  False, False, False, 'nothing'),  # first pass: no compile status yet
+    (True,  False, True,  True,  'nothing'),  # nothing to read under --noimage_mode
+    (True,  True,  True,  False, 'drop'),
+    (True,  True,  True,  True,  'nothing'),  # build-tune.sh --shim: every signature
+                                              # would look failed, leaving empty arrays
+    (True,  True,  False, False, 'nothing'),
+    # Without tuning data there is one default signature and nothing to repoint
+    # it to, so the untuned path only warns.
+    (False, False, True,  False, 'warn'),
+])
+def test_the_second_pass_runs_the_branch_that_matches_the_build(
+        monkeypatch, has_df, tuning, second_pass, noimage, expect):
+    """Pin the helper call sites and no-image guards in __init__."""
+    from aotriton.codegen import autotune as A
+    from aotriton.codegen import basetune as B
+
+    sigs = _sigs(2)
+    lut = np.array([[0, 1]])
+
+    class _BothKdesc(_Kdesc):
+        is_tunable = True
+
+        def translate_dataframe(self, f, df):
+            return lut.copy(), list(sigs), {}
+
+        def translate_empty_dataframe(self, f):
+            return lut.copy(), list(sigs), {}
+
+        def gen_signatures_for_tuning(self, f):
+            return iter(sigs)
+
+        def sancheck_lut_tensor(self, f, lut_tensor):
+            return True, [], []
+
+    class _NonEmptyDf:
+        empty = False
+
+    functional = _Functional()
+    functional.meta_object = _BothKdesc()
+
+    args = _Args()
+    args.build_for_tuning = tuning
+    args.build_for_tuning_second_pass = second_pass
+    args.noimage_mode = noimage
+
+    def _base_init(self, args, f, df, parent_repo):
+        self._args, self._f, self._df, self._parent_repo = args, f, df, parent_repo
+
+    monkeypatch.setattr(B.BaseTuneCodeGenerator, '__init__', _base_init)
+    # The stand-in signatures are not KernelSignature instances, and __init__
+    # ends by asserting they are.
+    monkeypatch.setattr(A, 'KernelSignature', _Sig)
+    # The first signature is the one the compiler rejected.
+    monkeypatch.setattr(A.AutotuneCodeGenerator, 'hsaco_compile_successful',
+                        lambda self, ksig: ksig is not sigs[0])
+
+    repointed = []
+    monkeypatch.setattr(A.AutotuneCodeGenerator, 'repoint_failed_lut_cells',
+                        lambda self: repointed.append(True))
+    warned = []
+    monkeypatch.setattr(A.AutotuneCodeGenerator, 'warn_if_default_failed',
+                        lambda self: warned.append(True))
+
+    gen = A.AutotuneCodeGenerator(args, functional,
+                                  _NonEmptyDf() if has_df else None, (), None)
+
+    assert bool(repointed) is (expect == 'repoint')
+    assert bool(warned) is (expect == 'warn')
+    if expect == 'drop':
+        assert gen._sigs == sigs[1:]
+    else:
+        assert gen._sigs == sigs
+
+
+def test_the_second_pass_leaves_the_build_manifests_alone(tmp_path, monkeypatch):
+    """Leave first-pass Bare.* files unchanged when workers write no shards.
+
+    The seeded shards differ from those files, so an accidental merge is visible.
+    """
+    from aotriton.codegen import root as R
+
+    items = ['flash/triton/attn_fwd', 'flash/triton/bwd_kernel_dq']
+    names = ['Bare.shim', 'Bare.compile', 'Bare.cluster', 'Affine.cluster', 'Bare.flatzip']
+    for item in items:
+        shard_dir = tmp_path / 'Bare.shards' / R._shard_path(item)
+        shard_dir.mkdir(parents=True)
+        for name in names:
+            (shard_dir / name).write_text(f'stale-shard:{item}:{name}\n')
+    for name in names:
+        (tmp_path / name).write_text(''.join(f'{item}:{name}\n' for item in items))
+    before = {name: (tmp_path / name).read_text() for name in names}
+
+    gen = R.RootGenerator.__new__(R.RootGenerator)
+    gen._args = _Args(tmp_path)
+    gen._args.selective = None
+    gen._args.build_for_tuning_second_pass = True
+    gen._dispatcher_operators = []
+    gen._affine_kernels = []
+    gen._triton_kernels = [_Kernel(item) for item in items]
+
+    spawned = []
+    monkeypatch.setattr(R.subprocess, 'run',
+                        lambda cmd, **kw: spawned.append(cmd) or _Completed())
+    monkeypatch.setattr(R.sys, 'argv', ['generate', '--build_for_tuning_second_pass'])
+
+    gen.launch_workers()
+
+    assert len(spawned) == len(items), 'every item still gets a second-pass worker'
+    for name in names:
+        assert (tmp_path / name).read_text() == before[name]

--- a/v3src/CMakeLists.txt
+++ b/v3src/CMakeLists.txt
@@ -160,6 +160,10 @@ COMMAND_ERROR_IS_FATAL ANY
 
 # Compile HSACO Kernels
 if(NOT AOTRITON_NOIMAGE_MODE)
+  # Configuration reruns the first pass above. Touch this afterwards so the
+  # build-time second pass reruns even when the generated tables look current.
+  set(AOTRITON_FIRST_PASS_STAMP "${AOTRITON_V2_BUILD_DIR}/first_pass.stamp")
+  file(TOUCH "${AOTRITON_FIRST_PASS_STAMP}")
   set(SIGNATURE_FILE "${AOTRITON_V2_BUILD_DIR}/__signature__.json")
   add_custom_command(OUTPUT "${SIGNATURE_FILE}"
     COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR}
@@ -346,26 +350,6 @@ if(NOT AOTRITON_NOIMAGE_MODE)
   add_custom_target(aotriton_kernel_storage_v3 ALL DEPENDS ${ALL_ZIPS})
 endif(NOT AOTRITON_NOIMAGE_MODE)
 
-# The build logic is slightly different when AOTRITON_BUILD_FOR_TUNING=ON
-# Some GPU kernels may fail to compile and autotune files should be re-generated accordingly
-if(AOTRITON_BUILD_FOR_TUNING)
-  # Regenerate with --ignore_missing_kernels
-  add_custom_target(aotriton_v2_regen_shim
-    COMMAND ${CMAKE_COMMAND}
-    -E env VIRTUAL_ENV=${VENV_DIR}
-    AOTRITON_ENABLE_FP32=${AOTRITON_ENABLE_FP32}
-    "${VENV_BIN_PYTHON}" -m aotriton.generate
-    --target_gpus ${EFFECTIVE_TARGET_GPUS}
-    --build_dir "${AOTRITON_V2_BUILD_DIR}"
-    --root_dir "${CMAKE_CURRENT_SOURCE_PARENT_DIR}"
-    ${GENERATE_OPTION}
-    --build_for_tuning_second_pass
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_PARENT_DIR}")
-  if(NOT AOTRITON_NOIMAGE_MODE)
-    add_dependencies(aotriton_v2_regen_shim aotriton_v2_compile)
-  endif(NOT AOTRITON_NOIMAGE_MODE)
-endif(AOTRITON_BUILD_FOR_TUNING)
-
 set(AOTRITON_SHIM_FLAGS "")
 if(AOTRITON_NAME_SUFFIX)
   list(APPEND AOTRITON_SHIM_FLAGS "--library_suffix" "${AOTRITON_NAME_SUFFIX}")
@@ -373,6 +357,31 @@ endif()
 message(STATUS "AOTRITON_SHIM_FLAGS ${AOTRITON_SHIM_FLAGS}")
 
 file(STRINGS "${AOTRITON_V2_BUILD_DIR}/Bare.shim" SHIM_CC_FILES ENCODING UTF-8)
+
+# Regenerate tuning tables after compilation so they avoid failed images.
+if(NOT AOTRITON_NOIMAGE_MODE)
+  # The generator emits both kinds, although only autotune tables can change.
+  set(AOTRITON_TUNE_CC_FILES ${SHIM_CC_FILES})
+  list(FILTER AOTRITON_TUNE_CC_FILES INCLUDE REGEX "/(auto|op)tune\\.[^/]+/[^/]+\\.cc$")
+  list(LENGTH AOTRITON_TUNE_CC_FILES NUM_TUNE_CC_FILES)
+  message(STATUS "Tuning tables checked by the second pass: ${NUM_TUNE_CC_FILES}")
+  if(AOTRITON_TUNE_CC_FILES)
+    add_custom_command(OUTPUT ${AOTRITON_TUNE_CC_FILES}
+      COMMAND ${CMAKE_COMMAND}
+      -E env VIRTUAL_ENV=${VENV_DIR}
+      AOTRITON_ENABLE_FP32=${AOTRITON_ENABLE_FP32}
+      "${VENV_BIN_PYTHON}" -X utf8 -m aotriton.generate
+      --target_gpus ${EFFECTIVE_TARGET_GPUS}
+      --build_dir "${AOTRITON_V2_BUILD_DIR}"
+      --root_dir "${CMAKE_CURRENT_SOURCE_PARENT_DIR}"
+      ${GENERATE_OPTION}
+      --build_for_tuning_second_pass
+      DEPENDS ${ALL_HSACOS} "${AOTRITON_FIRST_PASS_STAMP}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_PARENT_DIR}"
+      COMMENT "Checking tuning tables against GPU kernel compile status"
+      VERBATIM)
+  endif(AOTRITON_TUNE_CC_FILES)
+endif(NOT AOTRITON_NOIMAGE_MODE)
 
 aux_source_directory(. CC_FILES)
 # Modular family C++ sources: every modules/<family>/csrc/**.cc (recursively, so
@@ -397,7 +406,6 @@ set_target_properties(aotriton_v2 PROPERTIES
 )
 if(AOTRITON_BUILD_FOR_TUNING)
   target_compile_definitions(aotriton_v2 PRIVATE -DAOTRITON_BUILD_FOR_TUNING=1)
-  add_dependencies(aotriton_v2 aotriton_v2_regen_shim)
 else(AOTRITON_BUILD_FOR_TUNING)
   target_compile_definitions(aotriton_v2 PRIVATE -DAOTRITON_BUILD_FOR_TUNING=0)
 endif(AOTRITON_BUILD_FOR_TUNING)


### PR DESCRIPTION
## Summary

Prevent database-backed dispatch tables from selecting Triton kernels whose
build produced an unusable artifact. With a positive
`AOTRITON_GPU_BUILD_TIMEOUT`, `compile.py` may record a failure as a zero-byte
`.hsaco` plus status JSON and still let the build continue; that image was then
packaged and could fail at runtime with `hipErrorInvalidImage`.

## Implementation

After HSACO compilation, rerun code generation and treat a signature as usable
only when its image is nonempty and its status is `Complete`.

For a database-backed functional, repoint failed LUT entries to the compiled
signature already serving the most cells. This is a generic, deterministic
fallback that needs no kernel-specific performance-model knowledge. Keep the
signature list unchanged because its order defines offsets into the packed
string table in the first-pass `shim.<kernel>.cc`. Also retain the first-pass
LUT integer type because that shim is not regenerated.

Fail with `NoCompiledKernel` when no compiled signature survives. A functional
built with only its default kernel has no replacement, so it emits a warning and
keeps the existing behavior.

The second pass leaves `Bare.*` files and tuning manifests untouched. CMake
models its tuning-table `.cc` files as generated outputs depending on all HSACOs,
so Ninja recompiles changed tables in the same invocation. A stamp reruns the
second pass after reconfiguration, when the configure-time first pass may have
restored the original tables. No-image builds skip the pass.

This handles recorded compile failures only; it cannot detect a nonempty kernel
that compiles successfully but is incorrect at load or execution time.

## Testing

- CPU-only focused tests: artifact validation, LUT repointing, signature/order and
  LUT-type preservation, no-survivor and default-only behavior, build-mode
  routing, and preservation of generated manifests.
- Full Python suite: `279 passed, 2 skipped`.
- Manual 19,187-kernel gfx1100 build: healthy pass was a no-op; one failed kernel
  changed and rebuilt one tuning table; reconfigure reran the repair; the next
  Ninja invocation reported no work.

## AI Disclosure
  Help of Claude Code was used for writing this code.
  All the code was reviewed and tested by human.