### PR TITLE
Add watchdog to pytest-gpu-lease package

### DIFF
--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -87,6 +87,31 @@ fi
     [ -n "$_sig" ] && cat "$_sig" \
       || echo "NO __signature__ file at $PYTHONPATH/aotriton.images/"
   } > "${outdir}/${fnprefix}${pass}.out"
+  # pytest-timeout's SIGALRM cannot interrupt a worker parked in an unreturning
+  # HIP call -- CPython only runs a Python signal handler at a bytecode
+  # boundary, and a thread stuck in a C call never reaches one. The watchdog
+  # polls each worker's lease page from a separate process instead and
+  # escalates SIGTERM (for a faulthandler stack dump) then SIGKILL from
+  # outside, where it needs no cooperation from the wedged thread at all.
+  #
+  # /dev/shm rather than $outdir: this file is pure IPC between the workers
+  # and the watchdog for the lifetime of this one run, never an artifact worth
+  # keeping or shipping off-host. Named with both $pass and $$ (this
+  # subshell's parent pid -- bash's $$ reports that, not the subshell's own,
+  # even inside `( ... )`) so concurrent passes, and concurrent runs on the
+  # same host, never collide on one file.
+  export GPU_LEASE_LOCKFILE="/dev/shm/gpu_lease.${pass}.$$"
+  python3 -m pytest_gpu_lease.watchdog --workers "${ngpus}" \
+    2>"${outdir}/${fnprefix}${pass}.watchdog.err" &
+  watchdog_pid=$!
+  # EXIT fires when this subshell exits by any path, including the `|| true`
+  # below swallowing a pytest failure -- exactly the scope the watchdog and
+  # its lock file should live for. Kill before unlink: a watchdog left running
+  # past its own pytest session would go on polling a file nothing populates
+  # anymore and could eventually act on a pid number reused for something
+  # unrelated; a lock file deleted while still open is harmless by contrast,
+  # since the inode lives on until every fd on it closes.
+  trap 'kill "${watchdog_pid}" 2>/dev/null; rm -f "${GPU_LEASE_LOCKFILE}"' EXIT
   # One invocation over the whole suite dir (conftest.py sets up sys.path); pytest
   # collects test_backward / test_varlen together (test_forward.py is excluded via
   # conftest.py's collect_ignore - its coverage is a subset of test_backward.py's).

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -91,7 +91,6 @@ fi
   # collects test_backward / test_varlen together (test_forward.py is excluded via
   # conftest.py's collect_ignore - its coverage is a subset of test_backward.py's).
   pytest --tb=line -n ${ngpus} --max-worker-restart 9999 -rfEsx \
-    --timeout=300 \
     -p no:cacheprovider \
     ${SELECT_FROM} \
     modules/flash/tests \

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -92,29 +92,36 @@ fi
   # Named with both $pass and $$ for uniqueness.
   # Note: this is inside a subshell. Hence parent pid `$$` is the right one to use.
   export GPU_LEASE_LOCKFILE="/dev/shm/gpu_lease.${pass}.$$"
-  # The same `python` that provides `pytest`: requirements-dev.txt installs
-  # ./python/pytest-gpu-lease into it, so failing to import is a broken
-  # environment to hear about, not something to probe around.
-  python -m pytest_gpu_lease.watchdog --workers "${ngpus}" \
-    2>"${outdir}/${fnprefix}${pass}.watchdog.err" &
+  # One stderr file for the whole pass, so there is a single thing to tail.
+  # Truncated once here and appended to from then on: two `2>` on one path
+  # would have pytest re-truncate a file the watchdog already holds open, and
+  # the watchdog's fd keeps its own offset, so its next line would land past a
+  # hole.
+  _errfile="${outdir}/${fnprefix}${pass}.err"
+  : > "${_errfile}"
+  # Start watchdog service, assume pytest_gpu_lease already installed.
+  # If not, do it with `pip install -r requirements-dev.txt`
+  python -m pytest_gpu_lease.watchdog --workers "${ngpus}" 2>>"${_errfile}" &
   watchdog_pid=$!
-  # Loud rather than silent: without this the only evidence of a watchdog that
-  # never started is a stderr file nobody opens until a pass has already hung,
-  # and with --timeout=300 gone that is a pass with no hang protection at all.
+  # Report either way: a silent success reads exactly like a watchdog that
+  # never started, and the difference only becomes visible once a pass has
+  # already hung -- with --timeout=300 gone, with no hang protection at all.
   sleep 1
-  kill -0 "${watchdog_pid}" 2>/dev/null \
-    || echo "WARNING: pytest_gpu_lease.watchdog did not start; this pass has NO hang protection. See ${outdir}/${fnprefix}${pass}.watchdog.err" >&2
+  if kill -0 "${watchdog_pid}" 2>/dev/null; then
+    echo "run-test.sh: watchdog running, pid ${watchdog_pid}, lockfile ${GPU_LEASE_LOCKFILE}" >> "${_errfile}"
+  else
+    echo "run-test.sh: WARNING watchdog did not start; this pass has NO hang protection" \
+      | tee -a "${_errfile}" >&2
+  fi
   # The watchdog unlinks the lock file itself, so this only has to stop it.
   # `wait` is what makes that deterministic: `kill` just posts the signal, and
   # without waiting we would return while the unlink is still in flight and
   # leave a zombie behind until PID 1 reaps it.
   _stop_watchdog() { kill "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
   # EXIT alone is not enough: an untrapped SIGTERM or SIGHUP kills the shell
-  # without running it (measured; SIGINT does run it). Naming them explicitly
-  # matters more than it used to: the watchdog is a service that never stops on
-  # its own, so this is the only thing that stops it. Under SIGKILL, which no
-  # trap can catch, it is left running -- inert, but visible in `ps`, and its
-  # /dev/shm lock file stays behind.
+  # without running it (measured; SIGINT does run it).
+  # Known Issue: kill -9 CI script (rarely needed) will leave stale lock file
+  # under /dev/shm. Users should terminate manually by inspecting ps.
   trap '_stop_watchdog' EXIT
   trap '_stop_watchdog; exit 130' INT
   trap '_stop_watchdog; exit 143' TERM HUP
@@ -127,7 +134,7 @@ fi
     modules/flash/tests \
     -v \
     1>>"${outdir}/${fnprefix}${pass}.out" \
-    2>"${outdir}/${fnprefix}${pass}.err" || true
+    2>>"${_errfile}" || true
   grep '^FAILED' "${outdir}/${fnprefix}${pass}.out"|sed 's/^FAILED //' | sed 's/].*/]/' > "${outdir}/sel${pass}.txt"
   if [ -n "${RECORD_ADIFFS_TO:-}" ]; then
     SCRIPT_DIR_ABS="$(cd "${SCRIPT_DIR}" && pwd)"

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -151,14 +151,25 @@ fi
     # The watchdog unlinks the lock file itself; this only stops it. SIGTERM is
     # its documented stop signal, named rather than left to `kill`'s default, and
     # `wait` reaps it so the unlink has finished before we return.
+    #
+    # pytest is stopped from here too, and by pid. Ctrl+C reaches it on its own
+    # (SIGINT goes to the whole foreground group) but Ctrl+\\ does not:
+    # measured, SIGQUIT kills this shell outright while pytest and the watchdog,
+    # both of which inherited SIG_IGN for it, carry on. `pytest_pid` is empty
+    # until pytest starts, which covers the early-exit path below.
     _stop_watchdog() { kill -s TERM "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
-    # EXIT alone is not enough: an untrapped SIGTERM or SIGHUP kills the shell
-    # without running it (measured; SIGINT does run it).
+    _stop_pass() {
+      kill -s TERM "${pytest_pid:-}" 2>/dev/null; wait "${pytest_pid:-}" 2>/dev/null
+      _stop_watchdog
+    }
+    # EXIT alone is not enough: an untrapped SIGTERM, SIGHUP or SIGQUIT kills
+    # the shell without running it (measured; SIGINT does run it).
     # Known Issue: kill -9 CI script (rarely needed) will leave stale lock file
     # under /dev/shm. Users should terminate manually by inspecting ps.
-    trap '_stop_watchdog' EXIT
-    trap '_stop_watchdog; exit 130' INT
-    trap '_stop_watchdog; exit 143' TERM HUP
+    trap '_stop_pass' EXIT
+    trap '_stop_pass; exit 130' INT
+    trap '_stop_pass; exit 131' QUIT
+    trap '_stop_pass; exit 143' TERM HUP
     # Fatal here, unlike the no-pidfd case above: we asked for a watchdog and did
     # not get one, which is an environment that is broken rather than merely old,
     # and the failure would otherwise surface as one wedged worker eating the
@@ -185,7 +196,13 @@ fi
     modules/flash/tests \
     -v \
     1>>"${outdir}/${fnprefix}${pass}.out" \
-    2>>"${_errfile}" || true
+    2>>"${_errfile}" &
+  # Backgrounded so the traps above can reach it by pid; `wait` is
+  # interrupted when one fires, where a foreground pytest would have to
+  # finish first.
+  pytest_pid=$!
+  wait "${pytest_pid}" || true
+  pytest_pid=''
   # The check before pytest only proved the watchdog survived its first
   # second. If it died somewhere in the middle, everything after that point
   # ran with no hang protection, and the results should not be read as if it

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -109,16 +109,6 @@ fi
   python -m pytest_gpu_lease.watchdog --lockfile "${GPU_LEASE_LOCKFILE}" \
     --workers "${ngpus}" 2>>"${_errfile}" &
   watchdog_pid=$!
-  # Report either way: a silent success reads exactly like a watchdog that
-  # never started, and the difference only becomes visible once a pass has
-  # already hung -- with --timeout=300 gone, with no hang protection at all.
-  sleep 1
-  if kill -0 "${watchdog_pid}" 2>/dev/null; then
-    echo "run-test.sh: watchdog running, pid ${watchdog_pid}, lockfile ${GPU_LEASE_LOCKFILE}" >> "${_errfile}"
-  else
-    echo "run-test.sh: WARNING watchdog did not start; this pass has NO hang protection" \
-      | tee -a "${_errfile}" >&2
-  fi
   # The watchdog unlinks the lock file itself; this only stops it. SIGTERM is
   # its documented stop signal, named rather than left to `kill`'s default, and
   # `wait` reaps it so the unlink has finished before we return.
@@ -130,6 +120,18 @@ fi
   trap '_stop_watchdog' EXIT
   trap '_stop_watchdog; exit 130' INT
   trap '_stop_watchdog; exit 143' TERM HUP
+  # Fatal, not a warning. --timeout=300 is gone, so a pass without the
+  # watchdog has no hang protection at all, and the way that surfaces is one
+  # wedged worker eating the remaining 22 hours. Better to lose the run now.
+  # Reported on success too: silence reads exactly like a failure to start.
+  sleep 1
+  if kill -0 "${watchdog_pid}" 2>/dev/null; then
+    echo "run-test.sh: watchdog running, pid ${watchdog_pid}, lockfile ${GPU_LEASE_LOCKFILE}" >> "${_errfile}"
+  else
+    echo "run-test.sh: watchdog did not start; refusing to run a pass with no hang protection" \
+      | tee -a "${_errfile}" >&2
+    exit 1
+  fi
   # One invocation over the whole suite dir (conftest.py sets up sys.path); pytest
   # collects test_backward / test_varlen together (test_forward.py is excluded via
   # conftest.py's collect_ignore - its coverage is a subset of test_backward.py's).

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -101,7 +101,13 @@ fi
   : > "${_errfile}"
   # Start watchdog service, assume pytest_gpu_lease already installed.
   # If not, do it with `pip install -r requirements-dev.txt`
-  python -m pytest_gpu_lease.watchdog --workers "${ngpus}" 2>>"${_errfile}" &
+  #
+  # --lockfile is redundant with the exported GPU_LEASE_LOCKFILE the watchdog
+  # would fall back to, and passed anyway so that `ps aux` says which file each
+  # watchdog is watching. That is how a stale one from a SIGKILLed pass is told
+  # apart from the live one; an env var is not visible in ps output.
+  python -m pytest_gpu_lease.watchdog --lockfile "${GPU_LEASE_LOCKFILE}" \
+    --workers "${ngpus}" 2>>"${_errfile}" &
   watchdog_pid=$!
   # Report either way: a silent success reads exactly like a watchdog that
   # never started, and the difference only becomes visible once a pass has

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -123,7 +123,10 @@ fi
   # `wait` is what makes that deterministic: `kill` just posts the signal, and
   # without waiting we would return while the unlink is still in flight and
   # leave a zombie behind until PID 1 reaps it.
-  _stop_watchdog() { kill "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
+  # `-s TERM` rather than a bare `kill`: SIGTERM is the watchdog's documented
+  # stop signal and the only one it treats as a clean shutdown, so name it here
+  # instead of inheriting whatever the shell's default happens to be.
+  _stop_watchdog() { kill -s TERM "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
   # EXIT alone is not enough: an untrapped SIGTERM or SIGHUP kills the shell
   # without running it (measured; SIGINT does run it).
   # Known Issue: kill -9 CI script (rarely needed) will leave stale lock file

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -186,6 +186,14 @@ fi
     -v \
     1>>"${outdir}/${fnprefix}${pass}.out" \
     2>>"${_errfile}" || true
+  # The check before pytest only proved the watchdog survived its first
+  # second. If it died somewhere in the middle, everything after that point
+  # ran with no hang protection, and the results should not be read as if it
+  # had been there.
+  if [ "${use_watchdog}" != 0 ] && ! kill -0 "${watchdog_pid}" 2>/dev/null; then
+    echo "run-test.sh: WARNING the watchdog died during this pass; an unknown" \
+         "portion of it ran with no hang protection" | tee -a "${_errfile}" >&2
+  fi
   grep '^FAILED' "${outdir}/${fnprefix}${pass}.out"|sed 's/^FAILED //' | sed 's/].*/]/' > "${outdir}/sel${pass}.txt"
   if [ -n "${RECORD_ADIFFS_TO:-}" ]; then
     SCRIPT_DIR_ABS="$(cd "${SCRIPT_DIR}" && pwd)"

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -119,13 +119,9 @@ fi
     echo "run-test.sh: WARNING watchdog did not start; this pass has NO hang protection" \
       | tee -a "${_errfile}" >&2
   fi
-  # The watchdog unlinks the lock file itself, so this only has to stop it.
-  # `wait` is what makes that deterministic: `kill` just posts the signal, and
-  # without waiting we would return while the unlink is still in flight and
-  # leave a zombie behind until PID 1 reaps it.
-  # `-s TERM` rather than a bare `kill`: SIGTERM is the watchdog's documented
-  # stop signal and the only one it treats as a clean shutdown, so name it here
-  # instead of inheriting whatever the shell's default happens to be.
+  # The watchdog unlinks the lock file itself; this only stops it. SIGTERM is
+  # its documented stop signal, named rather than left to `kill`'s default, and
+  # `wait` reaps it so the unlink has finished before we return.
   _stop_watchdog() { kill -s TERM "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
   # EXIT alone is not enough: an untrapped SIGTERM or SIGHUP kills the shell
   # without running it (measured; SIGINT does run it).

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -167,6 +167,9 @@ fi
       kill -s TERM "${pytest_pid:-}" 2>/dev/null; wait "${pytest_pid:-}" 2>/dev/null
       kill -s TERM "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null
     }
+    # Single-quoted, so the body is re-parsed when the trap fires and picks up
+    # `pytest_pid`, assigned further below. Double quotes would bake in "".
+    #
     # EXIT alone is not enough: an untrapped SIGTERM, SIGHUP or SIGQUIT kills
     # the shell without running it (measured; SIGINT does run it).
     # Known Issue: kill -9 CI script (rarely needed) will leave stale lock file

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -121,6 +121,27 @@ fi
   # Python 3.9+ on an older kernel has the function and fails at the syscall.
   # Running unprotected is worse than a watchdog and better than refusing to
   # test at all.
+  # The one teardown for this pass. Outside the watchdog branch on purpose:
+  # USE_WATCHDOG=0 still has a pytest to stop. pytest first, since the watchdog
+  # unlinks the lock file on its way out and workers must not still hold locks.
+  # By pid, not via the terminal: Ctrl+\\ never reaches either of them, both
+  # having inherited SIG_IGN for SIGQUIT. `wait` reaps; `:-` covers "not
+  # started" and "no watchdog".
+  _stop_pass() {
+    kill -s TERM "${pytest_pid:-}" 2>/dev/null; wait "${pytest_pid:-}" 2>/dev/null
+    kill -s TERM "${watchdog_pid:-}" 2>/dev/null; wait "${watchdog_pid:-}" 2>/dev/null
+  }
+  # Single-quoted, so the body is re-parsed when the trap fires and picks up
+  # `pytest_pid` and `watchdog_pid`, assigned below. Double quotes bake in "".
+  #
+  # EXIT alone is not enough: an untrapped SIGTERM, SIGHUP or SIGQUIT kills
+  # the shell without running it (measured; SIGINT does run it).
+  # Known Issue: kill -9 CI script (rarely needed) will leave stale lock file
+  # under /dev/shm. Users should terminate manually by inspecting ps.
+  trap '_stop_pass' EXIT
+  trap '_stop_pass; exit 130' INT
+  trap '_stop_pass; exit 131' QUIT
+  trap '_stop_pass; exit 143' TERM HUP
   use_watchdog="${USE_WATCHDOG:-1}"
   if [ "${use_watchdog}" != 0 ] \
      && ! python -c 'import os; os.close(os.pidfd_open(os.getpid()))' 2>/dev/null; then
@@ -148,36 +169,6 @@ fi
     python -m pytest_gpu_lease.watchdog --lockfile "${GPU_LEASE_LOCKFILE}" \
       --workers "${ngpus}" 2>>"${_errfile}" &
     watchdog_pid=$!
-    # The one teardown for this pass, and the only thing the traps below call.
-    # pytest first, then the watchdog that was protecting it: the watchdog
-    # unlinks the lock file on its way out, and doing that while workers still
-    # hold locks would let a replacement recreate the path as a fresh inode.
-    #
-    # SIGTERM to both, named rather than left to `kill`'s default, since it is
-    # the watchdog's documented stop signal. `wait` after each, so the unlink
-    # has finished and neither is left a zombie before this returns.
-    #
-    # pytest is stopped by pid rather than left to the terminal: Ctrl+C reaches
-    # it on its own (SIGINT goes to the whole foreground group) but Ctrl+\\ does
-    # not -- measured, SIGQUIT kills this shell outright while pytest and the
-    # watchdog, both of which inherited SIG_IGN for it, carry on. `pytest_pid`
-    # is empty before pytest starts and cleared after it returns, so the
-    # early-exit path below and a completed run both signal nothing.
-    _stop_pass() {
-      kill -s TERM "${pytest_pid:-}" 2>/dev/null; wait "${pytest_pid:-}" 2>/dev/null
-      kill -s TERM "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null
-    }
-    # Single-quoted, so the body is re-parsed when the trap fires and picks up
-    # `pytest_pid`, assigned further below. Double quotes would bake in "".
-    #
-    # EXIT alone is not enough: an untrapped SIGTERM, SIGHUP or SIGQUIT kills
-    # the shell without running it (measured; SIGINT does run it).
-    # Known Issue: kill -9 CI script (rarely needed) will leave stale lock file
-    # under /dev/shm. Users should terminate manually by inspecting ps.
-    trap '_stop_pass' EXIT
-    trap '_stop_pass; exit 130' INT
-    trap '_stop_pass; exit 131' QUIT
-    trap '_stop_pass; exit 143' TERM HUP
     # Fatal here, unlike the no-pidfd case above: we asked for a watchdog and did
     # not get one, which is an environment that is broken rather than merely old,
     # and the failure would otherwise surface as one wedged worker eating the

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -94,13 +94,23 @@ fi
   # hole.
   _errfile="${outdir}/${fnprefix}${pass}.err"
   : > "${_errfile}"
-  # The watchdog signals through a pidfd, so it needs Linux 5.3+ and refuses to
-  # load without it. Probe by using it rather than by checking a version: on
-  # Python 3.9+ over an older kernel the function exists and fails at the
-  # syscall. Without it, run unprotected -- worse than a watchdog, still better
-  # than refusing to test at all, and it is what ROCm's own RHEL 8.10 support
-  # would hit.
-  if python -c 'import os; os.close(os.pidfd_open(os.getpid()))' 2>/dev/null; then
+  # Watchdog: on unless USE_WATCHDOG=0, and off regardless on a host that
+  # cannot support it. Two independent reasons, one switch.
+  #
+  # It signals through a pidfd and refuses to load without one, which needs
+  # Linux 5.3+; ROCm still supports RHEL 8.10, whose kernel predates that.
+  # Probed by calling pidfd_open rather than by testing a version, because
+  # Python 3.9+ on an older kernel has the function and fails at the syscall.
+  # Running unprotected is worse than a watchdog and better than refusing to
+  # test at all.
+  use_watchdog="${USE_WATCHDOG:-1}"
+  if [ "${use_watchdog}" != 0 ] \
+     && ! python -c 'import os; os.close(os.pidfd_open(os.getpid()))' 2>/dev/null; then
+    echo "run-test.sh: no pidfd support (needs Linux 5.3+); disabling the watchdog" \
+      | tee -a "${_errfile}" >&2
+    use_watchdog=0
+  fi
+  if [ "${use_watchdog}" != 0 ]; then
     # Start watchdog process, use /dev/shm to avoid wearing: container's /tmp
     # may not be tmpfs.
     # Named with both $pass and $$ for uniqueness.
@@ -144,7 +154,7 @@ fi
       exit 1
     fi
   else
-    echo "run-test.sh: no pidfd support (needs Linux 5.3+); running WITHOUT hang protection" \
+    echo "run-test.sh: running WITHOUT hang protection; a wedged worker will not be killed" \
       | tee -a "${_errfile}" >&2
   fi
   # One invocation over the whole suite dir (conftest.py sets up sys.path); pytest

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -87,11 +87,6 @@ fi
     [ -n "$_sig" ] && cat "$_sig" \
       || echo "NO __signature__ file at $PYTHONPATH/aotriton.images/"
   } > "${outdir}/${fnprefix}${pass}.out"
-  # Start watchdog process, use /dev/shm to avoid wearing: container's /tmp
-  # may not be tmpfs.
-  # Named with both $pass and $$ for uniqueness.
-  # Note: this is inside a subshell. Hence parent pid `$$` is the right one to use.
-  export GPU_LEASE_LOCKFILE="/dev/shm/gpu_lease.${pass}.$$"
   # One stderr file for the whole pass, so there is a single thing to tail.
   # Truncated once here and appended to from then on: two `2>` on one path
   # would have pytest re-truncate a file the watchdog already holds open, and
@@ -99,38 +94,58 @@ fi
   # hole.
   _errfile="${outdir}/${fnprefix}${pass}.err"
   : > "${_errfile}"
-  # Start watchdog service, assume pytest_gpu_lease already installed.
-  # If not, do it with `pip install -r requirements-dev.txt`
-  #
-  # --lockfile is redundant with the exported GPU_LEASE_LOCKFILE the watchdog
-  # would fall back to, and passed anyway so that `ps aux` says which file each
-  # watchdog is watching. That is how a stale one from a SIGKILLed pass is told
-  # apart from the live one; an env var is not visible in ps output.
-  python -m pytest_gpu_lease.watchdog --lockfile "${GPU_LEASE_LOCKFILE}" \
-    --workers "${ngpus}" 2>>"${_errfile}" &
-  watchdog_pid=$!
-  # The watchdog unlinks the lock file itself; this only stops it. SIGTERM is
-  # its documented stop signal, named rather than left to `kill`'s default, and
-  # `wait` reaps it so the unlink has finished before we return.
-  _stop_watchdog() { kill -s TERM "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
-  # EXIT alone is not enough: an untrapped SIGTERM or SIGHUP kills the shell
-  # without running it (measured; SIGINT does run it).
-  # Known Issue: kill -9 CI script (rarely needed) will leave stale lock file
-  # under /dev/shm. Users should terminate manually by inspecting ps.
-  trap '_stop_watchdog' EXIT
-  trap '_stop_watchdog; exit 130' INT
-  trap '_stop_watchdog; exit 143' TERM HUP
-  # Fatal, not a warning. --timeout=300 is gone, so a pass without the
-  # watchdog has no hang protection at all, and the way that surfaces is one
-  # wedged worker eating the remaining 22 hours. Better to lose the run now.
-  # Reported on success too: silence reads exactly like a failure to start.
-  sleep 1
-  if kill -0 "${watchdog_pid}" 2>/dev/null; then
-    echo "run-test.sh: watchdog running, pid ${watchdog_pid}, lockfile ${GPU_LEASE_LOCKFILE}" >> "${_errfile}"
+  # The watchdog signals through a pidfd, so it needs Linux 5.3+ and refuses to
+  # load without it. Probe by using it rather than by checking a version: on
+  # Python 3.9+ over an older kernel the function exists and fails at the
+  # syscall. Without it, run unprotected -- worse than a watchdog, still better
+  # than refusing to test at all, and it is what ROCm's own RHEL 8.10 support
+  # would hit.
+  if python -c 'import os; os.close(os.pidfd_open(os.getpid()))' 2>/dev/null; then
+    # Start watchdog process, use /dev/shm to avoid wearing: container's /tmp
+    # may not be tmpfs.
+    # Named with both $pass and $$ for uniqueness.
+    # Note: this is inside a subshell. Hence parent pid `$$` is the right one to use.
+    #
+    # Exported only on this branch: it is what tells the workers a watchdog is
+    # listening, and it also gates their per-worker stack dumps, which nothing
+    # would read if none is running.
+    export GPU_LEASE_LOCKFILE="/dev/shm/gpu_lease.${pass}.$$"
+    # Start watchdog service, assume pytest_gpu_lease already installed.
+    # If not, do it with `pip install -r requirements-dev.txt`
+    #
+    # --lockfile is redundant with the exported GPU_LEASE_LOCKFILE the watchdog
+    # would fall back to, and passed anyway so that `ps aux` says which file each
+    # watchdog is watching. That is how a stale one from a SIGKILLed pass is told
+    # apart from the live one; an env var is not visible in ps output.
+    python -m pytest_gpu_lease.watchdog --lockfile "${GPU_LEASE_LOCKFILE}" \
+      --workers "${ngpus}" 2>>"${_errfile}" &
+    watchdog_pid=$!
+    # The watchdog unlinks the lock file itself; this only stops it. SIGTERM is
+    # its documented stop signal, named rather than left to `kill`'s default, and
+    # `wait` reaps it so the unlink has finished before we return.
+    _stop_watchdog() { kill -s TERM "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
+    # EXIT alone is not enough: an untrapped SIGTERM or SIGHUP kills the shell
+    # without running it (measured; SIGINT does run it).
+    # Known Issue: kill -9 CI script (rarely needed) will leave stale lock file
+    # under /dev/shm. Users should terminate manually by inspecting ps.
+    trap '_stop_watchdog' EXIT
+    trap '_stop_watchdog; exit 130' INT
+    trap '_stop_watchdog; exit 143' TERM HUP
+    # Fatal here, unlike the no-pidfd case above: we asked for a watchdog and did
+    # not get one, which is an environment that is broken rather than merely old,
+    # and the failure would otherwise surface as one wedged worker eating the
+    # remaining 22 hours. Reported on success too: silence reads the same either way.
+    sleep 1
+    if kill -0 "${watchdog_pid}" 2>/dev/null; then
+      echo "run-test.sh: watchdog running, pid ${watchdog_pid}, lockfile ${GPU_LEASE_LOCKFILE}" >> "${_errfile}"
+    else
+      echo "run-test.sh: watchdog did not start; refusing to run a pass with no hang protection" \
+        | tee -a "${_errfile}" >&2
+      exit 1
+    fi
   else
-    echo "run-test.sh: watchdog did not start; refusing to run a pass with no hang protection" \
+    echo "run-test.sh: no pidfd support (needs Linux 5.3+); running WITHOUT hang protection" \
       | tee -a "${_errfile}" >&2
-    exit 1
   fi
   # One invocation over the whole suite dir (conftest.py sets up sys.path); pytest
   # collects test_backward / test_varlen together (test_forward.py is excluded via

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -148,19 +148,24 @@ fi
     python -m pytest_gpu_lease.watchdog --lockfile "${GPU_LEASE_LOCKFILE}" \
       --workers "${ngpus}" 2>>"${_errfile}" &
     watchdog_pid=$!
-    # The watchdog unlinks the lock file itself; this only stops it. SIGTERM is
-    # its documented stop signal, named rather than left to `kill`'s default, and
-    # `wait` reaps it so the unlink has finished before we return.
+    # The one teardown for this pass, and the only thing the traps below call.
+    # pytest first, then the watchdog that was protecting it: the watchdog
+    # unlinks the lock file on its way out, and doing that while workers still
+    # hold locks would let a replacement recreate the path as a fresh inode.
     #
-    # pytest is stopped from here too, and by pid. Ctrl+C reaches it on its own
-    # (SIGINT goes to the whole foreground group) but Ctrl+\\ does not:
-    # measured, SIGQUIT kills this shell outright while pytest and the watchdog,
-    # both of which inherited SIG_IGN for it, carry on. `pytest_pid` is empty
-    # until pytest starts, which covers the early-exit path below.
-    _stop_watchdog() { kill -s TERM "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
+    # SIGTERM to both, named rather than left to `kill`'s default, since it is
+    # the watchdog's documented stop signal. `wait` after each, so the unlink
+    # has finished and neither is left a zombie before this returns.
+    #
+    # pytest is stopped by pid rather than left to the terminal: Ctrl+C reaches
+    # it on its own (SIGINT goes to the whole foreground group) but Ctrl+\\ does
+    # not -- measured, SIGQUIT kills this shell outright while pytest and the
+    # watchdog, both of which inherited SIG_IGN for it, carry on. `pytest_pid`
+    # is empty before pytest starts and cleared after it returns, so the
+    # early-exit path below and a completed run both signal nothing.
     _stop_pass() {
       kill -s TERM "${pytest_pid:-}" 2>/dev/null; wait "${pytest_pid:-}" 2>/dev/null
-      _stop_watchdog
+      kill -s TERM "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null
     }
     # EXIT alone is not enough: an untrapped SIGTERM, SIGHUP or SIGQUIT kills
     # the shell without running it (measured; SIGINT does run it).

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -87,19 +87,10 @@ fi
     [ -n "$_sig" ] && cat "$_sig" \
       || echo "NO __signature__ file at $PYTHONPATH/aotriton.images/"
   } > "${outdir}/${fnprefix}${pass}.out"
-  # pytest-timeout's SIGALRM cannot interrupt a worker parked in an unreturning
-  # HIP call -- CPython only runs a Python signal handler at a bytecode
-  # boundary, and a thread stuck in a C call never reaches one. The watchdog
-  # polls each worker's lease page from a separate process instead and
-  # escalates SIGTERM (for a faulthandler stack dump) then SIGKILL from
-  # outside, where it needs no cooperation from the wedged thread at all.
-  #
-  # /dev/shm rather than $outdir: this file is pure IPC between the workers
-  # and the watchdog for the lifetime of this one run, never an artifact worth
-  # keeping or shipping off-host. Named with both $pass and $$ (this
-  # subshell's parent pid -- bash's $$ reports that, not the subshell's own,
-  # even inside `( ... )`) so concurrent passes, and concurrent runs on the
-  # same host, never collide on one file.
+  # Start watchdog process, use /dev/shm to avoid wearing: container's /tmp
+  # may not be tmpfs.
+  # Named with both $pass and $$ for uniquenecess.
+  # Note: this is inside a subshell. Hence parent pid `$$` is the right one to use>
   export GPU_LEASE_LOCKFILE="/dev/shm/gpu_lease.${pass}.$$"
   python3 -m pytest_gpu_lease.watchdog --workers "${ngpus}" \
     2>"${outdir}/${fnprefix}${pass}.watchdog.err" &

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -89,12 +89,21 @@ fi
   } > "${outdir}/${fnprefix}${pass}.out"
   # Start watchdog process, use /dev/shm to avoid wearing: container's /tmp
   # may not be tmpfs.
-  # Named with both $pass and $$ for uniquenecess.
-  # Note: this is inside a subshell. Hence parent pid `$$` is the right one to use>
+  # Named with both $pass and $$ for uniqueness.
+  # Note: this is inside a subshell. Hence parent pid `$$` is the right one to use.
   export GPU_LEASE_LOCKFILE="/dev/shm/gpu_lease.${pass}.$$"
-  python3 -m pytest_gpu_lease.watchdog --workers "${ngpus}" \
+  # The same `python` that provides `pytest`: requirements-dev.txt installs
+  # ./python/pytest-gpu-lease into it, so failing to import is a broken
+  # environment to hear about, not something to probe around.
+  python -m pytest_gpu_lease.watchdog --workers "${ngpus}" \
     2>"${outdir}/${fnprefix}${pass}.watchdog.err" &
   watchdog_pid=$!
+  # Loud rather than silent: without this the only evidence of a watchdog that
+  # never started is a stderr file nobody opens until a pass has already hung,
+  # and with --timeout=300 gone that is a pass with no hang protection at all.
+  sleep 1
+  kill -0 "${watchdog_pid}" 2>/dev/null \
+    || echo "WARNING: pytest_gpu_lease.watchdog did not start; this pass has NO hang protection. See ${outdir}/${fnprefix}${pass}.watchdog.err" >&2
   # The watchdog unlinks the lock file itself, so this only has to stop it.
   # `wait` is what makes that deterministic: `kill` just posts the signal, and
   # without waiting we would return while the unlink is still in flight and
@@ -102,8 +111,10 @@ fi
   _stop_watchdog() { kill "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
   # EXIT alone is not enough: an untrapped SIGTERM or SIGHUP kills the shell
   # without running it (measured; SIGINT does run it). Naming them explicitly
-  # makes teardown prompt -- if none of this runs, e.g. under SIGKILL, the
-  # watchdog still exits on its own once no page has been locked for a while.
+  # matters more than it used to: the watchdog is a service that never stops on
+  # its own, so this is the only thing that stops it. Under SIGKILL, which no
+  # trap can catch, it is left running -- inert, but visible in `ps`, and its
+  # /dev/shm lock file stays behind.
   trap '_stop_watchdog' EXIT
   trap '_stop_watchdog; exit 130' INT
   trap '_stop_watchdog; exit 143' TERM HUP

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -141,10 +141,10 @@ fi
     # Start watchdog service, assume pytest_gpu_lease already installed.
     # If not, do it with `pip install -r requirements-dev.txt`
     #
-    # --lockfile is redundant with the exported GPU_LEASE_LOCKFILE the watchdog
-    # would fall back to, and passed anyway so that `ps aux` says which file each
-    # watchdog is watching. That is how a stale one from a SIGKILLed pass is told
-    # apart from the live one; an env var is not visible in ps output.
+    # --lockfile is required: the watchdog does not read GPU_LEASE_LOCKFILE, so
+    # that `ps aux` says which file each one is watching. That is how a stale
+    # watchdog from a SIGKILLed pass is told apart from the live one, and an
+    # env var is not visible in ps output. The variable is for the workers.
     python -m pytest_gpu_lease.watchdog --lockfile "${GPU_LEASE_LOCKFILE}" \
       --workers "${ngpus}" 2>>"${_errfile}" &
     watchdog_pid=$!

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -95,14 +95,18 @@ fi
   python3 -m pytest_gpu_lease.watchdog --workers "${ngpus}" \
     2>"${outdir}/${fnprefix}${pass}.watchdog.err" &
   watchdog_pid=$!
-  # EXIT fires when this subshell exits by any path, including the `|| true`
-  # below swallowing a pytest failure -- exactly the scope the watchdog and
-  # its lock file should live for. Kill before unlink: a watchdog left running
-  # past its own pytest session would go on polling a file nothing populates
-  # anymore and could eventually act on a pid number reused for something
-  # unrelated; a lock file deleted while still open is harmless by contrast,
-  # since the inode lives on until every fd on it closes.
-  trap 'kill "${watchdog_pid}" 2>/dev/null; rm -f "${GPU_LEASE_LOCKFILE}"' EXIT
+  # The watchdog unlinks the lock file itself, so this only has to stop it.
+  # `wait` is what makes that deterministic: `kill` just posts the signal, and
+  # without waiting we would return while the unlink is still in flight and
+  # leave a zombie behind until PID 1 reaps it.
+  _stop_watchdog() { kill "${watchdog_pid}" 2>/dev/null; wait "${watchdog_pid}" 2>/dev/null; }
+  # EXIT alone is not enough: an untrapped SIGTERM or SIGHUP kills the shell
+  # without running it (measured; SIGINT does run it). Naming them explicitly
+  # makes teardown prompt -- if none of this runs, e.g. under SIGKILL, the
+  # watchdog still exits on its own once no page has been locked for a while.
+  trap '_stop_watchdog' EXIT
+  trap '_stop_watchdog; exit 130' INT
+  trap '_stop_watchdog; exit 143' TERM HUP
   # One invocation over the whole suite dir (conftest.py sets up sys.path); pytest
   # collects test_backward / test_varlen together (test_forward.py is excluded via
   # conftest.py's collect_ignore - its coverage is a subset of test_backward.py's).

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -26,7 +26,11 @@ shift 3
 KFILTER=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    -k)  KFILTER=(-k "$2"); shift 2 ;;
+    -k)  # `shift 2` with one argument left fails *without shifting*, and the
+         # loop condition would never change: a bare trailing -k spins forever
+         # instead of running anything.
+         [ "$#" -ge 2 ] || { echo "run-test.sh: -k needs an expression" >&2; exit 1; }
+         KFILTER=(-k "$2"); shift 2 ;;
     -k*) KFILTER=(-k "${1#-k}"); shift ;;
     *)   echo "run-test.sh: unexpected argument '$1' (only -k is accepted here)" >&2
          exit 1 ;;

--- a/.ci/run-test.sh
+++ b/.ci/run-test.sh
@@ -5,8 +5,8 @@ if [ -z "$BASH_VERSION" ]; then
   exit 1
 fi
 
-if [ "$#" -ne 3 ]; then
-  echo 'Missing arguments. Usage: run-test.sh <pass#> <test_level> <split/fused/aiter/v3>' >&2
+if [ "$#" -lt 3 ]; then
+  echo 'Missing arguments. Usage: run-test.sh <pass#> <test_level> <split/fused/aiter/v3> [-k EXPR]' >&2
   exit 1
 fi
 
@@ -18,6 +18,20 @@ add_rocm_sdk_ldconfig
 pass=$1
 test_level="$2"
 backend="$3"
+shift 3
+
+# Optional pytest -k, passed straight through. An array rather than a string:
+# the expressions worth typing have spaces in them ("hdim224 and not causal"),
+# and the unquoted ${SELECT_FROM} idiom below would split one into words.
+KFILTER=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -k)  KFILTER=(-k "$2"); shift 2 ;;
+    -k*) KFILTER=(-k "${1#-k}"); shift ;;
+    *)   echo "run-test.sh: unexpected argument '$1' (only -k is accepted here)" >&2
+         exit 1 ;;
+  esac
+done
 if [ -n "${AOTRITON_TEST_LIBDIR:-}" ]; then
   bdir=""
 else
@@ -163,6 +177,7 @@ fi
   pytest --tb=line -n ${ngpus} --max-worker-restart 9999 -rfEsx \
     -p no:cacheprovider \
     ${SELECT_FROM} \
+    "${KFILTER[@]}" \
     modules/flash/tests \
     -v \
     1>>"${outdir}/${fnprefix}${pass}.out" \

--- a/python/pytest-gpu-lease/README.md
+++ b/python/pytest-gpu-lease/README.md
@@ -70,7 +70,7 @@ file each watchdog is watching -- the only way to tell a stale one from the live
 See `--help` for `--threshold`, `--grace` and `--poll_interval`.
 
 The watchdog needs `pidfd_open`: Linux 5.3+ and Python 3.9+. That is narrower than
-ROCm itself, which still supports AlmaLinux 8, and is deliberate -- this is Level-3 CI
+ROCm itself, which still supports RHEL 8.10, and is deliberate -- this is Level-3 CI
 tooling running on Ubuntu 22.04 or later. The lease fixtures have no such requirement;
 only `pytest_gpu_lease.watchdog` does, and it asserts at import rather than degrading.
 

--- a/python/pytest-gpu-lease/README.md
+++ b/python/pytest-gpu-lease/README.md
@@ -30,12 +30,44 @@ driver / firmware / VBIOS. The mapping is strictly 1:1 worker-to-GPU.
 |---|---|---|
 | `GPU_LEASE_PIN` | unset | Bypass leasing; pin every worker to this GPU index. |
 | `GPU_LEASE_DEVICE_CLASS` | `cuda` | Accelerator class `gpu_device` formats with. |
+| `GPU_LEASE_LOCKFILE` | derived from `tmp_path_factory` | Path of the shared lock file. Set it to run the watchdog (below), which cannot predict the derived path. Also enables the per-worker stack dump. |
 
 `PYTEST_XDIST_WORKER_COUNT` is **not** consulted. `pytest-xdist` sets it inside the
 worker process, but this module is imported at `pytest11` entry-point time -- earlier
 than that -- so reading it saw `0` and put every worker on GPU 0. The worker count comes
 from `config.workerinput`, which is populated before any fixture runs. Nothing here is
 read from the environment at import time.
+
+## Watchdog
+
+A test whose GPU kernel never retires wedges its worker for good: the device sync
+never returns, so no in-process timeout can fire -- `pytest-timeout`'s signal method
+needs the main thread to reach a bytecode boundary, and a thread parked in a driver
+call never does.
+
+`pytest_gpu_lease.watchdog` detects that from outside. Each worker stamps
+`time.monotonic_ns()` into its own lease page before every test and zeroes it after;
+the watchdog polls the file and, when a page has gone `--threshold` seconds without a
+fresh stamp, sends SIGTERM (a stack dump, via `faulthandler`), waits `--grace`, then
+SIGKILLs. Signals go through a `pidfd`, so a reissued pid cannot be hit.
+
+```bash
+export GPU_LEASE_LOCKFILE=/dev/shm/gpu_lease.$$        # both sides must agree
+python -m pytest_gpu_lease.watchdog --lockfile "$GPU_LEASE_LOCKFILE" --workers 4 &
+watchdog_pid=$!
+trap 'kill -s TERM "$watchdog_pid"; wait "$watchdog_pid"' EXIT
+pytest -n 4 ...
+```
+
+**It is a service and never stops on its own.** Whoever starts it stops it, with
+SIGTERM; every rule for inferring "the pass is over" from the lock file is a guess,
+and a wrong guess silently leaves the rest of a long run unprotected. On SIGTERM it
+removes the lock file and any stack dumps beside it. SIGKILL is the one case it
+cannot clean up after.
+
+`--lockfile` is required rather than read from the environment, so `ps` shows which
+file each watchdog is watching -- the only way to tell a stale one from the live one.
+See `--help` for `--threshold`, `--grace` and `--poll_interval`.
 
 ## Fixtures
 

--- a/python/pytest-gpu-lease/README.md
+++ b/python/pytest-gpu-lease/README.md
@@ -69,6 +69,11 @@ cannot clean up after.
 file each watchdog is watching -- the only way to tell a stale one from the live one.
 See `--help` for `--threshold`, `--grace` and `--poll_interval`.
 
+The watchdog needs `pidfd_open`: Linux 5.3+ and Python 3.9+. That is narrower than
+ROCm itself, which still supports AlmaLinux 8, and is deliberate -- this is Level-3 CI
+tooling running on Ubuntu 22.04 or later. The lease fixtures have no such requirement;
+only `pytest_gpu_lease.watchdog` does, and it asserts at import rather than degrading.
+
 ## Fixtures
 
 | Fixture | Type | Description |

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -64,7 +64,7 @@ def _budget_ns() -> int:
 
 # Set by the leased branch of `gpu_id` once a lease is actually held, and
 # cleared again at its teardown; `None` the rest of the time. The
-# `pytest_runtest_call` hookwrapper below needs to know whether there is
+# `pytest_runtest_protocol` hookwrapper below needs to know whether there is
 # a page to heartbeat, but it is a plugin-level hook, not a fixture, so it
 # cannot request `gpu_id` or read its generator frame -- this module global
 # is the connecting state. A plain global is safe here because `gpu_id` is
@@ -226,6 +226,20 @@ def gpu_id(request):
             # call, sent SIGTERM, printed a full stack dump naming the frame.
             faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
             _active_lease = (f.fileno(), page_base)
+            # Arm a deadline right now, not just from the first heartbeat below.
+            # `pytest_runtest_protocol`'s hookwrapper (below) wraps setup, call
+            # and teardown as a single hook call, and its pre-yield code -- where
+            # a fresh deadline is normally written -- runs *before* that call
+            # even starts, i.e. before this fixture body has run at all. So for
+            # this worker's first test, that pre-yield code sees `_active_lease`
+            # still `None` and, correctly, touches nothing; without this write,
+            # the page would carry no deadline through the whole of that first
+            # test's setup, call, and teardown, and a wedge anywhere in it would
+            # be invisible to the watchdog. This write closes exactly that gap
+            # and nothing else: every later test gets a fresh deadline from the
+            # hookwrapper itself, since by then `_active_lease` is already set
+            # when that wrapper's pre-yield code runs.
+            os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns() + _budget_ns()), page_base)
             try:
                 yield gpu
             finally:
@@ -237,7 +251,7 @@ def gpu_id(request):
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_call():
+def pytest_runtest_protocol():
     """Heartbeat this worker's page with the current test's deadline.
 
     Inert unless `gpu_id` actually holds a lease: `_active_lease` is only set by
@@ -247,24 +261,31 @@ def pytest_runtest_call():
     pytest process in the environment, so being a no-op absent a lease is not
     optional.
 
-    Wraps `pytest_runtest_call`, NOT `pytest_runtest_protocol`, and that choice
-    is load-bearing, not cosmetic. `runtestprotocol()` runs setup, call and
-    teardown as three separate hook calls in sequence -- `pytest_runtest_setup`,
-    then this one, then `pytest_runtest_teardown` -- and `gpu_id`'s lock-acquire
-    (which sets `_active_lease`) happens during fixture setup, i.e. inside the
-    *first* of those. A hookwrapper on `pytest_runtest_protocol` instead wraps
-    all three phases as one call, so its pre-yield code runs *before* setup has
-    resolved any fixtures at all: on a worker's very first test, `_active_lease`
-    is still `None` at that point regardless of whether a lease is about to be
-    taken, and the first test's heartbeat -- often the one most likely to be hit
-    by an early wedge -- silently never gets written. (Caught by an end-to-end
-    test that wedged the first parametrized case on a worker: the watchdog never
-    fired, because the deadline it was polling for had never been written.)
-    Wrapping `pytest_runtest_call` instead means setup has already completed
-    -- and `_active_lease` is already current -- every time this hook's
-    pre-yield code runs, first test included. The same reasoning rules out
-    `pytest_runtest_teardown` for the zeroing half below: it is a still later,
-    separate phase, so zeroing there would race the *next* test's setup instead.
+    Wraps the whole protocol -- setup, call, and teardown -- deliberately, so a
+    worker that wedges anywhere in any of the three (a GPU allocation during
+    setup, the test body itself, a cache-empty or sync during teardown) is
+    covered by one and the same deadline. The alternative, wrapping only
+    `pytest_runtest_call`, was tried first and rejected: it left setup and
+    teardown outside the heartbeat entirely, so a fixture-level wedge would
+    never be caught at all.
+
+    That whole-protocol wrapping has one gap of its own, and `gpu_id` closes it
+    rather than this hook: `runtestprotocol()` still runs setup, call and
+    teardown as separate hook calls internally, and `gpu_id`'s lock-acquire
+    (which sets `_active_lease`) happens inside the first of those, i.e. *after*
+    this wrapper's pre-yield code has already run for a worker's first test.
+    That pre-yield code reads `_active_lease` once, before the wrapped call
+    starts, so on the first test it correctly sees `None` and writes nothing --
+    but with nothing else in place, that leaves the entire first test
+    heartbeat-less. (Caught by an end-to-end test that wedged the very first
+    parametrized case on a worker: the watchdog never fired, because no
+    deadline had ever been written for that page.) `gpu_id` covers this by
+    writing an initial deadline itself, at the moment the lease is taken --
+    see the comment there. From the second test onward, `_active_lease` is
+    already set by the time this wrapper's pre-yield code runs, so it takes
+    over the refreshing normally. The two writers never race: at most one of
+    them is ever the one enabled for a given test, controlled by the same
+    single check of `_active_lease` here.
 
     Runs on whatever thread pytest calls hooks on for this test, which under
     xdist is the worker's MainThread -- deliberately: the heartbeat must stop
@@ -278,6 +299,14 @@ def pytest_runtest_call():
     other synchronisation is needed on either side. Zeroing the deadline after
     the test, rather than leaving the last one in place, is what keeps an idle
     worker between tests from ever looking like a candidate to the watchdog.
+    (The first test is the one exception: this wrapper takes the `is None`
+    branch for it and never zeros afterwards, leaving `gpu_id`'s initial write
+    in place until the second test's pre-yield code overwrites it. That stale
+    value cannot cause a false idle read -- it is a real, if slightly dated,
+    future deadline, not a zero -- and cannot cause a false SIGTERM either
+    unless the gap between the first test finishing and the second one
+    starting itself exceeds the budget, which would mean the worker really is
+    stuck somewhere between tests.)
     """
     lease = _active_lease
     if lease is None:
@@ -289,14 +318,13 @@ def pytest_runtest_call():
     try:
         yield
     finally:
-        # `gpu_id`'s teardown (closing `fd`) happens in the later, separate
-        # `pytest_runtest_teardown` phase, so `fd` is still the live lease fd
-        # here even on a worker's last test -- unlike the now-abandoned
-        # `pytest_runtest_protocol` wrapping, where that teardown ran inside
-        # this same wrapped call. The `except OSError` stays anyway: it costs
-        # nothing to tolerate an fd that turns out to be closed, and pinning
-        # correctness here on the exact phase boundaries of a pytest internal
-        # we do not control would be one refactor away from a silent regression.
+        # On this worker's last test (`nextitem is None`), the very call being
+        # wrapped also tears down the session-scoped `gpu_id` fixture -- which
+        # closes `fd` and releases the lock -- before control returns here, so
+        # `fd` may already be a stale, closed number. That is fine to ignore:
+        # zeroing a deadline is only ever meaningful while the page is still
+        # locked, and the watchdog never reads a page's deadline without first
+        # finding it locked, so a released page's stale value is never seen.
         try:
             os.pwrite(fd, struct.pack('<Q', 0), page_base)
         except OSError:

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -22,11 +22,14 @@ firmware / VBIOS races.
 """
 
 import fcntl
+import faulthandler
 import itertools
 import os
+import signal
 import struct
 import sys
 import time
+from pathlib import Path
 from types import MappingProxyType
 
 import pytest
@@ -34,6 +37,40 @@ import pytest
 STRUCT_FLOCK = 'hhqqi'
 PAGE_SIZE = 4096
 _RETRY_INTERVAL = 0.05
+
+# How long a single test may legitimately run before the watchdog (see
+# watchdog.py, which imports this) treats the worker holding it as wedged.
+# Not the suite length, not the worker count -- the heartbeat below is
+# rewritten before every test, so this number is exactly one thing: the
+# longest one test may take. A real pass ran 265,282 tests in 227,112
+# worker-seconds, 0.86s/test mean, so 600s is about the tail, not the
+# average -- and the tail is plausibly the torch reference materialising an
+# 8192x8192 score matrix, not the kernel under test, so sizing it off kernel
+# cost alone would guess far too low. The cost of being wrong is asymmetric:
+# too high and a wedge idles a worker for the excess (a handful of tests a
+# pass); too low and a slow-but-passing test is recorded as a crash, a
+# restart is burned, and the scheduler goes through the teardown path again.
+# ``GPU_LEASE_BUDGET_S`` overrides it, mainly so a test of the watchdog
+# itself can use a fuse of seconds rather than waiting out the real one.
+_DEFAULT_BUDGET_S = 600
+
+
+def _budget_ns() -> int:
+    """Per-test heartbeat budget in nanoseconds. Read lazily, never at import."""
+    raw = os.getenv('GPU_LEASE_BUDGET_S', default=None)
+    seconds = _DEFAULT_BUDGET_S if raw is None else float(raw)
+    return int(seconds * 1_000_000_000)
+
+
+# Set by the leased branch of `gpu_id` once a lease is actually held, and
+# cleared again at its teardown; `None` the rest of the time. The
+# `pytest_runtest_call` hookwrapper below needs to know whether there is
+# a page to heartbeat, but it is a plugin-level hook, not a fixture, so it
+# cannot request `gpu_id` or read its generator frame -- this module global
+# is the connecting state. A plain global is safe here because `gpu_id` is
+# session-scoped and, under xdist, "session" means "per worker process": at
+# most one lease is ever active in a given interpreter.
+_active_lease: tuple[int, int] | None = None  # (fd, page_base)
 
 
 # Stand-in for a process that is not an xdist worker: the controller, a plain
@@ -113,9 +150,21 @@ def _gpu_lease_lockfile(tmp_path_factory):
     The file is never sized or truncated. POSIX record locks may be placed beyond EOF,
     so pre-sizing buys nothing -- and the old open(..., 'wb') let a late-starting worker
     truncate a file its peers were already locking.
+
+    ``GPU_LEASE_LOCKFILE``, when set, wins over the derived path. The watchdog is a
+    separate process started before pytest exists, so it cannot predict what
+    ``getbasetemp()`` will resolve to for this run -- run-test.sh instead mints a
+    path up front and both sides read it from the environment. The derived path
+    stays as the fallback so a plain ``pytest`` invocation, with no watchdog and
+    no env var, is unchanged. Side benefit: the lease file becomes greppable by a
+    fixed name during a hang instead of living inside a per-run ``pytest-NNN/`` dir.
     """
-    # getbasetemp().parent is shared by all workers of the run; getbasetemp() is per-worker.
-    lockfile = tmp_path_factory.getbasetemp().parent / 'gpulock'
+    override = os.getenv('GPU_LEASE_LOCKFILE', default=None)
+    if override is not None:
+        lockfile = Path(override)
+    else:
+        # getbasetemp().parent is shared by all workers of the run; getbasetemp() is per-worker.
+        lockfile = tmp_path_factory.getbasetemp().parent / 'gpulock'
     fd = os.open(lockfile, os.O_RDWR | os.O_CREAT, 0o644)
     os.close(fd)
     return lockfile
@@ -152,10 +201,12 @@ def gpu_id(request):
     # would create the file in the no-xdist and pinned modes too -- the very
     # side effect dropping `autouse` was meant to prevent.
     lockfile = request.getfixturevalue('_gpu_lease_lockfile')
+    global _active_lease
     with open(lockfile, 'r+b') as f:
         for gpu in itertools.cycle(range(nworkers)):
+            page_base = PAGE_SIZE * gpu
             claim = struct.pack(STRUCT_FLOCK, fcntl.F_WRLCK, os.SEEK_SET,
-                                PAGE_SIZE * gpu, PAGE_SIZE, 0)
+                                page_base, PAGE_SIZE, 0)
             try:
                 fcntl.fcntl(f, fcntl.F_SETLK, claim)
             except BlockingIOError:
@@ -166,13 +217,90 @@ def gpu_id(request):
                 continue
             _announce(request.config,
                       f'{worker_id} uses GPU {gpu} filelock = {lockfile}')
+            # A Python-level SIGTERM handler would fail the same way pytest-timeout's
+            # SIGALRM handler does: CPython only runs a Python signal handler when the
+            # main thread reaches a bytecode boundary, and a thread parked in a HIP
+            # call never reaches one. faulthandler's handler is C-level and needs no
+            # GIL, so it still fires -- and dumps every thread's stack -- while the
+            # main thread is stuck. Verified: a process blocked in a ctypes.PyDLL
+            # call, sent SIGTERM, printed a full stack dump naming the frame.
+            faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
+            _active_lease = (f.fileno(), page_base)
             try:
                 yield gpu
             finally:
+                _active_lease = None
                 release = struct.pack(STRUCT_FLOCK, fcntl.F_UNLCK, os.SEEK_SET,
-                                      PAGE_SIZE * gpu, PAGE_SIZE, 0)
+                                      page_base, PAGE_SIZE, 0)
                 fcntl.fcntl(f, fcntl.F_SETLK, release)
             return
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call():
+    """Heartbeat this worker's page with the current test's deadline.
+
+    Inert unless `gpu_id` actually holds a lease: `_active_lease` is only set by
+    the leased branch above, so pinned mode, no-xdist mode, and GPU-less suites
+    (which never request `gpu_id`, so that fixture body never runs at all) hit
+    the `is None` check and do no I/O -- this hook fires for every test in every
+    pytest process in the environment, so being a no-op absent a lease is not
+    optional.
+
+    Wraps `pytest_runtest_call`, NOT `pytest_runtest_protocol`, and that choice
+    is load-bearing, not cosmetic. `runtestprotocol()` runs setup, call and
+    teardown as three separate hook calls in sequence -- `pytest_runtest_setup`,
+    then this one, then `pytest_runtest_teardown` -- and `gpu_id`'s lock-acquire
+    (which sets `_active_lease`) happens during fixture setup, i.e. inside the
+    *first* of those. A hookwrapper on `pytest_runtest_protocol` instead wraps
+    all three phases as one call, so its pre-yield code runs *before* setup has
+    resolved any fixtures at all: on a worker's very first test, `_active_lease`
+    is still `None` at that point regardless of whether a lease is about to be
+    taken, and the first test's heartbeat -- often the one most likely to be hit
+    by an early wedge -- silently never gets written. (Caught by an end-to-end
+    test that wedged the first parametrized case on a worker: the watchdog never
+    fired, because the deadline it was polling for had never been written.)
+    Wrapping `pytest_runtest_call` instead means setup has already completed
+    -- and `_active_lease` is already current -- every time this hook's
+    pre-yield code runs, first test included. The same reasoning rules out
+    `pytest_runtest_teardown` for the zeroing half below: it is a still later,
+    separate phase, so zeroing there would race the *next* test's setup instead.
+
+    Runs on whatever thread pytest calls hooks on for this test, which under
+    xdist is the worker's MainThread -- deliberately: the heartbeat must stop
+    the instant that thread stops reaching this hook, which is exactly what
+    happens when it wedges in a HIP call. A background heartbeat thread would
+    keep ticking regardless and defeat the whole scheme.
+
+    The write is a single aligned 8-byte pwrite at the page base -- the
+    platform's atomic write granularity for a page-aligned offset -- so the
+    watchdog's concurrent pread never observes a torn value; no seqlock or
+    other synchronisation is needed on either side. Zeroing the deadline after
+    the test, rather than leaving the last one in place, is what keeps an idle
+    worker between tests from ever looking like a candidate to the watchdog.
+    """
+    lease = _active_lease
+    if lease is None:
+        yield
+        return
+    fd, page_base = lease
+    deadline = time.monotonic_ns() + _budget_ns()
+    os.pwrite(fd, struct.pack('<Q', deadline), page_base)
+    try:
+        yield
+    finally:
+        # `gpu_id`'s teardown (closing `fd`) happens in the later, separate
+        # `pytest_runtest_teardown` phase, so `fd` is still the live lease fd
+        # here even on a worker's last test -- unlike the now-abandoned
+        # `pytest_runtest_protocol` wrapping, where that teardown ran inside
+        # this same wrapped call. The `except OSError` stays anyway: it costs
+        # nothing to tolerate an fd that turns out to be closed, and pinning
+        # correctness here on the exact phase boundaries of a pytest internal
+        # we do not control would be one refactor away from a silent regression.
+        try:
+            os.pwrite(fd, struct.pack('<Q', 0), page_base)
+        except OSError:
+            pass
 
 
 @pytest.fixture(scope='session')

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -28,6 +28,7 @@ import os
 import signal
 import struct
 import sys
+import sysconfig
 import time
 from pathlib import Path
 from types import MappingProxyType
@@ -36,6 +37,31 @@ import pytest
 
 STRUCT_FLOCK = 'hhqqi'
 PAGE_SIZE = 4096
+
+# `struct flock` as the kernel wants it, valid exactly when off_t is 64 bits:
+# two shorts, two 64-bit offsets, an int pid. That covers LP64 and any stock
+# 32-bit CPython alike -- configure runs AC_SYS_LARGEFILE, so pyconfig.h
+# carries _FILE_OFFSET_BITS=64, off_t widens to 8 bytes, and glibc redirects
+# F_SETLK/F_GETLK to their 64-bit variants in the same breath, keeping the
+# constant and the layout in agreement. (`q` rather than `l` for that reason:
+# the two are identical on LP64, but `l` is 4 bytes on 32-bit and would
+# describe the wrong struct there.)
+#
+# The single build this is wrong for is a 32-bit CPython with largefile
+# support disabled, where off_t is a 4-byte long and the kernel wants a
+# 16-byte struct. Checked here, at import, rather than on any result we get
+# back: passing a wrongly-sized buffer to fcntl() is itself the damage -- the
+# kernel would read F_SETLK's range from the wrong bytes and lock something
+# arbitrary, with nothing raised anywhere -- so the check has to happen before
+# the first call, not after it. Assert rather than handle: nobody is expected
+# to run that build, and being told is the entire goal.
+_SIZEOF_OFF_T = sysconfig.get_config_var('SIZEOF_OFF_T')
+assert _SIZEOF_OFF_T == 8, (
+    f'pytest_gpu_lease requires a 64-bit off_t; this interpreter reports '
+    f'SIZEOF_OFF_T={_SIZEOF_OFF_T!r}, so STRUCT_FLOCK={STRUCT_FLOCK!r} '
+    f'({struct.calcsize(STRUCT_FLOCK)} bytes) does not describe this '
+    f"platform's struct flock")
+
 _RETRY_INTERVAL = 0.05
 
 # How long a single test may legitimately run before the watchdog (see

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -326,3 +326,84 @@ def gpu_device(gpu_id, gpu_device_class) -> str:
 def torch_gpu(gpu_id) -> int:
     """Back-compat alias for :func:`gpu_id`."""
     return gpu_id
+
+
+def _tolerate_closed_worker_channel() -> None:
+    """Stop a second dying worker from turning the first one's crash into an
+    INTERNALERROR that kills the whole session.
+
+    The failure this guards against: the controller notices worker A died and
+    calls ``DSession.worker_errordown`` -> ``LoadScheduling.remove_node(A)``,
+    which reassigns A's pending items and then, still inside that same call,
+    tops up every *other* node's queue via ``check_schedule`` ->
+    ``_send_tests`` -> ``WorkerController.send_runtest_some`` ->
+    ``sendcommand`` -> ``execnet``'s ``channel.send``. If worker B is also
+    dying at that exact moment -- its own crash not yet reported, since that
+    report is itself an asynchronous execnet callback racing this one -- that
+    send raises ``OSError: cannot send (already closed?)``, uncaught, and
+    pytest reports it as an INTERNALERROR that ends the run, workers that were
+    fine included. This is not specific to any one test suite or wedge
+    scenario; it is a bug in xdist's own error path with no synthetic
+    reproduction needed here -- it was hit organically while exercising the
+    watchdog above, with no wedge involved at all, just two ordinary crashes
+    close enough together in time.
+
+    Every scheduling mode (``--dist=load/loadscope/loadgroup/worksteal/each``)
+    has its own scheduler class and its own call site for sending tests, but
+    every one of them ends up going through this same
+    ``WorkerController.sendcommand`` -- so patching here, instead of one
+    scheduler class's ``_send_tests``, is the version of this fix that
+    actually covers every ``--dist`` mode rather than just the default one.
+    It is also not really foreign monkeypatching so much as finishing a job
+    xdist already started: ``WorkerController.shutdown`` right next to this
+    method already wraps its own ``sendcommand`` call in ``try/except
+    OSError: pass`` for exactly this reason -- every other caller (the
+    schedulers) was simply missed.
+
+    Swallowing the error here and doing nothing further is deliberate, not
+    lazy: bookkeeping a phantom "sent" test against a dead node is harmless,
+    because that node's own crash -- already in flight, asynchronously -- will
+    shortly call ``remove_node`` on it too, which pops its *entire* pending
+    list (phantom entry included) and requeues it for a live node. Retrying
+    the send, or reaching into the scheduler to remove the node from inside
+    this call, would instead re-enter node removal from inside the very send
+    that node removal itself triggered -- recursion worth avoiding on
+    principle, not just because nothing here needs it: the safer, simpler
+    fix is to leave that removal to the async crash-detection path that is
+    already in flight for this node.
+
+    A no-op on any run that never sees a closed channel: the wrapped function
+    still calls straight through, so a healthy session pays only the cost of
+    one extra Python frame per command sent.
+    """
+    try:
+        from xdist.workermanage import WorkerController
+    except ImportError:
+        return  # xdist not installed in this environment, or this process never imports it
+
+    original = WorkerController.sendcommand
+    if getattr(original, '_gpu_lease_tolerates_closed_channel', False):
+        return  # pytest_configure can run more than once in the same interpreter
+
+    def sendcommand(self, name, **kwargs):
+        try:
+            original(self, name, **kwargs)
+        except OSError as exc:
+            print(f'pytest_gpu_lease: {self.gateway.id} channel already closed, '
+                  f'dropping {name}({kwargs}) instead of crashing the session ({exc})',
+                  file=sys.stderr, flush=True)
+
+    sendcommand._gpu_lease_tolerates_closed_channel = True
+    WorkerController.sendcommand = sendcommand
+
+
+@pytest.hookimpl
+def pytest_configure(config):
+    """Apply the scheduler guard above once, in every process this plugin loads
+    into. Harmless where it does not apply: workers never call
+    ``WorkerController.sendcommand`` (only the controller schedules), and a
+    plain non-distributed run never imports ``xdist.workermanage`` at all, so
+    the early return in ``_tolerate_closed_worker_channel`` makes this a no-op
+    there.
+    """
+    _tolerate_closed_worker_channel()

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -31,7 +31,7 @@ from types import MappingProxyType
 
 import pytest
 
-STRUCT_FLOCK = 'hhllh'
+STRUCT_FLOCK = 'hhqqi'
 PAGE_SIZE = 4096
 _RETRY_INTERVAL = 0.05
 

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -49,6 +49,27 @@ assert _SIZEOF_OFF_T == 8, (
 
 _RETRY_INTERVAL = 0.05
 
+# Page layout, shared with watchdog.py: an 8-byte `monotonic_ns` stamp at the
+# page base -- 0 meaning "between tests" -- then the pid of the worker that
+# wrote it.
+#
+# The pid is what makes a stale stamp harmless. A page is freed still carrying
+# an expired stamp in exactly one situation, and it is the one this feature
+# creates: the watchdog SIGKILLs a wedged worker, whose stamp is by definition
+# past the threshold, and xdist gives the replacement the page it just vacated.
+# Between that F_SETLK and the replacement's first write, the page reads
+# locked-and-ancient. Writing sooner only narrows that window; comparing the
+# recorded pid against the current lock holder closes it, however wide it is.
+#
+# Stamp first, pid second, so a reader that catches the pair half written sees
+# (new stamp, old pid) and skips it -- never (old stamp, new pid), the one
+# combination that would kill a healthy worker. That ordering is why this needs
+# no 16-byte atomic write.
+HEARTBEAT_FMT = '<Q'
+OWNER_FMT = '<q'
+OWNER_OFFSET = struct.calcsize(HEARTBEAT_FMT)
+HEARTBEAT_SIZE = OWNER_OFFSET + struct.calcsize(OWNER_FMT)
+
 
 def dump_path(lockfile, pid: int) -> str:
     """Where a leasing worker's faulthandler writes its stack dump.
@@ -218,7 +239,9 @@ def gpu_id(request):
             # vacated. A poll landing in that gap would read locked-and-ancient
             # and SIGTERM a brand-new healthy worker -- which then gets
             # SIGKILLed regardless, since escalation offers no reprieve.
-            os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns()), page_base)
+            os.pwrite(f.fileno(), struct.pack(HEARTBEAT_FMT, time.monotonic_ns()), page_base)
+            os.pwrite(f.fileno(), struct.pack(OWNER_FMT, os.getpid()),
+                      page_base + OWNER_OFFSET)
             _announce(request.config,
                       f'{worker_id} uses GPU {gpu} filelock = {lockfile}')
             # Handle SIGTERM from watchdog to print a full stack dump naming the frame.
@@ -292,10 +315,11 @@ def pytest_runtest_protocol():
             lease = _active_lease
             if lease is not None:
                 fd, page_base = lease
-                os.pwrite(fd, struct.pack('<Q', 0), page_base)
+                os.pwrite(fd, struct.pack(HEARTBEAT_FMT, 0), page_base)
         return
     fd, page_base = lease
-    os.pwrite(fd, struct.pack('<Q', time.monotonic_ns()), page_base)
+    # Stamp only; the owner pid is written once, when the lease is taken.
+    os.pwrite(fd, struct.pack(HEARTBEAT_FMT, time.monotonic_ns()), page_base)
     try:
         yield
     finally:
@@ -308,7 +332,7 @@ def pytest_runtest_protocol():
         # into somebody else's file. The watchdog needs nothing from this write
         # anyway: it only reads pages it found locked, and the lease is gone.
         if _active_lease is not None:
-            os.pwrite(fd, struct.pack('<Q', 0), page_base)
+            os.pwrite(fd, struct.pack(HEARTBEAT_FMT, 0), page_base)
 
 
 @pytest.fixture(scope='session')

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -67,27 +67,6 @@ _RETRY_INTERVAL = 0.05
 # How long a single test may legitimately run before the watchdog (see
 # watchdog.py, which imports this) treats the worker holding it as wedged.
 # Not the suite length, not the worker count -- the heartbeat below is
-# rewritten before every test, so this number is exactly one thing: the
-# longest one test may take. A real pass ran 265,282 tests in 227,112
-# worker-seconds, 0.86s/test mean, so 600s is about the tail, not the
-# average -- and the tail is plausibly the torch reference materialising an
-# 8192x8192 score matrix, not the kernel under test, so sizing it off kernel
-# cost alone would guess far too low. The cost of being wrong is asymmetric:
-# too high and a wedge idles a worker for the excess (a handful of tests a
-# pass); too low and a slow-but-passing test is recorded as a crash, a
-# restart is burned, and the scheduler goes through the teardown path again.
-# ``GPU_LEASE_BUDGET_S`` overrides it, mainly so a test of the watchdog
-# itself can use a fuse of seconds rather than waiting out the real one.
-_DEFAULT_BUDGET_S = 600
-
-
-def _budget_ns() -> int:
-    """Per-test heartbeat budget in nanoseconds. Read lazily, never at import."""
-    raw = os.getenv('GPU_LEASE_BUDGET_S', default=None)
-    seconds = _DEFAULT_BUDGET_S if raw is None else float(raw)
-    return int(seconds * 1_000_000_000)
-
-
 # Set by the leased branch of `gpu_id` once a lease is actually held, and
 # cleared again at its teardown; `None` the rest of the time. The
 # `pytest_runtest_protocol` hookwrapper below needs to know whether there is
@@ -252,20 +231,21 @@ def gpu_id(request):
             # call, sent SIGTERM, printed a full stack dump naming the frame.
             faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
             _active_lease = (f.fileno(), page_base)
-            # Arm a deadline right now, not just from the first heartbeat below.
-            # `pytest_runtest_protocol`'s hookwrapper (below) wraps setup, call
-            # and teardown as a single hook call, and its pre-yield code -- where
-            # a fresh deadline is normally written -- runs *before* that call
-            # even starts, i.e. before this fixture body has run at all. So for
-            # this worker's first test, that pre-yield code sees `_active_lease`
-            # still `None` and, correctly, touches nothing; without this write,
-            # the page would carry no deadline through the whole of that first
-            # test's setup, call, and teardown, and a wedge anywhere in it would
-            # be invisible to the watchdog. This write closes exactly that gap
-            # and nothing else: every later test gets a fresh deadline from the
-            # hookwrapper itself, since by then `_active_lease` is already set
-            # when that wrapper's pre-yield code runs.
-            os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns() + _budget_ns()), page_base)
+            # Stamp the page as active right now, not just from the first
+            # heartbeat below. `pytest_runtest_protocol`'s hookwrapper (below)
+            # wraps setup, call and teardown as a single hook call, and its
+            # pre-yield code -- where a fresh stamp is normally written -- runs
+            # *before* that call even starts, i.e. before this fixture body has
+            # run at all. So for this worker's first test, that pre-yield code
+            # sees `_active_lease` still `None` and, correctly, touches nothing;
+            # without this write, the page would carry no stamp through the
+            # whole of that first test's setup, call, and teardown, and a wedge
+            # anywhere in it would be invisible to the watchdog. This write
+            # closes exactly that gap and nothing else: every later test gets a
+            # fresh stamp from the hookwrapper itself, since by then
+            # `_active_lease` is already set when that wrapper's pre-yield code
+            # runs.
+            os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns()), page_base)
             try:
                 yield gpu
             finally:
@@ -278,7 +258,25 @@ def gpu_id(request):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_protocol():
-    """Heartbeat this worker's page with the current test's deadline.
+    """Heartbeat this worker's page with the time the current test started.
+
+    The page carries a plain `time.monotonic_ns()` stamp -- "this worker was
+    last seen alive at T" -- and nothing else. Deciding whether T is too long
+    ago is entirely the watchdog's business, so the timeout has exactly one
+    definition, in exactly one place (`watchdog.py`'s `--threshold`), and no
+    way for the two sides to disagree about it. An earlier revision wrote a
+    *deadline* here instead, `now + budget`, on the theory that a per-test
+    budget might one day be wanted; the cost was two thresholds in the tree at
+    once -- one baked into the file by the worker, one on the watchdog's
+    command line -- and no way to tell from either side which was in force.
+    Should a per-test budget ever actually be needed, the page has 4088 spare
+    bytes for the worker to state one explicitly, which is a better answer
+    than encoding it implicitly in the stamp.
+
+    `time.monotonic()` is `clock_gettime(CLOCK_MONOTONIC)`, which is
+    system-wide rather than per-process, so the watchdog compares these
+    against its own reading directly -- no shared epoch and no wall-clock
+    dependency, which also makes the scheme immune to NTP steps mid-pass.
 
     Inert unless `gpu_id` actually holds a lease: `_active_lease` is only set by
     the leased branch above, so pinned mode, no-xdist mode, and GPU-less suites
@@ -290,7 +288,7 @@ def pytest_runtest_protocol():
     Wraps the whole protocol -- setup, call, and teardown -- deliberately, so a
     worker that wedges anywhere in any of the three (a GPU allocation during
     setup, the test body itself, a cache-empty or sync during teardown) is
-    covered by one and the same deadline. The alternative, wrapping only
+    covered by one and the same stamp. The alternative, wrapping only
     `pytest_runtest_call`, was tried first and rejected: it left setup and
     teardown outside the heartbeat entirely, so a fixture-level wedge would
     never be caught at all.
@@ -305,8 +303,8 @@ def pytest_runtest_protocol():
     but with nothing else in place, that leaves the entire first test
     heartbeat-less. (Caught by an end-to-end test that wedged the very first
     parametrized case on a worker: the watchdog never fired, because no
-    deadline had ever been written for that page.) `gpu_id` covers this by
-    writing an initial deadline itself, at the moment the lease is taken --
+    stamp had ever been written for that page.) `gpu_id` covers this by
+    writing an initial stamp itself, at the moment the lease is taken --
     see the comment there. From the second test onward, `_active_lease` is
     already set by the time this wrapper's pre-yield code runs, so it takes
     over the refreshing normally. The two writers never race: at most one of
@@ -322,25 +320,24 @@ def pytest_runtest_protocol():
     The write is a single aligned 8-byte pwrite at the page base -- the
     platform's atomic write granularity for a page-aligned offset -- so the
     watchdog's concurrent pread never observes a torn value; no seqlock or
-    other synchronisation is needed on either side. Zeroing the deadline after
-    the test, rather than leaving the last one in place, is what keeps an idle
-    worker between tests from ever looking like a candidate to the watchdog.
+    other synchronisation is needed on either side. Zeroing the stamp after the
+    test, rather than leaving the last one in place, is what keeps an idle
+    worker between tests from ever looking like a candidate to the watchdog: 0
+    is the one value that means "not running a test", and the watchdog skips
+    such a page outright instead of ageing it.
     (The first test is the one exception: this wrapper takes the `is None`
     branch for it and never zeros afterwards, leaving `gpu_id`'s initial write
     in place until the second test's pre-yield code overwrites it. That stale
-    value cannot cause a false idle read -- it is a real, if slightly dated,
-    future deadline, not a zero -- and cannot cause a false SIGTERM either
-    unless the gap between the first test finishing and the second one
-    starting itself exceeds the budget, which would mean the worker really is
-    stuck somewhere between tests.)
+    stamp cannot be mistaken for idle -- it is a real reading, not a zero --
+    and it can only age past the threshold if the first test plus the gap after
+    it really did exceed the threshold, which is a wedge worth catching.)
     """
     lease = _active_lease
     if lease is None:
         yield
         return
     fd, page_base = lease
-    deadline = time.monotonic_ns() + _budget_ns()
-    os.pwrite(fd, struct.pack('<Q', deadline), page_base)
+    os.pwrite(fd, struct.pack('<Q', time.monotonic_ns()), page_base)
     try:
         yield
     finally:
@@ -348,8 +345,8 @@ def pytest_runtest_protocol():
         # wrapped also tears down the session-scoped `gpu_id` fixture -- which
         # closes `fd` and releases the lock -- before control returns here, so
         # `fd` may already be a stale, closed number. That is fine to ignore:
-        # zeroing a deadline is only ever meaningful while the page is still
-        # locked, and the watchdog never reads a page's deadline without first
+        # zeroing a stamp is only ever meaningful while the page is still
+        # locked, and the watchdog never reads a page's stamp without first
         # finding it locked, so a released page's stale value is never seen.
         try:
             os.pwrite(fd, struct.pack('<Q', 0), page_base)

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -49,6 +49,22 @@ assert _SIZEOF_OFF_T == 8, (
 
 _RETRY_INTERVAL = 0.05
 
+
+def dump_path(lockfile, pid: int) -> str:
+    """Where a leasing worker's faulthandler writes its stack dump.
+
+    One file per worker, not the shared stderr: a dump is many small writes, so
+    two workers dumping at once would splice into each other. `watchdog.py`
+    reads these back and relays them, being the only serial writer into the
+    pass's stderr.
+
+    Keyed by pid, not by GPU: a pass restarts workers many times, and a
+    replacement taking the freed page would otherwise truncate its
+    predecessor's dump before anyone had read it. pid is also the only handle
+    the watchdog has -- `F_GETLK` gives it that and nothing else.
+    """
+    return f'{lockfile}.{pid}.dump'
+
 # A plain global object to track current GPU lease. It is safe here because
 # `gpu_id` is session-scoped and, under xdist, "session" means "per worker
 # process": at most one lease is ever active in a given interpreter.
@@ -199,7 +215,20 @@ def gpu_id(request):
             # Note signal handler itself cannot detect blocked GPU kernel:
             # CPython only runs a Python signal handler when the main thread
             # reaches a bytecode boundary.
-            faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
+            # Only under a watchdog: GPU_LEASE_LOCKFILE is how run-test.sh
+            # hands one path to both sides, so without it nothing will ever
+            # read a dump -- and registering is not free, since chain=False
+            # disarms SIGTERM for the rest of the worker's session.
+            #
+            # NOT sys.stderr: at fixture setup that is pytest's fd-level
+            # capture target, and a capture buffer is only replayed when the
+            # test finishes -- which a wedged test never does. faulthandler
+            # needs its descriptor now, since the wedged worker runs no Python
+            # later, so it gets a file of its own (see dump_path).
+            dumpfile = None
+            if os.getenv('GPU_LEASE_LOCKFILE'):
+                dumpfile = open(dump_path(lockfile, os.getpid()), 'w')
+                faulthandler.register(signal.SIGTERM, file=dumpfile, all_threads=True)
             _active_lease = (f.fileno(), page_base)
             # Initialize the heartbeat value
             os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns()), page_base)
@@ -207,6 +236,16 @@ def gpu_id(request):
                 yield gpu
             finally:
                 _active_lease = None
+                if dumpfile is not None:
+                    faulthandler.unregister(signal.SIGTERM)  # before closing its file
+                    dumpfile.close()
+                    # The moment this worker can no longer wedge. /dev/shm is
+                    # small in a container and a long pass restarts workers
+                    # many times, so these must not outlive their owner.
+                    try:
+                        os.unlink(dump_path(lockfile, os.getpid()))
+                    except FileNotFoundError:
+                        pass
                 release = struct.pack(STRUCT_FLOCK, fcntl.F_UNLCK, os.SEEK_SET,
                                       page_base, PAGE_SIZE, 0)
                 fcntl.fcntl(f, fcntl.F_SETLK, release)

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -149,9 +149,9 @@ def _gpu_lease_lockfile(tmp_path_factory):
     so pre-sizing buys nothing -- and the old open(..., 'wb') let a late-starting worker
     truncate a file its peers were already locking.
 
-    ``GPU_LEASE_LOCKFILE``, when set, wins over the derived path. This is
-    designed for watchdog process, which is a started separately and before
-    pytest exists, so it cannot predict what ``getbasetemp()`` will resolve to
+    ``GPU_LEASE_LOCKFILE``, when set, wins over the derived path. It exists for
+    the watchdog, which is started separately and before pytest, and so cannot
+    predict what ``getbasetemp()`` will resolve to.
     """
     override = os.getenv('GPU_LEASE_LOCKFILE', default=None)
     if override is not None:

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -240,12 +240,16 @@ def pytest_runtest_protocol():
     try:
         yield
     finally:
-        # On the last test this same call tears down `gpu_id`, closing `fd`.
-        # Harmless: the watchdog only reads pages it found locked.
-        try:
+        # On the last test this same call tears down `gpu_id`, which clears
+        # `_active_lease` and then closes `fd`. Re-reading the global is what
+        # makes the write safe: `fd` is a bare integer, so once it is closed
+        # the kernel is free to hand that number to the next file opened -- and
+        # the rest of session teardown opens plenty. Writing to it then would
+        # not raise, it would silently drop eight zero bytes at `page_base`
+        # into somebody else's file. The watchdog needs nothing from this write
+        # anyway: it only reads pages it found locked, and the lease is gone.
+        if _active_lease is not None:
             os.pwrite(fd, struct.pack('<Q', 0), page_base)
-        except OSError:
-            pass
 
 
 @pytest.fixture(scope='session')

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -39,7 +39,7 @@ STRUCT_FLOCK = 'hhqqi'
 PAGE_SIZE = 4096
 
 # `struct flock` uses off_t, we only handle 64-bit off_t and fail loud for 32-bit off_t.
-# No plan to support 32-bit off_t. Systems with 32-bit off_t should upgrade.
+# No plan to support 32-bit off_t
 _SIZEOF_OFF_T = sysconfig.get_config_var('SIZEOF_OFF_T')
 assert _SIZEOF_OFF_T == 8, (
     f'pytest_gpu_lease requires a 64-bit off_t; this interpreter reports '

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -38,23 +38,8 @@ import pytest
 STRUCT_FLOCK = 'hhqqi'
 PAGE_SIZE = 4096
 
-# `struct flock` as the kernel wants it, valid exactly when off_t is 64 bits:
-# two shorts, two 64-bit offsets, an int pid. That covers LP64 and any stock
-# 32-bit CPython alike -- configure runs AC_SYS_LARGEFILE, so pyconfig.h
-# carries _FILE_OFFSET_BITS=64, off_t widens to 8 bytes, and glibc redirects
-# F_SETLK/F_GETLK to their 64-bit variants in the same breath, keeping the
-# constant and the layout in agreement. (`q` rather than `l` for that reason:
-# the two are identical on LP64, but `l` is 4 bytes on 32-bit and would
-# describe the wrong struct there.)
-#
-# The single build this is wrong for is a 32-bit CPython with largefile
-# support disabled, where off_t is a 4-byte long and the kernel wants a
-# 16-byte struct. Checked here, at import, rather than on any result we get
-# back: passing a wrongly-sized buffer to fcntl() is itself the damage -- the
-# kernel would read F_SETLK's range from the wrong bytes and lock something
-# arbitrary, with nothing raised anywhere -- so the check has to happen before
-# the first call, not after it. Assert rather than handle: nobody is expected
-# to run that build, and being told is the entire goal.
+# `struct flock` uses off_t, we only handle 64-bit off_t and fail loud for 32-bit off_t.
+# No plan to support 32-bit off_t. Systems with 32-bit off_t should upgrade.
 _SIZEOF_OFF_T = sysconfig.get_config_var('SIZEOF_OFF_T')
 assert _SIZEOF_OFF_T == 8, (
     f'pytest_gpu_lease requires a 64-bit off_t; this interpreter reports '
@@ -64,17 +49,9 @@ assert _SIZEOF_OFF_T == 8, (
 
 _RETRY_INTERVAL = 0.05
 
-# How long a single test may legitimately run before the watchdog (see
-# watchdog.py, which imports this) treats the worker holding it as wedged.
-# Not the suite length, not the worker count -- the heartbeat below is
-# Set by the leased branch of `gpu_id` once a lease is actually held, and
-# cleared again at its teardown; `None` the rest of the time. The
-# `pytest_runtest_protocol` hookwrapper below needs to know whether there is
-# a page to heartbeat, but it is a plugin-level hook, not a fixture, so it
-# cannot request `gpu_id` or read its generator frame -- this module global
-# is the connecting state. A plain global is safe here because `gpu_id` is
-# session-scoped and, under xdist, "session" means "per worker process": at
-# most one lease is ever active in a given interpreter.
+# A plain global object to track current GPU lease. It is safe here because
+# `gpu_id` is session-scoped and, under xdist, "session" means "per worker
+# process": at most one lease is ever active in a given interpreter.
 _active_lease: tuple[int, int] | None = None  # (fd, page_base)
 
 
@@ -156,13 +133,9 @@ def _gpu_lease_lockfile(tmp_path_factory):
     so pre-sizing buys nothing -- and the old open(..., 'wb') let a late-starting worker
     truncate a file its peers were already locking.
 
-    ``GPU_LEASE_LOCKFILE``, when set, wins over the derived path. The watchdog is a
-    separate process started before pytest exists, so it cannot predict what
-    ``getbasetemp()`` will resolve to for this run -- run-test.sh instead mints a
-    path up front and both sides read it from the environment. The derived path
-    stays as the fallback so a plain ``pytest`` invocation, with no watchdog and
-    no env var, is unchanged. Side benefit: the lease file becomes greppable by a
-    fixed name during a hang instead of living inside a per-run ``pytest-NNN/`` dir.
+    ``GPU_LEASE_LOCKFILE``, when set, wins over the derived path. This is
+    designed for watchdog process, which is a started separately and before
+    pytest exists, so it cannot predict what ``getbasetemp()`` will resolve to
     """
     override = os.getenv('GPU_LEASE_LOCKFILE', default=None)
     if override is not None:
@@ -222,29 +195,13 @@ def gpu_id(request):
                 continue
             _announce(request.config,
                       f'{worker_id} uses GPU {gpu} filelock = {lockfile}')
-            # A Python-level SIGTERM handler would fail the same way pytest-timeout's
-            # SIGALRM handler does: CPython only runs a Python signal handler when the
-            # main thread reaches a bytecode boundary, and a thread parked in a HIP
-            # call never reaches one. faulthandler's handler is C-level and needs no
-            # GIL, so it still fires -- and dumps every thread's stack -- while the
-            # main thread is stuck. Verified: a process blocked in a ctypes.PyDLL
-            # call, sent SIGTERM, printed a full stack dump naming the frame.
+            # Handle SIGTERM from watchdog to print a full stack dump naming the frame.
+            # Note signal handler itself cannot detect blocked GPU kernel:
+            # CPython only runs a Python signal handler when the main thread
+            # reaches a bytecode boundary.
             faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
             _active_lease = (f.fileno(), page_base)
-            # Stamp the page as active right now, not just from the first
-            # heartbeat below. `pytest_runtest_protocol`'s hookwrapper (below)
-            # wraps setup, call and teardown as a single hook call, and its
-            # pre-yield code -- where a fresh stamp is normally written -- runs
-            # *before* that call even starts, i.e. before this fixture body has
-            # run at all. So for this worker's first test, that pre-yield code
-            # sees `_active_lease` still `None` and, correctly, touches nothing;
-            # without this write, the page would carry no stamp through the
-            # whole of that first test's setup, call, and teardown, and a wedge
-            # anywhere in it would be invisible to the watchdog. This write
-            # closes exactly that gap and nothing else: every later test gets a
-            # fresh stamp from the hookwrapper itself, since by then
-            # `_active_lease` is already set when that wrapper's pre-yield code
-            # runs.
+            # Initialize the heartbeat value
             os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns()), page_base)
             try:
                 yield gpu
@@ -258,79 +215,21 @@ def gpu_id(request):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_protocol():
-    """Heartbeat this worker's page with the time the current test started.
+    """Stamp this worker's page with `monotonic_ns()` before each test, 0 after.
 
-    The page carries a plain `time.monotonic_ns()` stamp -- "this worker was
-    last seen alive at T" -- and nothing else. Deciding whether T is too long
-    ago is entirely the watchdog's business, so the timeout has exactly one
-    definition, in exactly one place (`watchdog.py`'s `--threshold`), and no
-    way for the two sides to disagree about it. An earlier revision wrote a
-    *deadline* here instead, `now + budget`, on the theory that a per-test
-    budget might one day be wanted; the cost was two thresholds in the tree at
-    once -- one baked into the file by the worker, one on the watchdog's
-    command line -- and no way to tell from either side which was in force.
-    Should a per-test budget ever actually be needed, the page has 4088 spare
-    bytes for the worker to state one explicitly, which is a better answer
-    than encoding it implicitly in the stamp.
+    0 means "between tests" and the watchdog skips it. `watchdog.py` owns the
+    timeout; this side only reports liveness.
 
-    `time.monotonic()` is `clock_gettime(CLOCK_MONOTONIC)`, which is
-    system-wide rather than per-process, so the watchdog compares these
-    against its own reading directly -- no shared epoch and no wall-clock
-    dependency, which also makes the scheme immune to NTP steps mid-pass.
+    Wraps the whole protocol so a wedge in fixture setup or teardown counts
+    too. Consequence: `gpu_id` resolves *inside* the first wrapped call, so
+    `_active_lease` is still None here for a worker's first test -- `gpu_id`
+    writes that initial stamp itself.
 
-    Inert unless `gpu_id` actually holds a lease: `_active_lease` is only set by
-    the leased branch above, so pinned mode, no-xdist mode, and GPU-less suites
-    (which never request `gpu_id`, so that fixture body never runs at all) hit
-    the `is None` check and do no I/O -- this hook fires for every test in every
-    pytest process in the environment, so being a no-op absent a lease is not
-    optional.
+    No lease means no I/O. This hook runs in every pytest process in the
+    environment, GPU-less suites included.
 
-    Wraps the whole protocol -- setup, call, and teardown -- deliberately, so a
-    worker that wedges anywhere in any of the three (a GPU allocation during
-    setup, the test body itself, a cache-empty or sync during teardown) is
-    covered by one and the same stamp. The alternative, wrapping only
-    `pytest_runtest_call`, was tried first and rejected: it left setup and
-    teardown outside the heartbeat entirely, so a fixture-level wedge would
-    never be caught at all.
-
-    That whole-protocol wrapping has one gap of its own, and `gpu_id` closes it
-    rather than this hook: `runtestprotocol()` still runs setup, call and
-    teardown as separate hook calls internally, and `gpu_id`'s lock-acquire
-    (which sets `_active_lease`) happens inside the first of those, i.e. *after*
-    this wrapper's pre-yield code has already run for a worker's first test.
-    That pre-yield code reads `_active_lease` once, before the wrapped call
-    starts, so on the first test it correctly sees `None` and writes nothing --
-    but with nothing else in place, that leaves the entire first test
-    heartbeat-less. (Caught by an end-to-end test that wedged the very first
-    parametrized case on a worker: the watchdog never fired, because no
-    stamp had ever been written for that page.) `gpu_id` covers this by
-    writing an initial stamp itself, at the moment the lease is taken --
-    see the comment there. From the second test onward, `_active_lease` is
-    already set by the time this wrapper's pre-yield code runs, so it takes
-    over the refreshing normally. The two writers never race: at most one of
-    them is ever the one enabled for a given test, controlled by the same
-    single check of `_active_lease` here.
-
-    Runs on whatever thread pytest calls hooks on for this test, which under
-    xdist is the worker's MainThread -- deliberately: the heartbeat must stop
-    the instant that thread stops reaching this hook, which is exactly what
-    happens when it wedges in a HIP call. A background heartbeat thread would
-    keep ticking regardless and defeat the whole scheme.
-
-    The write is a single aligned 8-byte pwrite at the page base -- the
-    platform's atomic write granularity for a page-aligned offset -- so the
-    watchdog's concurrent pread never observes a torn value; no seqlock or
-    other synchronisation is needed on either side. Zeroing the stamp after the
-    test, rather than leaving the last one in place, is what keeps an idle
-    worker between tests from ever looking like a candidate to the watchdog: 0
-    is the one value that means "not running a test", and the watchdog skips
-    such a page outright instead of ageing it.
-    (The first test is the one exception: this wrapper takes the `is None`
-    branch for it and never zeros afterwards, leaving `gpu_id`'s initial write
-    in place until the second test's pre-yield code overwrites it. That stale
-    stamp cannot be mistaken for idle -- it is a real reading, not a zero --
-    and it can only age past the threshold if the first test plus the gap after
-    it really did exceed the threshold, which is a wedge worth catching.)
+    Runs on the worker's MainThread deliberately: a background heartbeat
+    thread would keep ticking through the very wedge this exists to detect.
     """
     lease = _active_lease
     if lease is None:
@@ -341,13 +240,8 @@ def pytest_runtest_protocol():
     try:
         yield
     finally:
-        # On this worker's last test (`nextitem is None`), the very call being
-        # wrapped also tears down the session-scoped `gpu_id` fixture -- which
-        # closes `fd` and releases the lock -- before control returns here, so
-        # `fd` may already be a stale, closed number. That is fine to ignore:
-        # zeroing a stamp is only ever meaningful while the page is still
-        # locked, and the watchdog never reads a page's stamp without first
-        # finding it locked, so a released page's stale value is never seen.
+        # On the last test this same call tears down `gpu_id`, closing `fd`.
+        # Harmless: the watchdog only reads pages it found locked.
         try:
             os.pwrite(fd, struct.pack('<Q', 0), page_base)
         except OSError:
@@ -380,52 +274,26 @@ def torch_gpu(gpu_id) -> int:
 
 
 def _tolerate_closed_worker_channel() -> None:
-    """Stop a second dying worker from turning the first one's crash into an
+    """Stop a second dying worker turning the first one's crash into an
     INTERNALERROR that kills the whole session.
 
-    The failure this guards against: the controller notices worker A died and
-    calls ``DSession.worker_errordown`` -> ``LoadScheduling.remove_node(A)``,
-    which reassigns A's pending items and then, still inside that same call,
-    tops up every *other* node's queue via ``check_schedule`` ->
-    ``_send_tests`` -> ``WorkerController.send_runtest_some`` ->
-    ``sendcommand`` -> ``execnet``'s ``channel.send``. If worker B is also
-    dying at that exact moment -- its own crash not yet reported, since that
-    report is itself an asynchronous execnet callback racing this one -- that
-    send raises ``OSError: cannot send (already closed?)``, uncaught, and
-    pytest reports it as an INTERNALERROR that ends the run, workers that were
-    fine included. This is not specific to any one test suite or wedge
-    scenario; it is a bug in xdist's own error path with no synthetic
-    reproduction needed here -- it was hit organically while exercising the
-    watchdog above, with no wedge involved at all, just two ordinary crashes
-    close enough together in time.
+    `worker_errordown(A)` -> `remove_node` -> `check_schedule` -> `_send_tests`
+    tops up the *other* nodes' queues. If B is dying too -- its own crash
+    report still in flight -- that send raises `OSError: cannot send (already
+    closed?)`, uncaught, and the run ends.
 
-    Every scheduling mode (``--dist=load/loadscope/loadgroup/worksteal/each``)
-    has its own scheduler class and its own call site for sending tests, but
-    every one of them ends up going through this same
-    ``WorkerController.sendcommand`` -- so patching here, instead of one
-    scheduler class's ``_send_tests``, is the version of this fix that
-    actually covers every ``--dist`` mode rather than just the default one.
-    It is also not really foreign monkeypatching so much as finishing a job
-    xdist already started: ``WorkerController.shutdown`` right next to this
-    method already wraps its own ``sendcommand`` call in ``try/except
-    OSError: pass`` for exactly this reason -- every other caller (the
-    schedulers) was simply missed.
+    Usually triggered by killing several stalled GPU workers at once -- by
+    hand, or by the watchdog, which staggers to one kill per poll for exactly
+    this reason. Two ordinary crashes landing close enough together do it too.
 
-    Swallowing the error here and doing nothing further is deliberate, not
-    lazy: bookkeeping a phantom "sent" test against a dead node is harmless,
-    because that node's own crash -- already in flight, asynchronously -- will
-    shortly call ``remove_node`` on it too, which pops its *entire* pending
-    list (phantom entry included) and requeues it for a live node. Retrying
-    the send, or reaching into the scheduler to remove the node from inside
-    this call, would instead re-enter node removal from inside the very send
-    that node removal itself triggered -- recursion worth avoiding on
-    principle, not just because nothing here needs it: the safer, simpler
-    fix is to leave that removal to the async crash-detection path that is
-    already in flight for this node.
+    Patches `sendcommand` rather than one scheduler's `_send_tests` because
+    every `--dist` mode funnels through it, and `WorkerController.shutdown`
+    already wraps the same call in the same `except OSError` -- the schedulers
+    were just missed.
 
-    A no-op on any run that never sees a closed channel: the wrapped function
-    still calls straight through, so a healthy session pays only the cost of
-    one extra Python frame per command sent.
+    Swallowing is enough: B's own crash will `remove_node` it shortly, which
+    requeues its whole pending list, phantom entry included. Removing the node
+    from inside the send that node removal triggered would recurse.
     """
     try:
         from xdist.workermanage import WorkerController
@@ -450,11 +318,8 @@ def _tolerate_closed_worker_channel() -> None:
 
 @pytest.hookimpl
 def pytest_configure(config):
-    """Apply the scheduler guard above once, in every process this plugin loads
-    into. Harmless where it does not apply: workers never call
-    ``WorkerController.sendcommand`` (only the controller schedules), and a
-    plain non-distributed run never imports ``xdist.workermanage`` at all, so
-    the early return in ``_tolerate_closed_worker_channel`` makes this a no-op
-    there.
+    """Apply the scheduler guard once per process. A no-op where it does not
+    apply: only the controller schedules, and a non-distributed run never
+    imports xdist at all.
     """
     _tolerate_closed_worker_channel()

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -21,6 +21,7 @@ several tests concurrently on one GPU invites memory pressure and runtime / driv
 firmware / VBIOS races.
 """
 
+import errno
 import fcntl
 import faulthandler
 import itertools
@@ -360,6 +361,12 @@ def torch_gpu(gpu_id) -> int:
     return gpu_id
 
 
+# Errnos a pipe write produces when the process on the other end is gone. The
+# closed-channel case carries no errno at all, hence the isclosed() check too.
+_PEER_GONE_ERRNOS = frozenset({errno.EPIPE, errno.EBADF, errno.ECONNRESET,
+                               errno.ESHUTDOWN})
+
+
 def _tolerate_closed_worker_channel() -> None:
     """Stop a second dying worker turning the first one's crash into an
     INTERNALERROR that kills the whole session.
@@ -395,6 +402,19 @@ def _tolerate_closed_worker_channel() -> None:
         try:
             original(self, name, **kwargs)
         except OSError as exc:
+            # Only a peer that has gone. `sendcommand` reaches OSError by two
+            # different routes and they are not interchangeable: execnet's
+            # `Channel.send` raises one built from a bare string when the
+            # channel is already closed (so `errno` is None -- this is the case
+            # actually observed), while the gateway's own write below it can
+            # fail for any reason a pipe write can.
+            #
+            # Swallowing all of them would file a full disk or a failing device
+            # as "worker crashed" and quietly drop that node's tests, turning a
+            # broken machine into a green-looking short run. Re-raise anything
+            # that is not recognisably the peer being gone.
+            if not (self.channel.isclosed() or exc.errno in _PEER_GONE_ERRNOS):
+                raise
             print(f'pytest_gpu_lease: {self.gateway.id} channel already closed, '
                   f'dropping {name}({kwargs}) instead of crashing the session ({exc})',
                   file=sys.stderr, flush=True)

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -251,8 +251,7 @@ def gpu_id(request):
             # reaches a bytecode boundary.
             # Only under a watchdog: GPU_LEASE_LOCKFILE is how run-test.sh
             # hands one path to both sides, so without it nothing will ever
-            # read a dump -- and registering is not free, since chain=False
-            # disarms SIGTERM for the rest of the worker's session.
+            # read a dump.
             #
             # NOT sys.stderr: at fixture setup that is pytest's fd-level
             # capture target, and a capture buffer is only replayed when the
@@ -262,7 +261,15 @@ def gpu_id(request):
             dumpfile = None
             if os.getenv('GPU_LEASE_LOCKFILE'):
                 dumpfile = open(dump_path(lockfile, os.getpid()), 'w')
-                faulthandler.register(signal.SIGTERM, file=dumpfile, all_threads=True)
+                # chain=True so SIGTERM still terminates: faulthandler dumps,
+                # then restores the previous handler and re-raises, so the
+                # default action runs. Without it SIGTERM is disarmed for the
+                # rest of the session, which makes the watchdog's escalation
+                # the only way to end a worker and breaks `docker stop` and CI
+                # cancellation besides. SIGKILL stays what it should be -- the
+                # last resort for a process SIGTERM could not end.
+                faulthandler.register(signal.SIGTERM, file=dumpfile,
+                                      all_threads=True, chain=True)
             _active_lease = (f.fileno(), page_base)
             try:
                 yield gpu

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -209,6 +209,16 @@ def gpu_id(request):
                 if gpu == nworkers - 1:
                     time.sleep(_RETRY_INTERVAL)
                 continue
+            # Initialize the heartbeat value, before anything else that can
+            # take time. Until this write the page is locked but still carries
+            # the *previous* holder's stamp, and the one way a page is freed
+            # with a stale stamp is the case this feature creates: the watchdog
+            # SIGKILLed a wedged worker, whose stamp is by definition past the
+            # threshold, and xdist's replacement takes the page it just
+            # vacated. A poll landing in that gap would read locked-and-ancient
+            # and SIGTERM a brand-new healthy worker -- which then gets
+            # SIGKILLed regardless, since escalation offers no reprieve.
+            os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns()), page_base)
             _announce(request.config,
                       f'{worker_id} uses GPU {gpu} filelock = {lockfile}')
             # Handle SIGTERM from watchdog to print a full stack dump naming the frame.
@@ -230,8 +240,6 @@ def gpu_id(request):
                 dumpfile = open(dump_path(lockfile, os.getpid()), 'w')
                 faulthandler.register(signal.SIGTERM, file=dumpfile, all_threads=True)
             _active_lease = (f.fileno(), page_base)
-            # Initialize the heartbeat value
-            os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns()), page_base)
             try:
                 yield gpu
             finally:

--- a/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/plugin.py
@@ -272,7 +272,19 @@ def pytest_runtest_protocol():
     """
     lease = _active_lease
     if lease is None:
-        yield
+        try:
+            yield
+        finally:
+            # `gpu_id` may have taken the lease inside this very call -- a
+            # worker's first test -- and written the initial stamp with nothing
+            # to clear it. Left alone that stamp keeps ageing while the worker
+            # sits between its first and second test, so a slow first test plus
+            # the gap after it can cross the threshold and get an idle worker
+            # killed. Zero it here, as every later test does for itself.
+            lease = _active_lease
+            if lease is not None:
+                fd, page_base = lease
+                os.pwrite(fd, struct.pack('<Q', 0), page_base)
         return
     fd, page_base = lease
     os.pwrite(fd, struct.pack('<Q', time.monotonic_ns()), page_base)

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -6,8 +6,9 @@
 Run beside pytest, not inside it: ``python -m pytest_gpu_lease.watchdog --lockfile
 ... --workers N``. It polls the lease lock file that ``plugin.py`` already
 maintains -- one 4096-byte page per GPU, write-locked by whichever worker owns
-that GPU for the run -- and reads the 8-byte deadline ``pytest_runtest_protocol``
-writes there before each test and zeroes after.
+that GPU for the run -- and reads the 8-byte deadline written there: an initial
+one set by ``gpu_id`` the moment it takes the lease, refreshed before every
+test and zeroed after by a ``pytest_runtest_protocol`` hookwrapper.
 
 Why the lock file is the right substrate, in one line: ``fcntl(F_GETLK)`` fills
 ``l_pid`` with the pid holding a byte range, and the kernel releases a record
@@ -50,12 +51,24 @@ _DEFAULT_POLL_INTERVAL_S = 5.0
 # that a genuinely wedged worker is not left idle for long after being caught.
 _DEFAULT_GRACE_S = 30.0
 
-# Consecutive empty polls (no page locked at all) before the watchdog exits on
-# its own. This is the fallback for the case run-test.sh itself cannot reach
-# its own trap -- e.g. it is killed with SIGKILL, which a trap cannot catch --
-# so a watchdog started for one run does not outlive it and go on signalling
-# pids that by then belong to somebody else. At the default poll interval this
-# is one minute of a completely idle lock file.
+# Consecutive empty polls (no page locked at all) *after having seen at least
+# one page locked* before the watchdog exits on its own. This is the fallback
+# for the case run-test.sh itself cannot reach its own trap -- e.g. it is
+# killed with SIGKILL, which a trap cannot catch -- so a watchdog started for
+# one run does not outlive it and go on signalling pids that by then belong to
+# somebody else. At the default poll interval this is one minute of a
+# completely idle lock file, counted only once the run has actually gone idle
+# -- i.e. its last worker released its page -- not before the run has started.
+# The "at least one" qualifier is load bearing, not a nicety: run-test.sh
+# starts the watchdog before pytest even begins collecting, specifically so a
+# wedge during collection is covered too, and a Level-3 pass's collection
+# (~330k tests, a conftest that imports torch) takes minutes -- far longer
+# than idle_polls * poll_interval at the defaults. A watchdog that started
+# counting immediately would exit on its own well before the first worker ever
+# takes a lease, and every wedge for the following ~22h would go uncaught,
+# silently: the "no page locked ... exiting" line looks identical whether it
+# fires because the run is genuinely over or because it never got a chance to
+# start watching.
 _DEFAULT_IDLE_POLLS = 12
 
 
@@ -146,7 +159,7 @@ def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
         any_locked = True
         deadline = _read_deadline(fd, page)
         if deadline == 0:
-            continue  # between tests -- see plugin.py's pytest_runtest_protocol
+            continue  # between tests -- see plugin.py's gpu_id and pytest_runtest_protocol
         if now > deadline:
             running_s = (now - (deadline - threshold_ns)) / 1e9
             _send(pid, signal.SIGTERM,
@@ -160,19 +173,39 @@ def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
 def watch(lockfile: str, workers: int, threshold_s: float, grace_s: float,
          poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
          idle_polls: int = _DEFAULT_IDLE_POLLS) -> None:
-    """Poll `lockfile` until `idle_polls` consecutive sweeps find no page locked."""
+    """Poll `lockfile` until `idle_polls` consecutive sweeps find no page locked
+    -- but only start that countdown once a page has actually been seen locked
+    at least once.
+
+    Before that first sighting, `idle` still increments every empty poll (there
+    is no reason not to track it), but the loop condition ignores it: a
+    watchdog that has never seen a worker take a lease is not stray, it is
+    early -- started deliberately ahead of pytest itself, including ahead of
+    collection, which for a large suite can run for minutes. Counting idle
+    polls from process start would let the watchdog exit on its own before
+    collection even finished, and every wedge for the rest of that run would
+    then go uncaught. See `_DEFAULT_IDLE_POLLS` for the numbers this matters
+    most for.
+
+    Once armed, a worker's page stays locked for the whole of that worker's
+    session, so in steady state the idle countdown only ever starts once every
+    worker has finished and released its page -- i.e. once the run is actually
+    over -- which is the behaviour this fallback exists for in the first place.
+    """
     threshold_ns = int(threshold_s * 1_000_000_000)
     grace_ns = int(grace_s * 1_000_000_000)
     pending: dict[int, int] = {}
     idle = 0
+    armed = False
     # O_CREAT so the watchdog can be started before pytest ever touches the
     # lock file -- run-test.sh starts it first specifically so a wedge that
     # happens during collection would still be caught. plugin.py's own
     # lockfile fixture is equally permissive for the mirror-image reason.
     fd = os.open(lockfile, os.O_RDWR | os.O_CREAT, 0o644)
     try:
-        while idle < idle_polls:
+        while not armed or idle < idle_polls:
             if _poll_once(fd, workers, threshold_ns, grace_ns, pending):
+                armed = True
                 idle = 0
             else:
                 idle += 1

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -1,0 +1,225 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Detect a wedged pytest-xdist worker from outside its process, and kill it.
+
+Run beside pytest, not inside it: ``python -m pytest_gpu_lease.watchdog --lockfile
+... --workers N``. It polls the lease lock file that ``plugin.py`` already
+maintains -- one 4096-byte page per GPU, write-locked by whichever worker owns
+that GPU for the run -- and reads the 8-byte deadline ``pytest_runtest_protocol``
+writes there before each test and zeroes after.
+
+Why the lock file is the right substrate, in one line: ``fcntl(F_GETLK)`` fills
+``l_pid`` with the pid holding a byte range, and the kernel releases a record
+lock automatically when its owner dies. So this module never remembers a pid --
+it asks the kernel again immediately before every signal. A worker that already
+died on its own between one poll and the next is simply unlocked by the time we
+look, and gets nothing sent to it: pid reuse is not a hazard here, because a
+dead process holds no lock to be mistaken for a live one.
+
+Escalation is SIGTERM, a grace period, then SIGKILL if the page is still locked.
+``plugin.py`` registers SIGTERM with ``faulthandler`` on every leasing worker, so
+the SIGTERM here is not a death sentence by itself -- it is a request for a
+stack dump, C-level and GIL-free, naming whatever frame the wedge is in. Only a
+worker that ignores that and is still holding its page after ``--grace`` seconds
+gets SIGKILLed.
+
+Shares ``PAGE_SIZE`` and ``STRUCT_FLOCK`` with ``plugin.py`` by importing them
+rather than restating them, since a copy that drifts from the writer's layout
+would silently misread every deadline.
+"""
+
+import argparse
+import fcntl
+import os
+import signal
+import struct
+import sys
+import time
+
+from .plugin import PAGE_SIZE, STRUCT_FLOCK, _DEFAULT_BUDGET_S
+
+# Default cadence: frequent enough that a 600s budget is caught within a small
+# fraction of itself, infrequent enough that polling 4-8 pages is noise next to
+# a 15-22h pass.
+_DEFAULT_POLL_INTERVAL_S = 5.0
+
+# Default grace between SIGTERM and SIGKILL: long enough for faulthandler to
+# flush a stack dump to stderr (a syscall, not instant under load) and for a
+# process that was already exiting on its own to finish doing so, short enough
+# that a genuinely wedged worker is not left idle for long after being caught.
+_DEFAULT_GRACE_S = 30.0
+
+# Consecutive empty polls (no page locked at all) before the watchdog exits on
+# its own. This is the fallback for the case run-test.sh itself cannot reach
+# its own trap -- e.g. it is killed with SIGKILL, which a trap cannot catch --
+# so a watchdog started for one run does not outlive it and go on signalling
+# pids that by then belong to somebody else. At the default poll interval this
+# is one minute of a completely idle lock file.
+_DEFAULT_IDLE_POLLS = 12
+
+
+def _getlk(fd: int, page: int) -> tuple[bool, int]:
+    """Whether `page` is currently write-locked, and by which pid.
+
+    The pid is meaningless when the first element is False -- F_GETLK leaves
+    only `l_type` defined in that case (see fcntl(2)) -- and callers must not
+    use it.
+    """
+    probe = struct.pack(STRUCT_FLOCK, fcntl.F_WRLCK, os.SEEK_SET,
+                        PAGE_SIZE * page, PAGE_SIZE, 0)
+    result = fcntl.fcntl(fd, fcntl.F_GETLK, probe)
+    lock_type, _, _, _, pid = struct.unpack(STRUCT_FLOCK, result)
+    return lock_type != fcntl.F_UNLCK, pid
+
+
+def _read_deadline(fd: int, page: int) -> int:
+    """The 8-byte deadline at `page`'s base, or 0 if never written / zeroed.
+
+    A plain `os.pread` at a page-aligned offset -- no torn-read handling needed
+    for the same reason the writer needs none: 8 bytes at an aligned offset is
+    within the platform's atomic write granularity.
+
+    The lock file is never pre-sized (see plugin.py's `_gpu_lease_lockfile`), so
+    a page whose worker took the lease but has not yet reached its first test's
+    heartbeat write is genuinely short of 8 bytes there, not zero-filled -- a
+    plain `os.pread` returns fewer than 8 bytes rather than padding with
+    zeroes. Treated the same as an explicit zero: nothing has expired yet.
+    """
+    raw = os.pread(fd, 8, PAGE_SIZE * page)
+    if len(raw) < 8:
+        return 0
+    return struct.unpack('<Q', raw)[0]
+
+
+def _send(pid: int, sig: signal.Signals, reason: str) -> None:
+    """Signal `pid`, tolerating a process that is already gone.
+
+    The F_GETLK check immediately before every call site is the liveness proof
+    (see module docstring); the only race left is the process exiting in the
+    interval between that check and this call, which is exactly what
+    ProcessLookupError reports -- not a bug to guard against, just the same
+    race resolving itself one step later.
+    """
+    try:
+        os.kill(pid, sig)
+        print(f'pytest_gpu_lease.watchdog: sent {sig.name} to pid {pid} ({reason})',
+              file=sys.stderr, flush=True)
+    except ProcessLookupError:
+        print(f'pytest_gpu_lease.watchdog: pid {pid} already gone, no {sig.name} needed ({reason})',
+              file=sys.stderr, flush=True)
+
+
+def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
+              pending: dict[int, int]) -> bool:
+    """One sweep of every page. Sends at most one signal -- see module docstring
+    on staggering kills -- and returns whether any page is currently locked, for
+    the caller's idle/self-exit counter.
+
+    `pending` maps a page already SIGTERMed to the `monotonic_ns()` that signal
+    went out, and is mutated in place across calls so escalation survives
+    between polls without any state living outside this loop.
+    """
+    now = time.monotonic_ns()
+    any_locked = False
+
+    # Escalations in flight take priority over freshly-discovered ones: a kill
+    # already staged should not be starved, poll after poll, by a steady trickle
+    # of newly-expired pages elsewhere in the pool.
+    for page in list(pending):
+        locked, pid = _getlk(fd, page)
+        if not locked:
+            del pending[page]  # worker exited on its own; nothing left to escalate
+            continue
+        any_locked = True
+        if now - pending[page] >= grace_ns:
+            _send(pid, signal.SIGKILL, 'grace period expired, still holding its page')
+            del pending[page]
+            return any_locked  # one signal per poll
+
+    for page in range(workers):
+        if page in pending:
+            continue
+        locked, pid = _getlk(fd, page)
+        if not locked:
+            continue
+        any_locked = True
+        deadline = _read_deadline(fd, page)
+        if deadline == 0:
+            continue  # between tests -- see plugin.py's pytest_runtest_protocol
+        if now > deadline:
+            running_s = (now - (deadline - threshold_ns)) / 1e9
+            _send(pid, signal.SIGTERM,
+                  f'running ~{running_s:.1f}s, past its ~{threshold_ns / 1e9:.0f}s budget')
+            pending[page] = now
+            return any_locked  # one signal per poll
+
+    return any_locked
+
+
+def watch(lockfile: str, workers: int, threshold_s: float, grace_s: float,
+         poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+         idle_polls: int = _DEFAULT_IDLE_POLLS) -> None:
+    """Poll `lockfile` until `idle_polls` consecutive sweeps find no page locked."""
+    threshold_ns = int(threshold_s * 1_000_000_000)
+    grace_ns = int(grace_s * 1_000_000_000)
+    pending: dict[int, int] = {}
+    idle = 0
+    # O_CREAT so the watchdog can be started before pytest ever touches the
+    # lock file -- run-test.sh starts it first specifically so a wedge that
+    # happens during collection would still be caught. plugin.py's own
+    # lockfile fixture is equally permissive for the mirror-image reason.
+    fd = os.open(lockfile, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        while idle < idle_polls:
+            if _poll_once(fd, workers, threshold_ns, grace_ns, pending):
+                idle = 0
+            else:
+                idle += 1
+            time.sleep(poll_interval_s)
+    finally:
+        os.close(fd)
+    print(f'pytest_gpu_lease.watchdog: no page locked for {idle_polls} consecutive polls, exiting',
+          file=sys.stderr, flush=True)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog='python -m pytest_gpu_lease.watchdog',
+        description='Escalate SIGTERM -> SIGKILL on a pytest_gpu_lease worker whose '
+                    'per-test deadline has passed.')
+    parser.add_argument('--lockfile', default=os.getenv('GPU_LEASE_LOCKFILE'),
+                        help='Shared lease lock file to watch. Defaults to $GPU_LEASE_LOCKFILE, '
+                             'the same variable run-test.sh exports for pytest itself.')
+    parser.add_argument('--workers', type=int, required=True,
+                        help='Size of the GPU pool (the -n given to pytest); pages '
+                             '0..workers-1 are watched.')
+    parser.add_argument('--threshold', type=float, default=float(_DEFAULT_BUDGET_S),
+                        help='Seconds a test may legitimately run (default %(default)s, '
+                             'see plugin.py). The actual cutoff is always the deadline the '
+                             'worker itself wrote using its own budget (GPU_LEASE_BUDGET_S) '
+                             '-- this value never gates that decision, it only sizes the '
+                             '"running ~Ns" figure in the log line, so keep the two in sync '
+                             'if you change one.')
+    parser.add_argument('--grace', type=float, default=_DEFAULT_GRACE_S,
+                        help='Seconds to wait after SIGTERM before re-checking the lock '
+                             'and escalating to SIGKILL if it is still held.')
+    parser.add_argument('--poll_interval', type=float, default=_DEFAULT_POLL_INTERVAL_S,
+                        help='Seconds between sweeps of the lock file.')
+    parser.add_argument('--idle_polls', type=int, default=_DEFAULT_IDLE_POLLS,
+                        help='Consecutive empty polls before exiting on its own, so a stray '
+                             'watchdog cannot outlive the run that started it.')
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if not args.lockfile:
+        parser.error('--lockfile is required (or set GPU_LEASE_LOCKFILE)')
+    watch(args.lockfile, args.workers, args.threshold, args.grace,
+         args.poll_interval, args.idle_polls)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -222,6 +222,16 @@ def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
             continue
         any_locked = True
         if now - staged.sent_ns >= grace_ns:
+            # A SIGTERMed worker is not doomed: faulthandler makes that signal
+            # a stack dump rather than a death, so a merely slow test can
+            # finish inside the grace period. Judge it again on the same rule
+            # that staged it -- 0 means it reached the gap between tests, a
+            # recent stamp means it started another one. Checking only the lock
+            # and the pid would SIGKILL a worker that had already recovered.
+            last_activity = _read_last_activity(fd, page)
+            if last_activity == 0 or now - last_activity <= threshold_ns:
+                _discard(pending, page)
+                continue
             # Through the pidfd, so this cannot land on anyone else. The lock
             # check above answers the policy question -- is it still wedged and
             # still leasing -- but not the identity one: between that F_GETLK

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -6,9 +6,16 @@
 Run beside pytest, not inside it: ``python -m pytest_gpu_lease.watchdog --lockfile
 ... --workers N``. It polls the lease lock file that ``plugin.py`` already
 maintains -- one 4096-byte page per GPU, write-locked by whichever worker owns
-that GPU for the run -- and reads the 8-byte deadline written there: an initial
-one set by ``gpu_id`` the moment it takes the lease, refreshed before every
-test and zeroed after by a ``pytest_runtest_protocol`` hookwrapper.
+that GPU for the run -- and reads the 8-byte ``time.monotonic_ns()`` stamp
+written there: an initial one set by ``gpu_id`` the moment it takes the lease,
+refreshed before every test and zeroed after by a ``pytest_runtest_protocol``
+hookwrapper. A zero means the worker is between tests and is skipped.
+
+**This module owns the timeout.** The worker reports only when it was last
+seen alive; ``--threshold`` here is the sole definition of how stale that may
+get, so there is no second copy of the policy to fall out of sync with, and
+changing the timeout means changing one command line rather than a command
+line and an environment variable that have to agree.
 
 Why the lock file is the right substrate, in one line: ``fcntl(F_GETLK)`` fills
 ``l_pid`` with the pid holding a byte range, and the kernel releases a record
@@ -27,7 +34,7 @@ gets SIGKILLed.
 
 Shares ``PAGE_SIZE`` and ``STRUCT_FLOCK`` with ``plugin.py`` by importing them
 rather than restating them, since a copy that drifts from the writer's layout
-would silently misread every deadline.
+would silently misread every stamp.
 """
 
 import argparse
@@ -38,11 +45,28 @@ import struct
 import sys
 import time
 
-from .plugin import PAGE_SIZE, STRUCT_FLOCK, _DEFAULT_BUDGET_S
+from .plugin import PAGE_SIZE, STRUCT_FLOCK
 
-# Default cadence: frequent enough that a 600s budget is caught within a small
-# fraction of itself, infrequent enough that polling 4-8 pages is noise next to
-# a 15-22h pass.
+# The timeout, and the only one in the tree: how long a worker's page may go
+# without a fresh stamp before it is treated as wedged. Because the worker
+# rewrites its stamp before every test, this is exactly one thing -- the
+# longest a single test may legitimately take. Not the suite length, not the
+# worker count.
+#
+# A real pass ran 265,282 tests in 227,112 worker-seconds, 0.86s/test mean, so
+# 600s is about the tail, not the average -- and the tail is plausibly the
+# torch reference materialising an 8192x8192 score matrix, not the kernel
+# under test, so sizing this off kernel cost alone would guess far too low.
+# The cost of being wrong is asymmetric: too high and a wedge idles a worker
+# for the excess (a handful of tests a pass); too low and a slow-but-passing
+# test is recorded as a crash, a restart is burned, and the scheduler goes
+# through the worker-teardown path again. Refine it with
+# `pytest --durations=50 --durations-min=10` on an idle GPU.
+_DEFAULT_THRESHOLD_S = 600
+
+# Default cadence: frequent enough that a 600s threshold is caught within a
+# small fraction of itself, infrequent enough that polling 4-8 pages is noise
+# next to a 15-22h pass.
 _DEFAULT_POLL_INTERVAL_S = 5.0
 
 # Default grace between SIGTERM and SIGKILL: long enough for faulthandler to
@@ -86,8 +110,9 @@ def _getlk(fd: int, page: int) -> tuple[bool, int]:
     return lock_type != fcntl.F_UNLCK, pid
 
 
-def _read_deadline(fd: int, page: int) -> int:
-    """The 8-byte deadline at `page`'s base, or 0 if never written / zeroed.
+def _read_last_activity(fd: int, page: int) -> int:
+    """The 8-byte `monotonic_ns()` stamp at `page`'s base, or 0 if the worker
+    is between tests (never written, or zeroed after the last one).
 
     A plain `os.pread` at a page-aligned offset -- no torn-read handling needed
     for the same reason the writer needs none: 8 bytes at an aligned offset is
@@ -157,13 +182,14 @@ def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
         if not locked:
             continue
         any_locked = True
-        deadline = _read_deadline(fd, page)
-        if deadline == 0:
+        last_activity = _read_last_activity(fd, page)
+        if last_activity == 0:
             continue  # between tests -- see plugin.py's gpu_id and pytest_runtest_protocol
-        if now > deadline:
-            running_s = (now - (deadline - threshold_ns)) / 1e9
+        stale_ns = now - last_activity
+        if stale_ns > threshold_ns:
             _send(pid, signal.SIGTERM,
-                  f'running ~{running_s:.1f}s, past its ~{threshold_ns / 1e9:.0f}s budget')
+                  f'no heartbeat for {stale_ns / 1e9:.1f}s, past the '
+                  f'{threshold_ns / 1e9:.0f}s threshold')
             pending[page] = now
             return any_locked  # one signal per poll
 
@@ -220,20 +246,18 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog='python -m pytest_gpu_lease.watchdog',
         description='Escalate SIGTERM -> SIGKILL on a pytest_gpu_lease worker whose '
-                    'per-test deadline has passed.')
+                    'page has gone unstamped for too long.')
     parser.add_argument('--lockfile', default=os.getenv('GPU_LEASE_LOCKFILE'),
                         help='Shared lease lock file to watch. Defaults to $GPU_LEASE_LOCKFILE, '
                              'the same variable run-test.sh exports for pytest itself.')
     parser.add_argument('--workers', type=int, required=True,
                         help='Size of the GPU pool (the -n given to pytest); pages '
                              '0..workers-1 are watched.')
-    parser.add_argument('--threshold', type=float, default=float(_DEFAULT_BUDGET_S),
-                        help='Seconds a test may legitimately run (default %(default)s, '
-                             'see plugin.py). The actual cutoff is always the deadline the '
-                             'worker itself wrote using its own budget (GPU_LEASE_BUDGET_S) '
-                             '-- this value never gates that decision, it only sizes the '
-                             '"running ~Ns" figure in the log line, so keep the two in sync '
-                             'if you change one.')
+    parser.add_argument('--threshold', type=float, default=float(_DEFAULT_THRESHOLD_S),
+                        help='Seconds a test may legitimately run before its worker is '
+                             'treated as wedged (default %(default)s). This is the timeout: '
+                             'workers only report when they were last alive, so nothing '
+                             'else in the system has an opinion about it.')
     parser.add_argument('--grace', type=float, default=_DEFAULT_GRACE_S,
                         help='Seconds to wait after SIGTERM before re-checking the lock '
                              'and escalating to SIGKILL if it is still held.')

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -58,6 +58,12 @@ from typing import NamedTuple
 
 from .plugin import PAGE_SIZE, STRUCT_FLOCK, dump_path
 
+# Every signal goes through a pidfd, so this is a hard requirement rather than
+# an enhancement -- see _pidfd_open. Linux 5.3 / Python 3.9, both far older
+# than anything that runs a ROCm GPU. No plan to support systems without it.
+assert hasattr(os, 'pidfd_open') and hasattr(signal, 'pidfd_send_signal'), (
+    'pytest_gpu_lease.watchdog requires pidfd support: Linux 5.3+ and Python 3.9+')
+
 # The timeout, and the only one in the tree: how long a worker's page may go
 # without a fresh stamp before it is treated as wedged. Because the worker
 # rewrites its stamp before every test, this is exactly one thing -- the
@@ -127,11 +133,11 @@ class _Staged(NamedTuple):
 
     pid: int
     sent_ns: int
-    pidfd: int | None  # None only where pidfd is unavailable; see _pidfd_open
+    pidfd: int
 
 
 def _pidfd_open(pid: int) -> int | None:
-    """A handle to *this* process, or None where that is not available.
+    """A handle to *this* process, or None if it is already gone.
 
     A pid is not a stable identity: the moment its process is reaped the
     number can be handed to somebody else, so every `os.kill(pid, ...)` is a
@@ -140,24 +146,36 @@ def _pidfd_open(pid: int) -> int | None:
     through it after that process dies raises ProcessLookupError rather than
     reaching whoever inherited the number.
 
-    None on a kernel older than 5.3 or an interpreter older than 3.9, where
-    callers fall back to `os.kill` and the race is merely narrow rather than
-    closed.
+    Required, not best-effort: falling back to `os.kill` would silently give
+    up that guarantee on the one path where the payload is SIGKILL. It needs
+    Linux 5.3 and Python 3.9, both far below anything that runs a ROCm GPU,
+    so the module refuses to load without it (see the assert above).
+
+    None also for an `l_pid` that is not a local pid at all -- F_GETLK reports
+    -1 for an open-file-description lock, and a lock held over NFS can report
+    a pid meaningless here. `os.pidfd_open` would raise EINVAL, and the
+    check has to happen before it because this is the first place a raw
+    `l_pid` is used for anything.
     """
+    if pid <= 0:
+        print(f'pytest_gpu_lease.watchdog: ignoring a page held by pid {pid}; '
+              f'l_pid is not a local pid (OFD lock, or a lock held over NFS)',
+              file=sys.stderr, flush=True)
+        return None
     try:
         return os.pidfd_open(pid)
-    except (AttributeError, OSError):
+    except ProcessLookupError:
         return None
 
 
 def _discard(pending: dict[int, _Staged], page: int) -> None:
     """Drop a staged escalation, closing its pidfd."""
     staged = pending.pop(page, None)
-    if staged is not None and staged.pidfd is not None:
+    if staged is not None:
         os.close(staged.pidfd)
 
 
-def _send(pid: int, sig: signal.Signals, reason: str, pidfd: int | None = None) -> None:
+def _send(pid: int, sig: signal.Signals, reason: str, pidfd: int) -> None:
     """Signal `pid`, tolerating a process that is already gone.
 
     The F_GETLK check immediately before every call site is the liveness proof
@@ -166,23 +184,11 @@ def _send(pid: int, sig: signal.Signals, reason: str, pidfd: int | None = None) 
     ProcessLookupError reports -- not a bug to guard against, just the same
     race resolving itself one step later.
 
-    `pid > 0` is checked because `l_pid` is not always a local pid: F_GETLK
-    reports -1 for an open-file-description lock, and a lock held over NFS can
-    report a pid that means nothing on this host. `os.kill` reads 0 as "the
-    whole process group" and -1 as "every process this uid may signal", so a
-    single unexpected `l_pid` would take out the pass, the shell that started
-    it, and everything else the user owns.
+    `pid` is only for the log line: the signal goes to `pidfd`, which
+    `_pidfd_open` has already vetted.
     """
-    if pid <= 0:
-        print(f'pytest_gpu_lease.watchdog: refusing to signal pid {pid} ({reason}); '
-              f'l_pid is not a local pid (OFD lock, or a lock held over NFS)',
-              file=sys.stderr, flush=True)
-        return
     try:
-        if pidfd is None:
-            os.kill(pid, sig)
-        else:
-            signal.pidfd_send_signal(pidfd, sig)
+        signal.pidfd_send_signal(pidfd, sig)
         print(f'pytest_gpu_lease.watchdog: sent {sig.name} to pid {pid} ({reason})',
               file=sys.stderr, flush=True)
     except ProcessLookupError:
@@ -315,10 +321,11 @@ def _poll_once(fd: int, lockfile: str, workers: int, threshold_ns: int, grace_ns
             # read sees either an unlocked page or a different holder -- so the
             # handle we are about to signal through is the process we measured.
             pidfd = _pidfd_open(pid)
+            if pidfd is None:
+                continue  # exited between the F_GETLK above and the open
             locked_now, pid_now = _getlk(fd, page)
             if not locked_now or pid_now != pid:
-                if pidfd is not None:
-                    os.close(pidfd)
+                os.close(pidfd)
                 continue
             _send(pid, signal.SIGTERM,
                   f'no heartbeat for {stale_ns / 1e9:.1f}s, past the '

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -29,6 +29,11 @@ through a pidfd (see ``_pidfd_open``), which names one specific process for as
 long as the fd is open. The two questions stay separate: the lock decides
 whether to signal, the pidfd decides who receives it.
 
+Stopping it is a plain ``kill``: SIGTERM (also SIGINT, SIGHUP) unwinds
+cleanly and removes the lock file on the way out. SIGKILL is the one case
+that cannot, and leaves the file behind. It never stops on its own -- see
+``watch``.
+
 Escalation is SIGTERM, a grace period, then SIGKILL if the page is still locked.
 ``plugin.py`` registers SIGTERM with ``faulthandler`` on every leasing worker, so
 the SIGTERM here is not a death sentence by itself -- it is a request for a
@@ -334,10 +339,17 @@ def _build_parser() -> argparse.ArgumentParser:
 def _exit_on_signal(signum, _frame):
     """Turn a termination signal into a normal unwind.
 
-    SIGTERM and SIGHUP would otherwise kill the process outright, skipping the
-    `finally` in `main` that removes the lock file. SIGINT already unwinds, and
-    is handled here only so all three exit the same way.
+    A plain `kill` -- SIGTERM -- is how this service is meant to be stopped,
+    and with no handler it would kill the process outright, skipping the
+    `finally` in `main` that removes the lock file. SIGHUP is the same story.
+    SIGINT already unwinds and is handled only so all three behave alike.
+
+    The signal is named in the log because this now shares a file with
+    pytest's stderr, where "stopped" alone does not distinguish a shutdown
+    from a crash.
     """
+    print(f'pytest_gpu_lease.watchdog: caught {signal.Signals(signum).name}',
+          file=sys.stderr, flush=True)
     raise SystemExit(128 + signum)
 
 

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -80,25 +80,6 @@ _DEFAULT_POLL_INTERVAL_S = 5.0
 # that a genuinely wedged worker is not left idle for long after being caught.
 _DEFAULT_GRACE_S = 30.0
 
-# Consecutive empty polls (no page locked at all) *after having seen at least
-# one page locked* before the watchdog exits on its own. This is the fallback
-# for the case run-test.sh itself cannot reach its own trap -- e.g. it is
-# killed with SIGKILL, which a trap cannot catch -- so a watchdog started for
-# one run does not outlive it and go on signalling pids that by then belong to
-# somebody else. At the default poll interval this is one minute of a
-# completely idle lock file, counted only once the run has actually gone idle
-# -- i.e. its last worker released its page -- not before the run has started.
-# The "at least one" qualifier is load bearing, not a nicety: run-test.sh
-# starts the watchdog before pytest even begins collecting, specifically so a
-# wedge during collection is covered too, and a Level-3 pass's collection
-# (~330k tests, a conftest that imports torch) takes minutes -- far longer
-# than idle_polls * poll_interval at the defaults. A watchdog that started
-# counting immediately would exit on its own well before the first worker ever
-# takes a lease, and every wedge for the following ~22h would go uncaught,
-# silently: the "no page locked ... exiting" line looks identical whether it
-# fires because the run is genuinely over or because it never got a chance to
-# start watching.
-_DEFAULT_IDLE_POLLS = 12
 
 
 def _getlk(fd: int, page: int) -> tuple[bool, int]:
@@ -206,8 +187,8 @@ def _send(pid: int, sig: signal.Signals, reason: str, pidfd: int | None = None) 
 def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
               pending: dict[int, _Staged]) -> bool:
     """One sweep of every page. Sends at most one signal -- see module docstring
-    on staggering kills -- and returns whether any page is currently locked, for
-    the caller's idle/self-exit counter.
+    on staggering kills -- and returns whether any page is currently locked
+    (unused by `watch`, which never stops; the tests assert on it).
 
     `pending` maps a page already SIGTERMed to the `_Staged` record for that
     kill, and is mutated in place across calls so escalation survives between
@@ -280,51 +261,46 @@ def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
 
 
 def watch(lockfile: str, workers: int, threshold_s: float, grace_s: float,
-         poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
-         idle_polls: int = _DEFAULT_IDLE_POLLS) -> None:
-    """Poll `lockfile` until `idle_polls` consecutive sweeps find no page locked
-    -- but only start that countdown once a page has actually been seen locked
-    at least once.
+         poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S) -> None:
+    """Poll `lockfile` forever. Returns only when signalled.
 
-    Before that first sighting, `idle` still increments every empty poll (there
-    is no reason not to track it), but the loop condition ignores it: a
-    watchdog that has never seen a worker take a lease is not stray, it is
-    early -- started deliberately ahead of pytest itself, including ahead of
-    collection, which for a large suite can run for minutes. Counting idle
-    polls from process start would let the watchdog exit on its own before
-    collection even finished, and every wedge for the rest of that run would
-    then go uncaught. See `_DEFAULT_IDLE_POLLS` for the numbers this matters
-    most for.
+    Deliberately has no idea whether a pass is running, finishing, or finished:
+    it watches a file, and whoever started it decides when that stops being
+    useful (`run-test.sh` does, in a trap). Every rule for inferring "the run
+    is over" from the file itself is a guess, and a wrong guess is expensive
+    and silent -- the watchdog exits, `main` unlinks the lock file, and the
+    rest of a 22h pass runs unprotected with no line in any log saying so.
 
-    Once armed, a worker's page stays locked for the whole of that worker's
-    session, so in steady state the idle countdown only ever starts once every
-    worker has finished and released its page -- i.e. once the run is actually
-    over -- which is the behaviour this fallback exists for in the first place.
+    An earlier revision guessed from consecutive polls with no page locked.
+    That is not the same question: a worker this watchdog just killed is
+    replaced, and the replacement holds no lease until it has re-imported torch
+    and re-collected -- minutes, with the whole pool in that state at once
+    after a multi-worker wedge. The first threshold was 60s and fired during
+    exactly that; raising it only moved the guess.
+
+    The cost of never stopping is an orphan if the starting shell is SIGKILLed
+    and its trap never runs. That orphan is inert: `fd` is opened once here, so
+    once the file is unlinked it polls a deleted inode, and a later run gets a
+    new path and a new inode it can never see. No locks observed means no
+    pidfds opened and nothing signalled. It shows up in `ps`, and its lock file
+    is left behind in /dev/shm.
     """
     threshold_ns = int(threshold_s * 1_000_000_000)
     grace_ns = int(grace_s * 1_000_000_000)
     pending: dict[int, _Staged] = {}
-    idle = 0
-    armed = False
     # O_CREAT so the watchdog can be started before pytest ever touches the
-    # lock file -- run-test.sh starts it first specifically so a wedge that
-    # happens during collection would still be caught. plugin.py's own
-    # lockfile fixture is equally permissive for the mirror-image reason.
+    # lock file: run-test.sh starts it first so that it is already watching by
+    # the time the first worker takes a lease. plugin.py's own lockfile fixture
+    # is equally permissive for the mirror-image reason.
     fd = os.open(lockfile, os.O_RDWR | os.O_CREAT, 0o644)
     try:
-        while not armed or idle < idle_polls:
-            if _poll_once(fd, workers, threshold_ns, grace_ns, pending):
-                armed = True
-                idle = 0
-            else:
-                idle += 1
+        while True:
+            _poll_once(fd, workers, threshold_ns, grace_ns, pending)
             time.sleep(poll_interval_s)
     finally:
         for page in list(pending):
             _discard(pending, page)  # close any pidfd still staged
         os.close(fd)
-    print(f'pytest_gpu_lease.watchdog: no page locked for {idle_polls} consecutive polls, exiting',
-          file=sys.stderr, flush=True)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -348,9 +324,6 @@ def _build_parser() -> argparse.ArgumentParser:
                              'and escalating to SIGKILL if it is still held.')
     parser.add_argument('--poll_interval', type=float, default=_DEFAULT_POLL_INTERVAL_S,
                         help='Seconds between sweeps of the lock file.')
-    parser.add_argument('--idle_polls', type=int, default=_DEFAULT_IDLE_POLLS,
-                        help='Consecutive empty polls before exiting on its own, so a stray '
-                             'watchdog cannot outlive the run that started it.')
     return parser
 
 
@@ -373,22 +346,22 @@ def main(argv: list[str] | None = None) -> None:
         signal.signal(sig, _exit_on_signal)
     try:
         watch(args.lockfile, args.workers, args.threshold, args.grace,
-             args.poll_interval, args.idle_polls)
+             args.poll_interval)
     finally:
         # The watchdog owns the lock file, so whoever started it needs no
         # cleanup of its own -- which matters because an untrapped SIGTERM or
-        # SIGHUP skips a starting script's EXIT trap entirely (measured), and
-        # a SIGKILL cannot be trapped at all. In that last case nobody signals
-        # us either, and the idle self-exit above is what eventually gets here.
+        # SIGHUP skips a starting script's EXIT trap entirely (measured).
+        # SIGKILL is the gap: nothing runs here, and the file is left behind.
         #
-        # Only reached with no page locked (idle exit) or on our way out, so
-        # this cannot pull the file out from under a running pass. Note it is
-        # deliberately not in `watch()`: that stays a pure poll loop, callable
-        # from tests against a file they own.
+        # `watch()` never returns on its own, so reaching this means we were
+        # told to stop and the pass is over -- the file cannot be pulled out
+        # from under a running one. Deliberately not inside `watch()`, which
+        # stays a pure poll loop callable from tests against a file they own.
         try:
             os.unlink(args.lockfile)
         except FileNotFoundError:
             pass
+        print('pytest_gpu_lease.watchdog: stopped', file=sys.stderr, flush=True)
 
 
 if __name__ == '__main__':

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -19,11 +19,15 @@ line and an environment variable that have to agree.
 
 Why the lock file is the right substrate, in one line: ``fcntl(F_GETLK)`` fills
 ``l_pid`` with the pid holding a byte range, and the kernel releases a record
-lock automatically when its owner dies. So this module never remembers a pid --
-it asks the kernel again immediately before every signal. A worker that already
-died on its own between one poll and the next is simply unlocked by the time we
-look, and gets nothing sent to it: pid reuse is not a hazard here, because a
-dead process holds no lock to be mistaken for a live one.
+lock automatically when its owner dies. So the lock answers "does this still
+need killing?" on its own: a worker that died between one poll and the next is
+simply unlocked by the time we look, and gets nothing sent to it.
+
+It does not answer "who is this?", and pids are not stable identities -- once a
+process is reaped its number can be reissued. Every signal therefore goes
+through a pidfd (see ``_pidfd_open``), which names one specific process for as
+long as the fd is open. The two questions stay separate: the lock decides
+whether to signal, the pidfd decides who receives it.
 
 Escalation is SIGTERM, a grace period, then SIGKILL if the page is still locked.
 ``plugin.py`` registers SIGTERM with ``faulthandler`` on every leasing worker, so
@@ -44,6 +48,7 @@ import signal
 import struct
 import sys
 import time
+from typing import NamedTuple
 
 from .plugin import PAGE_SIZE, STRUCT_FLOCK
 
@@ -130,7 +135,42 @@ def _read_last_activity(fd: int, page: int) -> int:
     return struct.unpack('<Q', raw)[0]
 
 
-def _send(pid: int, sig: signal.Signals, reason: str) -> None:
+class _Staged(NamedTuple):
+    """A page whose holder has been SIGTERMed and may still need SIGKILL."""
+
+    pid: int
+    sent_ns: int
+    pidfd: int | None  # None only where pidfd is unavailable; see _pidfd_open
+
+
+def _pidfd_open(pid: int) -> int | None:
+    """A handle to *this* process, or None where that is not available.
+
+    A pid is not a stable identity: the moment its process is reaped the
+    number can be handed to somebody else, so every `os.kill(pid, ...)` is a
+    bet that nothing has changed since whatever check justified it. A pidfd
+    refers to one specific process for as long as the fd is open -- signalling
+    through it after that process dies raises ProcessLookupError rather than
+    reaching whoever inherited the number.
+
+    None on a kernel older than 5.3 or an interpreter older than 3.9, where
+    callers fall back to `os.kill` and the race is merely narrow rather than
+    closed.
+    """
+    try:
+        return os.pidfd_open(pid)
+    except (AttributeError, OSError):
+        return None
+
+
+def _discard(pending: dict[int, _Staged], page: int) -> None:
+    """Drop a staged escalation, closing its pidfd."""
+    staged = pending.pop(page, None)
+    if staged is not None and staged.pidfd is not None:
+        os.close(staged.pidfd)
+
+
+def _send(pid: int, sig: signal.Signals, reason: str, pidfd: int | None = None) -> None:
     """Signal `pid`, tolerating a process that is already gone.
 
     The F_GETLK check immediately before every call site is the liveness proof
@@ -152,7 +192,10 @@ def _send(pid: int, sig: signal.Signals, reason: str) -> None:
               file=sys.stderr, flush=True)
         return
     try:
-        os.kill(pid, sig)
+        if pidfd is None:
+            os.kill(pid, sig)
+        else:
+            signal.pidfd_send_signal(pidfd, sig)
         print(f'pytest_gpu_lease.watchdog: sent {sig.name} to pid {pid} ({reason})',
               file=sys.stderr, flush=True)
     except ProcessLookupError:
@@ -161,14 +204,14 @@ def _send(pid: int, sig: signal.Signals, reason: str) -> None:
 
 
 def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
-              pending: dict[int, int]) -> bool:
+              pending: dict[int, _Staged]) -> bool:
     """One sweep of every page. Sends at most one signal -- see module docstring
     on staggering kills -- and returns whether any page is currently locked, for
     the caller's idle/self-exit counter.
 
-    `pending` maps a page already SIGTERMed to the `monotonic_ns()` that signal
-    went out, and is mutated in place across calls so escalation survives
-    between polls without any state living outside this loop.
+    `pending` maps a page already SIGTERMed to the `_Staged` record for that
+    kill, and is mutated in place across calls so escalation survives between
+    polls without any state living outside this loop.
     """
     now = time.monotonic_ns()
     any_locked = False
@@ -177,14 +220,31 @@ def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
     # already staged should not be starved, poll after poll, by a steady trickle
     # of newly-expired pages elsewhere in the pool.
     for page in list(pending):
+        staged = pending[page]
         locked, pid = _getlk(fd, page)
-        if not locked:
-            del pending[page]  # worker exited on its own; nothing left to escalate
+        # "Still locked" is not enough to escalate: the page has to still be
+        # held by the *same* process. A SIGTERMed worker that dies anyway (the
+        # HIP runtime aborting on a fault is the common way) is replaced by
+        # xdist, and the replacement takes the lowest free page -- very often
+        # the one just vacated -- well inside a 30s grace period. Escalating on
+        # the page alone would SIGKILL that healthy replacement, then drop the
+        # entry and be free to do it again. Dropping the entry here instead
+        # hands the page back to the heartbeat scan below, where a replacement
+        # is judged on its own stamp like any other worker.
+        if not locked or pid != staged.pid:
+            _discard(pending, page)
             continue
         any_locked = True
-        if now - pending[page] >= grace_ns:
-            _send(pid, signal.SIGKILL, 'grace period expired, still holding its page')
-            del pending[page]
+        if now - staged.sent_ns >= grace_ns:
+            # Through the pidfd, so this cannot land on anyone else. The lock
+            # check above answers the policy question -- is it still wedged and
+            # still leasing -- but not the identity one: between that F_GETLK
+            # and this call the process may exit and its pid be reissued. That
+            # window is small and the payload is SIGKILL, which is precisely
+            # the combination not to leave to chance.
+            _send(staged.pid, signal.SIGKILL,
+                  'grace period expired, still holding its page', staged.pidfd)
+            _discard(pending, page)
             return any_locked  # one signal per poll
 
     for page in range(workers):
@@ -199,10 +259,21 @@ def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
             continue  # between tests -- see plugin.py's gpu_id and pytest_runtest_protocol
         stale_ns = now - last_activity
         if stale_ns > threshold_ns:
+            # Take the handle first, then re-read the lock. If the pid was
+            # reissued between the F_GETLK above and the pidfd_open, the
+            # original holder is dead, its lock is released, and this second
+            # read sees either an unlocked page or a different holder -- so the
+            # handle we are about to signal through is the process we measured.
+            pidfd = _pidfd_open(pid)
+            locked_now, pid_now = _getlk(fd, page)
+            if not locked_now or pid_now != pid:
+                if pidfd is not None:
+                    os.close(pidfd)
+                continue
             _send(pid, signal.SIGTERM,
                   f'no heartbeat for {stale_ns / 1e9:.1f}s, past the '
-                  f'{threshold_ns / 1e9:.0f}s threshold')
-            pending[page] = now
+                  f'{threshold_ns / 1e9:.0f}s threshold', pidfd)
+            pending[page] = _Staged(pid, now, pidfd)
             return any_locked  # one signal per poll
 
     return any_locked
@@ -232,7 +303,7 @@ def watch(lockfile: str, workers: int, threshold_s: float, grace_s: float,
     """
     threshold_ns = int(threshold_s * 1_000_000_000)
     grace_ns = int(grace_s * 1_000_000_000)
-    pending: dict[int, int] = {}
+    pending: dict[int, _Staged] = {}
     idle = 0
     armed = False
     # O_CREAT so the watchdog can be started before pytest ever touches the
@@ -249,6 +320,8 @@ def watch(lockfile: str, workers: int, threshold_s: float, grace_s: float,
                 idle += 1
             time.sleep(poll_interval_s)
     finally:
+        for page in list(pending):
+            _discard(pending, page)  # close any pidfd still staged
         os.close(fd)
     print(f'pytest_gpu_lease.watchdog: no page locked for {idle_polls} consecutive polls, exiting',
           file=sys.stderr, flush=True)

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -138,7 +138,19 @@ def _send(pid: int, sig: signal.Signals, reason: str) -> None:
     interval between that check and this call, which is exactly what
     ProcessLookupError reports -- not a bug to guard against, just the same
     race resolving itself one step later.
+
+    `pid > 0` is checked because `l_pid` is not always a local pid: F_GETLK
+    reports -1 for an open-file-description lock, and a lock held over NFS can
+    report a pid that means nothing on this host. `os.kill` reads 0 as "the
+    whole process group" and -1 as "every process this uid may signal", so a
+    single unexpected `l_pid` would take out the pass, the shell that started
+    it, and everything else the user owns.
     """
+    if pid <= 0:
+        print(f'pytest_gpu_lease.watchdog: refusing to signal pid {pid} ({reason}); '
+              f'l_pid is not a local pid (OFD lock, or a lock held over NFS)',
+              file=sys.stderr, flush=True)
+        return
     try:
         os.kill(pid, sig)
         print(f'pytest_gpu_lease.watchdog: sent {sig.name} to pid {pid} ({reason})',

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -48,6 +48,7 @@ would silently misread every stamp.
 
 import argparse
 import fcntl
+import glob
 import os
 import signal
 import struct
@@ -55,7 +56,7 @@ import sys
 import time
 from typing import NamedTuple
 
-from .plugin import PAGE_SIZE, STRUCT_FLOCK
+from .plugin import PAGE_SIZE, STRUCT_FLOCK, dump_path
 
 # The timeout, and the only one in the tree: how long a worker's page may go
 # without a fresh stamp before it is treated as wedged. Because the worker
@@ -189,7 +190,59 @@ def _send(pid: int, sig: signal.Signals, reason: str, pidfd: int | None = None) 
               file=sys.stderr, flush=True)
 
 
-def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
+def _emit_dump(lockfile: str, page: int, pid: int) -> None:
+    """Relay a wedged worker's stack dump into our stderr, then delete it.
+
+    The worker writes it to a file of its own rather than the shared stream
+    (see `plugin.dump_path`); this process is the serialisation point. Deleted
+    as soon as it is read: the owner is about to be SIGKILLed and will never
+    reach the teardown that would otherwise remove it.
+    """
+    path = dump_path(lockfile, pid)
+    try:
+        with open(path) as f:
+            dump = f.read().rstrip()
+    except OSError:
+        dump = ''
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+    if dump:
+        print(f'--- pytest_gpu_lease.watchdog: stack of pid {pid} on GPU {page} ---\n'
+              f'{dump}\n--- end of stack ---', file=sys.stderr, flush=True)
+
+
+def _sweep_dumps(lockfile: str) -> None:
+    """Delete dump files whose worker is gone.
+
+    A worker killed by a GPU fault reaches no teardown, so it never removes
+    its own file, and the watchdog will never see its pid again -- F_GETLK
+    reports live lock holders and nothing else. Sweeping every poll rather
+    than at shutdown keeps /dev/shm, which is small in a container, from
+    collecting one file per dead worker across a pass that restarts them
+    dozens of times.
+    """
+    prefix, suffix = f'{lockfile}.', '.dump'
+    for path in glob.glob(glob.escape(lockfile) + '.*' + suffix):
+        try:
+            pid = int(path[len(prefix):-len(suffix)])
+        except ValueError:
+            continue  # not one of ours
+        try:
+            os.kill(pid, 0)
+            continue  # still alive: its dump is still wanted
+        except PermissionError:
+            continue  # alive, just not ours to signal
+        except ProcessLookupError:
+            pass
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
+def _poll_once(fd: int, lockfile: str, workers: int, threshold_ns: int, grace_ns: int,
               pending: dict[int, _Staged]) -> bool:
     """One sweep of every page. Sends at most one signal -- see module docstring
     on staggering kills -- and returns whether any page is currently locked
@@ -201,6 +254,7 @@ def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
     """
     now = time.monotonic_ns()
     any_locked = False
+    _sweep_dumps(lockfile)
 
     # Escalations in flight take priority over freshly-discovered ones: a kill
     # already staged should not be starved, poll after poll, by a steady trickle
@@ -238,6 +292,9 @@ def _poll_once(fd: int, workers: int, threshold_ns: int, grace_ns: int,
             # and this call the process may exit and its pid be reissued. That
             # window is small and the payload is SIGKILL, which is precisely
             # the combination not to leave to chance.
+            # Before the kill: the SIGTERM's whole point was this dump, and
+            # after SIGKILL nobody is left to ask.
+            _emit_dump(lockfile, page, staged.pid)
             _send(staged.pid, signal.SIGKILL,
                   'grace period expired, still holding its page', staged.pidfd)
             _discard(pending, page)
@@ -310,7 +367,7 @@ def watch(lockfile: str, workers: int, threshold_s: float, grace_s: float,
     fd = os.open(lockfile, os.O_RDWR | os.O_CREAT, 0o644)
     try:
         while True:
-            _poll_once(fd, workers, threshold_ns, grace_ns, pending)
+            _poll_once(fd, lockfile, workers, threshold_ns, grace_ns, pending)
             time.sleep(poll_interval_s)
     finally:
         for page in list(pending):
@@ -381,10 +438,14 @@ def main(argv: list[str] | None = None) -> None:
         # told to stop and the pass is over -- the file cannot be pulled out
         # from under a running one. Deliberately not inside `watch()`, which
         # stays a pure poll loop callable from tests against a file they own.
-        try:
-            os.unlink(args.lockfile)
-        except FileNotFoundError:
-            pass
+        # Sweep, not enumerate: a worker aborted by a GPU fault reaches no
+        # teardown, so its dump can outlive it with nobody else to notice.
+        for _path in [args.lockfile,
+                      *glob.glob(glob.escape(args.lockfile) + '.*.dump')]:
+            try:
+                os.unlink(_path)
+            except FileNotFoundError:
+                pass
         print('pytest_gpu_lease.watchdog: stopped', file=sys.stderr, flush=True)
 
 

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -269,13 +269,41 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _exit_on_signal(signum, _frame):
+    """Turn a termination signal into a normal unwind.
+
+    SIGTERM and SIGHUP would otherwise kill the process outright, skipping the
+    `finally` in `main` that removes the lock file. SIGINT already unwinds, and
+    is handled here only so all three exit the same way.
+    """
+    raise SystemExit(128 + signum)
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
     if not args.lockfile:
         parser.error('--lockfile is required (or set GPU_LEASE_LOCKFILE)')
-    watch(args.lockfile, args.workers, args.threshold, args.grace,
-         args.poll_interval, args.idle_polls)
+    for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        signal.signal(sig, _exit_on_signal)
+    try:
+        watch(args.lockfile, args.workers, args.threshold, args.grace,
+             args.poll_interval, args.idle_polls)
+    finally:
+        # The watchdog owns the lock file, so whoever started it needs no
+        # cleanup of its own -- which matters because an untrapped SIGTERM or
+        # SIGHUP skips a starting script's EXIT trap entirely (measured), and
+        # a SIGKILL cannot be trapped at all. In that last case nobody signals
+        # us either, and the idle self-exit above is what eventually gets here.
+        #
+        # Only reached with no page locked (idle exit) or on our way out, so
+        # this cannot pull the file out from under a running pass. Note it is
+        # deliberately not in `watch()`: that stays a pure poll loop, callable
+        # from tests against a file they own.
+        try:
+            os.unlink(args.lockfile)
+        except FileNotFoundError:
+            pass
 
 
 if __name__ == '__main__':

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -59,8 +59,13 @@ from typing import NamedTuple
 from .plugin import PAGE_SIZE, STRUCT_FLOCK, dump_path
 
 # Every signal goes through a pidfd, so this is a hard requirement rather than
-# an enhancement -- see _pidfd_open. Linux 5.3 / Python 3.9, both far older
-# than anything that runs a ROCm GPU. No plan to support systems without it.
+# an enhancement -- see _pidfd_open. Needs Linux 5.3 and Python 3.9.
+#
+# That is a statement about this harness, not about ROCm: ROCm still supports
+# AlmaLinux 8, whose kernel predates pidfd_open. This is Level-3 CI tooling,
+# deployed on Ubuntu 22.04 or later (5.15, Python 3.10), where the requirement
+# costs nothing. A suite that has to run on something older should not be
+# using this module.
 assert hasattr(os, 'pidfd_open') and hasattr(signal, 'pidfd_send_signal'), (
     'pytest_gpu_lease.watchdog requires pidfd support: Linux 5.3+ and Python 3.9+')
 
@@ -147,9 +152,9 @@ def _pidfd_open(pid: int) -> int | None:
     reaching whoever inherited the number.
 
     Required, not best-effort: falling back to `os.kill` would silently give
-    up that guarantee on the one path where the payload is SIGKILL. It needs
-    Linux 5.3 and Python 3.9, both far below anything that runs a ROCm GPU,
-    so the module refuses to load without it (see the assert above).
+    up that guarantee on the one path where the payload is SIGKILL. The module
+    refuses to load without it; the assert at the top of this file records
+    which systems that rules out and why they are out of scope here.
 
     None also for an `l_pid` that is not a local pid at all -- F_GETLK reports
     -1 for an open-file-description lock, and a lock held over NFS can report

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -56,7 +56,8 @@ import sys
 import time
 from typing import NamedTuple
 
-from .plugin import PAGE_SIZE, STRUCT_FLOCK, dump_path
+from .plugin import (HEARTBEAT_FMT, HEARTBEAT_SIZE, OWNER_FMT, OWNER_OFFSET,
+                     PAGE_SIZE, STRUCT_FLOCK, dump_path)
 
 # Every signal goes through a pidfd, so this is a hard requirement rather than
 # an enhancement -- see _pidfd_open. Needs Linux 5.3 and Python 3.9.
@@ -129,24 +130,25 @@ def _getlk(fd: int, page: int) -> tuple[bool, int]:
     return lock_type != fcntl.F_UNLCK, pid
 
 
-def _read_last_activity(fd: int, page: int) -> int:
-    """The 8-byte `monotonic_ns()` stamp at `page`'s base, or 0 if the worker
-    is between tests (never written, or zeroed after the last one).
+def _read_heartbeat(fd: int, page: int) -> tuple[int, int]:
+    """The stamp at `page`'s base and the pid of the worker that wrote it.
 
-    A plain `os.pread` at a page-aligned offset -- no torn-read handling needed
-    for the same reason the writer needs none: 8 bytes at an aligned offset is
-    within the platform's atomic write granularity.
+    `(0, 0)` when the record is not fully there. The lock file is never
+    pre-sized (see plugin.py's `_gpu_lease_lockfile`), so a page whose worker
+    holds the lock but has not written yet is genuinely short of these bytes
+    rather than zero-filled, and `os.pread` returns what exists. Treated the
+    same as an explicit zero: nothing has expired.
 
-    The lock file is never pre-sized (see plugin.py's `_gpu_lease_lockfile`), so
-    a page whose worker took the lease but has not yet reached its first test's
-    heartbeat write is genuinely short of 8 bytes there, not zero-filled -- a
-    plain `os.pread` returns fewer than 8 bytes rather than padding with
-    zeroes. Treated the same as an explicit zero: nothing has expired yet.
+    No torn-read handling, for the same reason the writer needs none -- see
+    the layout note in plugin.py for why stamp-then-pid ordering makes a
+    half-written pair safe to read.
     """
-    raw = os.pread(fd, 8, PAGE_SIZE * page)
-    if len(raw) < 8:
-        return 0
-    return struct.unpack('<Q', raw)[0]
+    raw = os.pread(fd, HEARTBEAT_SIZE, PAGE_SIZE * page)
+    if len(raw) < HEARTBEAT_SIZE:
+        return 0, 0
+    stamp, = struct.unpack_from(HEARTBEAT_FMT, raw, 0)
+    owner, = struct.unpack_from(OWNER_FMT, raw, OWNER_OFFSET)
+    return stamp, owner
 
 
 class _Staged(NamedTuple):
@@ -350,9 +352,15 @@ def _poll_once(fd: int, lockfile: str, workers: int, threshold_ns: int, grace_ns
         if not locked:
             continue
         any_locked = True
-        last_activity = _read_last_activity(fd, page)
+        last_activity, owner = _read_heartbeat(fd, page)
         if last_activity == 0:
             continue  # between tests -- see plugin.py's gpu_id and pytest_runtest_protocol
+        if owner != pid:
+            # The stamp belongs to a previous holder: this worker has the lock
+            # but has not written yet. Judging it on someone else's stamp is
+            # how a replacement gets killed for inheriting the expired one left
+            # by the worker this watchdog had just SIGKILLed off that page.
+            continue
         stale_ns = now - last_activity
         if stale_ns > threshold_ns:
             # Take the handle first, then re-read the lock. If the pid was

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -35,11 +35,11 @@ that cannot, and leaves the file behind. It never stops on its own -- see
 ``watch``.
 
 Escalation is SIGTERM, a grace period, then SIGKILL if the page is still locked.
-``plugin.py`` registers SIGTERM with ``faulthandler`` on every leasing worker, so
-the SIGTERM here is not a death sentence by itself -- it is a request for a
-stack dump, C-level and GIL-free, naming whatever frame the wedge is in. Only a
-worker that ignores that and is still holding its page after ``--grace`` seconds
-gets SIGKILLed.
+SIGTERM is expected to end the worker: ``plugin.py`` registers it with
+``faulthandler`` using ``chain=True``, so it dumps a stack -- C-level and
+GIL-free, naming whatever frame the wedge is in -- and then terminates as it
+normally would. SIGKILL is the last resort, for a process SIGTERM could not
+end, such as one stuck in an uninterruptible driver call.
 
 Shares ``PAGE_SIZE`` and ``STRUCT_FLOCK`` with ``plugin.py`` by importing them
 rather than restating them, since a copy that drifts from the writer's layout
@@ -313,8 +313,8 @@ def _poll_once(fd: int, lockfile: str, workers: int, threshold_ns: int, grace_ns
         # hands the page back to the heartbeat scan below, where a replacement
         # is judged on its own stamp like any other worker.
         if not locked or pid != staged.pid:
-            # It died inside the grace period, which by the comment above is
-            # the usual way a SIGTERMed worker goes. Relay its dump anyway:
+            # It died inside the grace period -- normally because the SIGTERM
+            # did its job. Relay its dump before the entry goes:
             # producing that was the entire point of the SIGTERM, and letting
             # this path discard silently threw it away in the common case.
             _emit_dump(lockfile, page, staged.pid)
@@ -324,12 +324,11 @@ def _poll_once(fd: int, lockfile: str, workers: int, threshold_ns: int, grace_ns
             continue
         any_locked = True
         if now - staged.sent_ns >= grace_ns:
-            # No reprieve for a page that came back to life inside the grace
-            # period. A worker past the threshold is a dead worker: the grace
-            # exists for faulthandler to finish its dump, not as a window in
-            # which to be pardoned. The test that ran long enough to be
-            # signalled has already failed, and sparing its worker would make
-            # the pass depend on how close to the threshold it landed.
+            # Reaching here means SIGTERM did not end it, which normally it
+            # does. No reprieve for a page that came back to life meanwhile: a
+            # worker past the threshold is a dead worker, and the test that ran
+            # long enough to be signalled has already failed. Sparing it would
+            # make the pass depend on how close to the threshold it landed.
             #
             # Dump first: producing it was the whole point of the SIGTERM, and
             # after the SIGKILL nobody is left to ask.

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -240,7 +240,7 @@ def _emit_dump(lockfile: str, page: int, pid: int) -> None:
               f'{dump}\n--- end of stack ---', file=sys.stderr, flush=True)
 
 
-def _sweep_dumps(lockfile: str) -> None:
+def _sweep_dumps(lockfile: str, keep: set[int]) -> None:
     """Delete dump files whose worker is gone.
 
     A worker killed by a GPU fault reaches no teardown, so it never removes
@@ -256,6 +256,10 @@ def _sweep_dumps(lockfile: str) -> None:
             pid = int(path[len(prefix):-len(suffix)])
         except ValueError:
             continue  # not one of ours
+        if pid in keep:
+            # Staged for escalation. Its owner dying is precisely when the
+            # dump becomes worth reading, so it must outlive the process.
+            continue
         try:
             os.kill(pid, 0)
             continue  # still alive: its dump is still wanted
@@ -281,7 +285,7 @@ def _poll_once(fd: int, lockfile: str, workers: int, threshold_ns: int, grace_ns
     """
     now = time.monotonic_ns()
     any_locked = False
-    _sweep_dumps(lockfile)
+    _sweep_dumps(lockfile, {staged.pid for staged in pending.values()})
 
     # Escalations in flight take priority over freshly-discovered ones: a kill
     # already staged should not be starved, poll after poll, by a steady trickle
@@ -299,6 +303,13 @@ def _poll_once(fd: int, lockfile: str, workers: int, threshold_ns: int, grace_ns
         # hands the page back to the heartbeat scan below, where a replacement
         # is judged on its own stamp like any other worker.
         if not locked or pid != staged.pid:
+            # It died inside the grace period, which by the comment above is
+            # the usual way a SIGTERMed worker goes. Relay its dump anyway:
+            # producing that was the entire point of the SIGTERM, and letting
+            # this path discard silently threw it away in the common case.
+            _emit_dump(lockfile, page, staged.pid)
+            print(f'pytest_gpu_lease.watchdog: pid {staged.pid} exited during its '
+                  f'grace period; no SIGKILL needed', file=sys.stderr, flush=True)
             _discard(pending, page)
             continue
         any_locked = True

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -66,8 +66,24 @@ from .plugin import PAGE_SIZE, STRUCT_FLOCK, dump_path
 # deployed on Ubuntu 22.04 or later (5.15, Python 3.10), where the requirement
 # costs nothing. A suite that has to run on something older should not be
 # using this module.
-assert hasattr(os, 'pidfd_open') and hasattr(signal, 'pidfd_send_signal'), (
-    'pytest_gpu_lease.watchdog requires pidfd support: Linux 5.3+ and Python 3.9+')
+def _pidfd_supported() -> bool:
+    """Whether pidfd actually works here, by using it rather than asking.
+
+    `hasattr(os, 'pidfd_open')` is not the question: Python 3.9+ on a 4.18
+    kernel has the function and fails at the syscall, which would surface as a
+    crash mid-pass instead of a refusal at import. run-test.sh probes the same
+    way before deciding whether to start a watchdog at all.
+    """
+    try:
+        os.close(os.pidfd_open(os.getpid()))
+        return True
+    except (AttributeError, OSError):
+        return False
+
+
+assert _pidfd_supported(), (
+    'pytest_gpu_lease.watchdog requires working pidfd support: Linux 5.3+ and '
+    'Python 3.9+')
 
 # The timeout, and the only one in the tree: how long a worker's page may go
 # without a fresh stamp before it is treated as wedged. Because the worker

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -417,33 +417,39 @@ def _exit_on_signal(signum, _frame):
     raise SystemExit(128 + signum)
 
 
+def _remove_run_files(lockfile: str) -> None:
+    """Remove the lock file and any dumps left beside it."""
+    for path in [lockfile, *glob.glob(glob.escape(lockfile) + '.*.dump')]:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
     for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
         signal.signal(sig, _exit_on_signal)
+    stopped_cleanly = False
     try:
         watch(args.lockfile, args.workers, args.threshold, args.grace,
              args.poll_interval)
+        stopped_cleanly = True  # watch() does not return today
+    except SystemExit:
+        stopped_cleanly = True  # _exit_on_signal: told to stop, so the pass is over
+        raise
     finally:
-        # The watchdog owns the lock file, so whoever started it needs no
-        # cleanup of its own -- which matters because an untrapped SIGTERM or
-        # SIGHUP skips a starting script's EXIT trap entirely (measured).
-        # SIGKILL is the gap: nothing runs here, and the file is left behind.
-        #
-        # `watch()` never returns on its own, so reaching this means we were
-        # told to stop and the pass is over -- the file cannot be pulled out
-        # from under a running one. Deliberately not inside `watch()`, which
-        # stays a pure poll loop callable from tests against a file they own.
-        # Sweep, not enumerate: a worker aborted by a GPU fault reaches no
-        # teardown, so its dump can outlive it with nobody else to notice.
-        for _path in [args.lockfile,
-                      *glob.glob(glob.escape(args.lockfile) + '.*.dump')]:
-            try:
-                os.unlink(_path)
-            except FileNotFoundError:
-                pass
-        print('pytest_gpu_lease.watchdog: stopped', file=sys.stderr, flush=True)
+        # Only after a clean stop. On an unexpected failure the pass may still
+        # be running, and unlinking then would hand replacement workers a fresh
+        # inode while their peers still hold locks on this one -- two workers
+        # leasing one GPU, which is the failure the lease exists to prevent.
+        if stopped_cleanly:
+            _remove_run_files(args.lockfile)
+            print('pytest_gpu_lease.watchdog: stopped', file=sys.stderr, flush=True)
+        else:
+            print(f'pytest_gpu_lease.watchdog: crashed; leaving {args.lockfile} '
+                  f'in place for any pass still using it', file=sys.stderr, flush=True)
 
 
 if __name__ == '__main__':

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -359,6 +359,13 @@ def _poll_once(fd: int, lockfile: str, workers: int, threshold_ns: int, grace_ns
             # but has not written yet. Judging it on someone else's stamp is
             # how a replacement gets killed for inheriting the expired one left
             # by the worker this watchdog had just SIGKILLed off that page.
+            #
+            # Not proof against pid rollover: were the dead worker's pid handed
+            # straight back to its own replacement, the stale stamp would look
+            # owned and the new worker would be signalled. That needs the pid
+            # counter to wrap in the millisecond between the two, and the cost
+            # is one spurious kill on a run that is already restarting workers.
+            # Not fixed; a generation counter would not pay for itself.
             continue
         stale_ns = now - last_activity
         if stale_ns > threshold_ns:

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -308,9 +308,13 @@ def _build_parser() -> argparse.ArgumentParser:
         prog='python -m pytest_gpu_lease.watchdog',
         description='Escalate SIGTERM -> SIGKILL on a pytest_gpu_lease worker whose '
                     'page has gone unstamped for too long.')
-    parser.add_argument('--lockfile', default=os.getenv('GPU_LEASE_LOCKFILE'),
-                        help='Shared lease lock file to watch. Defaults to $GPU_LEASE_LOCKFILE, '
-                             'the same variable run-test.sh exports for pytest itself.')
+    parser.add_argument('--lockfile', required=True,
+                        help='Shared lease lock file to watch. Required, rather than '
+                             'defaulted from $GPU_LEASE_LOCKFILE, so that `ps` shows which '
+                             'file each watchdog is on -- that is the only way to tell a '
+                             'stale watchdog from a live one. Workers still find the same '
+                             'file through the environment variable; only this process '
+                             'insists on being told.')
     parser.add_argument('--workers', type=int, required=True,
                         help='Size of the GPU pool (the -n given to pytest); pages '
                              '0..workers-1 are watched.')
@@ -340,8 +344,6 @@ def _exit_on_signal(signum, _frame):
 def main(argv: list[str] | None = None) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
-    if not args.lockfile:
-        parser.error('--lockfile is required (or set GPU_LEASE_LOCKFILE)')
     for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
         signal.signal(sig, _exit_on_signal)
     try:

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -62,7 +62,7 @@ from .plugin import PAGE_SIZE, STRUCT_FLOCK, dump_path
 # an enhancement -- see _pidfd_open. Needs Linux 5.3 and Python 3.9.
 #
 # That is a statement about this harness, not about ROCm: ROCm still supports
-# AlmaLinux 8, whose kernel predates pidfd_open. This is Level-3 CI tooling,
+# RHEL 8.10, whose kernel predates pidfd_open. This is Level-3 CI tooling,
 # deployed on Ubuntu 22.04 or later (5.15, Python 3.10), where the requirement
 # costs nothing. A suite that has to run on something older should not be
 # using this module.

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -187,6 +187,14 @@ def _pidfd_open(pid: int) -> int | None:
         return os.pidfd_open(pid)
     except ProcessLookupError:
         return None
+    except OSError as exc:
+        # Anything else -- a transient EMFILE, say. Skipping this page for one
+        # poll costs a few seconds; letting it out of `_poll_once` kills the
+        # loop, and the pass then runs the rest of its 22 hours unprotected
+        # with one line in a log to show for it.
+        print(f'pytest_gpu_lease.watchdog: no pidfd for {pid} ({exc}); retrying next poll',
+              file=sys.stderr, flush=True)
+        return None
 
 
 def _discard(pending: dict[int, _Staged], page: int) -> None:

--- a/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
+++ b/python/pytest-gpu-lease/pytest_gpu_lease/watchdog.py
@@ -276,25 +276,22 @@ def _poll_once(fd: int, lockfile: str, workers: int, threshold_ns: int, grace_ns
             continue
         any_locked = True
         if now - staged.sent_ns >= grace_ns:
-            # A SIGTERMed worker is not doomed: faulthandler makes that signal
-            # a stack dump rather than a death, so a merely slow test can
-            # finish inside the grace period. Judge it again on the same rule
-            # that staged it -- 0 means it reached the gap between tests, a
-            # recent stamp means it started another one. Checking only the lock
-            # and the pid would SIGKILL a worker that had already recovered.
-            last_activity = _read_last_activity(fd, page)
-            if last_activity == 0 or now - last_activity <= threshold_ns:
-                _discard(pending, page)
-                continue
+            # No reprieve for a page that came back to life inside the grace
+            # period. A worker past the threshold is a dead worker: the grace
+            # exists for faulthandler to finish its dump, not as a window in
+            # which to be pardoned. The test that ran long enough to be
+            # signalled has already failed, and sparing its worker would make
+            # the pass depend on how close to the threshold it landed.
+            #
+            # Dump first: producing it was the whole point of the SIGTERM, and
+            # after the SIGKILL nobody is left to ask.
+            _emit_dump(lockfile, page, staged.pid)
             # Through the pidfd, so this cannot land on anyone else. The lock
             # check above answers the policy question -- is it still wedged and
             # still leasing -- but not the identity one: between that F_GETLK
             # and this call the process may exit and its pid be reissued. That
             # window is small and the payload is SIGKILL, which is precisely
             # the combination not to leave to chance.
-            # Before the kill: the SIGTERM's whole point was this dump, and
-            # after SIGKILL nobody is left to ask.
-            _emit_dump(lockfile, page, staged.pid)
             _send(staged.pid, signal.SIGKILL,
                   'grace period expired, still holding its page', staged.pidfd)
             _discard(pending, page)

--- a/python/pytest-gpu-lease/tests/test_plugin.py
+++ b/python/pytest-gpu-lease/tests/test_plugin.py
@@ -279,3 +279,75 @@ def test_pinned_resolves_without_the_xdist_plugin(pytester, monkeypatch):
     result.assert_outcomes(passed=1)
     assert not list(pytester.path.rglob('gpulock')), \
         "pinned mode must not create a lockfile"
+
+
+def test_sendcommand_guard_swallows_closed_channel_instead_of_raising(capsys):
+    """Unit test for the controller-side scheduler guard, exercised directly
+    rather than by racing two real worker crashes against each other.
+
+    The actual failure -- two workers dying close enough together that the
+    second's channel is already closed by the time the first's crash handling
+    tries to top up its queue -- is exactly the kind of race that only
+    sometimes reproduces under `-n N`. Driving it deterministically here,
+    against the real `xdist.workermanage.WorkerController` class rather than a
+    substitute, tests the actual guard installed in the real environment.
+    """
+    xdist_workermanage = pytest.importorskip('xdist.workermanage')
+    WorkerController = xdist_workermanage.WorkerController
+
+    original = WorkerController.sendcommand
+    try:
+        def _always_closed(self, name, **kwargs):
+            raise OSError('cannot send (already closed?)')
+
+        WorkerController.sendcommand = _always_closed
+        from pytest_gpu_lease.plugin import _tolerate_closed_worker_channel
+        _tolerate_closed_worker_channel()
+
+        class _FakeGateway:
+            id = 'gw-fake'
+
+        class _FakeNode:
+            gateway = _FakeGateway()
+
+        # Must not raise: this is the exact call site (LoadScheduling._send_tests
+        # -> WorkerController.send_runtest_some -> sendcommand) that used to
+        # propagate OSError all the way out to an INTERNALERROR.
+        WorkerController.sendcommand(_FakeNode(), 'runtests', indices=[1, 2])
+
+        err = capsys.readouterr().err
+        assert 'channel already closed' in err
+        assert 'gw-fake' in err
+    finally:
+        WorkerController.sendcommand = original
+
+
+def test_sendcommand_guard_is_idempotent(capsys):
+    """Calling the guard installer twice must not stack a second wrapper --
+    `pytest_configure` is not guaranteed to run exactly once per interpreter
+    in every embedding, and a double-wrap would still work but would print
+    the "channel already closed" line twice per failure for no reason.
+    """
+    xdist_workermanage = pytest.importorskip('xdist.workermanage')
+    WorkerController = xdist_workermanage.WorkerController
+
+    original = WorkerController.sendcommand
+    try:
+        def _always_closed(self, name, **kwargs):
+            raise OSError('cannot send (already closed?)')
+
+        WorkerController.sendcommand = _always_closed
+        from pytest_gpu_lease.plugin import _tolerate_closed_worker_channel
+        _tolerate_closed_worker_channel()
+        _tolerate_closed_worker_channel()
+
+        class _FakeGateway:
+            id = 'gw-fake'
+
+        class _FakeNode:
+            gateway = _FakeGateway()
+
+        WorkerController.sendcommand(_FakeNode(), 'runtests', indices=[1])
+        assert capsys.readouterr().err.count('channel already closed') == 1
+    finally:
+        WorkerController.sendcommand = original

--- a/python/pytest-gpu-lease/tests/test_plugin.py
+++ b/python/pytest-gpu-lease/tests/test_plugin.py
@@ -24,6 +24,12 @@ def _clear_lease_env(monkeypatch):
     # nested one. The plugin ignores it now, but leaving it set would hide
     # a regression back to reading it.
     monkeypatch.delenv('PYTEST_XDIST_WORKER_COUNT', raising=False)
+    # Same leak risk as above, but for real this time: run-test.sh (and a
+    # developer's own shell, while poking at the watchdog) sets these, and a
+    # value inherited here would silently redirect a test that asserts on the
+    # *derived* lockfile path to whatever the outer run happened to be using.
+    monkeypatch.delenv('GPU_LEASE_LOCKFILE', raising=False)
+    monkeypatch.delenv('GPU_LEASE_BUDGET_S', raising=False)
 
 
 def test_no_xdist_gpu_id_is_zero_and_no_lockfile(pytester, monkeypatch):
@@ -91,6 +97,32 @@ def test_leased_mode_assigns_distinct_gpus_and_creates_lockfile(pytester, monkey
     assert gpus == {0, 1}
     assert list(pytester.path.rglob('gpulock')), \
         "leased mode must create the shared lockfile"
+
+
+def test_gpu_lease_lockfile_env_overrides_derived_path(pytester, monkeypatch, tmp_path):
+    """``GPU_LEASE_LOCKFILE`` wins over the ``tmp_path_factory``-derived path.
+
+    The watchdog is a separate process started before this pytest session
+    exists, so it cannot predict where ``getbasetemp()`` will land; run-test.sh
+    instead mints the path itself and both sides read it from the environment.
+    This is the regression guard for that override actually taking effect --
+    without it, the watchdog and the workers would each be watching a
+    different file and the whole mechanism would silently do nothing.
+    """
+    _clear_lease_env(monkeypatch)
+    lockfile = tmp_path / 'chosen_by_env_gpulock'
+    monkeypatch.setenv('GPU_LEASE_LOCKFILE', str(lockfile))
+
+    pytester.makepyfile("""
+        def test_it(gpu_id):
+            assert gpu_id == 0
+    """)
+    result = pytester.runpytest_subprocess('-n', '1', '-p', 'xdist')
+    result.assert_outcomes(passed=1)
+
+    assert lockfile.exists(), 'the env-chosen path must be the one actually used'
+    assert not list(pytester.path.rglob('gpulock')), \
+        'the derived path must not also be created once the env var wins'
 
 
 def test_gpu_device_default_is_cuda(pytester, monkeypatch):

--- a/python/pytest-gpu-lease/tests/test_plugin.py
+++ b/python/pytest-gpu-lease/tests/test_plugin.py
@@ -12,7 +12,13 @@ Each case carries its own rationale in its docstring; the crash-and-restart and
 no-xdist cases are the two that guard against regressions already seen in the wild.
 """
 
+import os
+import struct
+import time
+
 import pytest
+
+from pytest_gpu_lease import plugin
 
 pytest_plugins = ['pytester']
 
@@ -350,3 +356,37 @@ def test_sendcommand_guard_is_idempotent(capsys):
         assert capsys.readouterr().err.count('channel already closed') == 1
     finally:
         WorkerController.sendcommand = original
+
+
+def test_wrapper_clears_a_lease_acquired_during_its_own_call(tmp_path):
+    """The first test must leave the page reading 0, like every later one.
+
+    `gpu_id` acquires during the first test's *setup*, i.e. after the
+    hookwrapper's pre-yield has already found no lease to heartbeat. Nothing
+    then clears the initial stamp `gpu_id` wrote, so it keeps ageing across the
+    gap before the second test, and a slow first test plus that gap can cross
+    the watchdog's threshold and get an idle worker killed.
+
+    Driven against the hookwrapper directly: in a session this window closes
+    the moment the second test's pre-yield rewrites the page, and on a
+    single-test session `gpu_id` is torn down inside the very same call, so
+    there is no point from inside a session where it can be observed.
+    """
+    lockfile = tmp_path / 'gpulock'
+    fd = os.open(str(lockfile), os.O_RDWR | os.O_CREAT, 0o644)
+    saved = plugin._active_lease
+    try:
+        wrapper = plugin.pytest_runtest_protocol()
+        next(wrapper)                                   # pre-yield: no lease yet
+        plugin._active_lease = (fd, 0)                  # gpu_id acquires during setup
+        os.pwrite(fd, struct.pack('<Q', time.monotonic_ns()), 0)
+        try:
+            next(wrapper)                               # post-yield
+        except StopIteration:
+            pass
+        stamp = struct.unpack('<Q', os.pread(fd, 8, 0))[0]
+    finally:
+        plugin._active_lease = saved
+        os.close(fd)
+
+    assert stamp == 0, f'page still reads as running a test ({stamp}) after the first one'

--- a/python/pytest-gpu-lease/tests/test_plugin.py
+++ b/python/pytest-gpu-lease/tests/test_plugin.py
@@ -29,7 +29,6 @@ def _clear_lease_env(monkeypatch):
     # value inherited here would silently redirect a test that asserts on the
     # *derived* lockfile path to whatever the outer run happened to be using.
     monkeypatch.delenv('GPU_LEASE_LOCKFILE', raising=False)
-    monkeypatch.delenv('GPU_LEASE_BUDGET_S', raising=False)
 
 
 def test_no_xdist_gpu_id_is_zero_and_no_lockfile(pytester, monkeypatch):

--- a/python/pytest-gpu-lease/tests/test_plugin.py
+++ b/python/pytest-gpu-lease/tests/test_plugin.py
@@ -12,6 +12,7 @@ Each case carries its own rationale in its docstring; the crash-and-restart and
 no-xdist cases are the two that guard against regressions already seen in the wild.
 """
 
+import errno
 import os
 import struct
 import time
@@ -312,8 +313,15 @@ def test_sendcommand_guard_swallows_closed_channel_instead_of_raising(capsys):
         class _FakeGateway:
             id = 'gw-fake'
 
+        class _FakeClosedChannel:
+            # The state the test name claims: execnet's Channel.send raises
+            # only after isclosed() is already True, and the guard now checks.
+            def isclosed(self):
+                return True
+
         class _FakeNode:
             gateway = _FakeGateway()
+            channel = _FakeClosedChannel()
 
         # Must not raise: this is the exact call site (LoadScheduling._send_tests
         # -> WorkerController.send_runtest_some -> sendcommand) that used to
@@ -349,8 +357,15 @@ def test_sendcommand_guard_is_idempotent(capsys):
         class _FakeGateway:
             id = 'gw-fake'
 
+        class _FakeClosedChannel:
+            # The state the test name claims: execnet's Channel.send raises
+            # only after isclosed() is already True, and the guard now checks.
+            def isclosed(self):
+                return True
+
         class _FakeNode:
             gateway = _FakeGateway()
+            channel = _FakeClosedChannel()
 
         WorkerController.sendcommand(_FakeNode(), 'runtests', indices=[1])
         assert capsys.readouterr().err.count('channel already closed') == 1
@@ -390,3 +405,54 @@ def test_wrapper_clears_a_lease_acquired_during_its_own_call(tmp_path):
         os.close(fd)
 
     assert stamp == 0, f'page still reads as running a test ({stamp}) after the first one'
+
+
+def test_sendcommand_guard_reraises_errors_that_are_not_a_dead_peer(capsys):
+    """A full disk is not a crashed worker.
+
+    `sendcommand` reaches OSError by two routes: execnet raises one with no
+    errno when the channel is already closed, and the gateway's pipe write
+    underneath can fail for any reason a write can. Swallowing the second kind
+    would record a failing device as a worker crash and silently drop that
+    node's tests -- a broken machine producing a short, green-looking run.
+    """
+    xdist_workermanage = pytest.importorskip('xdist.workermanage')
+    WorkerController = xdist_workermanage.WorkerController
+
+    class _Channel:
+        def __init__(self, closed):
+            self._closed = closed
+
+        def isclosed(self):
+            return self._closed
+
+    class _Gateway:
+        id = 'gw9'
+
+    class _Node:
+        def __init__(self, closed):
+            self.channel = _Channel(closed)
+            self.gateway = _Gateway()
+
+    original = WorkerController.sendcommand
+    try:
+        def _raise(err):
+            def _sendcommand(self, name, **kwargs):
+                raise err
+            return _sendcommand
+
+        # An open channel failing with ENOSPC is a real fault: it must escape.
+        WorkerController.sendcommand = _raise(OSError(errno.ENOSPC, 'No space left on device'))
+        plugin._tolerate_closed_worker_channel()
+        with pytest.raises(OSError) as caught:
+            WorkerController.sendcommand(_Node(closed=False), 'runtests', indices=[1])
+        assert caught.value.errno == errno.ENOSPC
+
+        # EPIPE on an open channel is the peer going away mid-write: tolerated.
+        WorkerController.sendcommand = original
+        WorkerController.sendcommand = _raise(OSError(errno.EPIPE, 'Broken pipe'))
+        plugin._tolerate_closed_worker_channel()
+        WorkerController.sendcommand(_Node(closed=False), 'runtests', indices=[1])
+        assert 'channel already closed' in capsys.readouterr().err
+    finally:
+        WorkerController.sendcommand = original

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -1,0 +1,173 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Self-test suite for pytest_gpu_lease.watchdog.
+
+Needs no GPU. Two kinds of case:
+
+* A direct test of the escalation logic against a process wedged in a genuine
+  C call, driven straight against `watchdog.watch()` -- no pytest session on
+  the wedged side at all. This isolates "does the watchdog correctly
+  SIGTERM-then-SIGKILL a stuck pid" from everything `pytest_gpu_lease.plugin`
+  does around it.
+
+* An end-to-end case with the plugin, the heartbeat, and the watchdog all
+  running together under `-n 2`, via a nested `pytester` session -- the
+  scenario the whole feature exists for.
+
+Both wedge by calling `os.read` on a pipe nobody ever writes to, rather than
+relying on any claim about GIL behaviour. An earlier attempt to wedge a thread
+via `ctypes.PyDLL` (chosen specifically because it does not release the GIL),
+to test that a background `threading.Timer` could not run during the wedge,
+gave a result inconsistent with that theory -- the Timer fired anyway. So
+nothing here depends on GIL semantics: `os.read` on an empty pipe blocks in
+the kernel regardless of GIL state, and what is checked afterwards is only
+what is directly observable -- the process does not return from that call on
+a plain SIGTERM (because faulthandler.register replaces the default terminate
+action), it does produce a stack dump naming the blocked frame, and it does
+die on SIGKILL, which no handler can intercept.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+
+import pytest
+
+from pytest_gpu_lease import watchdog
+
+pytest_plugins = ['pytester']
+
+
+_WEDGE_CHILD = """
+import fcntl, os, struct, sys, time, faulthandler, signal
+from pytest_gpu_lease.plugin import PAGE_SIZE, STRUCT_FLOCK
+
+lockfile = sys.argv[1]
+page = int(sys.argv[2])
+f = open(lockfile, 'r+b')
+claim = struct.pack(STRUCT_FLOCK, fcntl.F_WRLCK, os.SEEK_SET, PAGE_SIZE * page, PAGE_SIZE, 0)
+fcntl.fcntl(f, fcntl.F_SETLK, claim)
+# Deadline already in the past, so the watchdog acts on its very first poll
+# rather than this test also depending on wall-clock timing to expire one.
+os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns() - 1_000_000_000), PAGE_SIZE * page)
+faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
+r, w = os.pipe()
+print('READY', flush=True)
+os.read(r, 1)  # blocks forever: nobody ever writes to w
+"""
+
+
+def _spawn_wedge_child(tmp_path, lockfile, page=0):
+    child_script = tmp_path / f'wedge_child_{page}.py'
+    child_script.write_text(_WEDGE_CHILD)
+    err_path = tmp_path / f'child_{page}.err'
+    err_file = open(err_path, 'wb')
+    child = subprocess.Popen(
+        [sys.executable, str(child_script), str(lockfile), str(page)],
+        stdout=subprocess.PIPE, stderr=err_file, text=True)
+    assert child.stdout.readline().strip() == 'READY'
+    return child, err_path, err_file
+
+
+@pytest.mark.timeout(30)
+def test_watchdog_sigterms_then_sigkills_a_process_wedged_in_a_c_call(tmp_path):
+    """The escalation logic in isolation, against a real wedged process."""
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    child, err_path, err_file = _spawn_wedge_child(tmp_path, lockfile)
+    try:
+        watchdog.watch(str(lockfile), workers=1, threshold_s=1, grace_s=2,
+                        poll_interval_s=0.1, idle_polls=5)
+        ret = child.wait(timeout=10)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait()
+        err_file.close()
+
+    assert ret == -signal.SIGKILL, f'expected the child to die by SIGKILL, got {ret}'
+    stack = err_path.read_text()
+    assert 'wedge_child_0.py' in stack, f'no stack dump naming the wedged frame:\n{stack}'
+
+
+def test_getlk_reports_unlocked_after_holder_is_killed(tmp_path):
+    """F_GETLK auto-releases on process death -- the liveness proof the module
+    docstring relies on to re-check the lock immediately before every signal
+    instead of trusting a remembered pid. A dead process holds no lock, full
+    stop, so a reused pid can never be mistaken for the worker that had it.
+    """
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    child, err_path, err_file = _spawn_wedge_child(tmp_path, lockfile)
+    fd = os.open(str(lockfile), os.O_RDWR)
+    try:
+        locked, pid = watchdog._getlk(fd, 0)
+        assert locked and pid == child.pid
+
+        child.kill()  # SIGKILL: no handler can intervene
+        child.wait(timeout=5)
+
+        locked, _ = watchdog._getlk(fd, 0)
+        assert not locked, 'kernel did not auto-release the lock on process death'
+    finally:
+        os.close(fd)
+        err_file.close()
+
+
+@pytest.mark.timeout(90)
+def test_end_to_end_wedged_worker_is_replaced_and_run_stays_green(pytester, monkeypatch, tmp_path):
+    """The full path: heartbeat, watchdog, escalation, worker replacement.
+
+    One test out of six wedges in a C call under `-n 2`; the watchdog runs
+    alongside the nested pytest session exactly as run-test.sh will run it
+    (own process, same lock file, `--threshold`/`--grace` sized in seconds
+    instead of the real 600s/30s -- this test cannot wait out the real
+    default). Assertions: the wedged worker's stack dump names the wedged
+    frame, the other five tests still pass despite that worker being killed
+    mid-run, and the session terminates at all -- a leaked lease or a dead
+    watchdog would otherwise hang it.
+    """
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    monkeypatch.delenv('GPU_LEASE_PIN', raising=False)
+    monkeypatch.setenv('GPU_LEASE_LOCKFILE', str(lockfile))
+    monkeypatch.setenv('GPU_LEASE_BUDGET_S', '1')
+
+    pytester.makepyfile("""
+        import os
+
+        import pytest
+
+        @pytest.mark.parametrize('i', range(6))
+        def test_maybe_wedge(i, gpu_id):
+            if i == 0:
+                r, w = os.pipe()
+                os.read(r, 1)  # never returns
+            assert gpu_id in (0, 1)
+    """)
+
+    watchdog_proc = subprocess.Popen(
+        [sys.executable, '-m', 'pytest_gpu_lease.watchdog',
+         '--lockfile', str(lockfile), '--workers', '2',
+         '--threshold', '1', '--grace', '2',
+         '--poll_interval', '0.2', '--idle_polls', '15'],
+        stderr=subprocess.PIPE, text=True)
+    try:
+        result = pytester.runpytest_subprocess(
+            '-n', '2', '--max-worker-restart', '4', '-p', 'xdist', timeout=60)
+        _, watchdog_err = watchdog_proc.communicate(timeout=15)
+    finally:
+        if watchdog_proc.poll() is None:
+            watchdog_proc.kill()
+            watchdog_proc.communicate()
+
+    assert result.ret is not None, 'session did not terminate'
+    assert 'SIGTERM' in watchdog_err, watchdog_err
+    assert 'SIGKILL' in watchdog_err, watchdog_err
+
+    outcomes = result.parseoutcomes()
+    # 5 of the 6 parametrizations never touch the wedge; they must all still
+    # pass despite the sixth worker being killed and replaced mid-run.
+    assert outcomes.get('passed', 0) >= 5, outcomes

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -32,6 +32,8 @@ import os
 import signal
 import subprocess
 import sys
+import threading
+import time
 
 import pytest
 
@@ -114,6 +116,64 @@ def test_getlk_reports_unlocked_after_holder_is_killed(tmp_path):
     finally:
         os.close(fd)
         err_file.close()
+
+
+@pytest.mark.timeout(30)
+def test_watchdog_waits_indefinitely_before_first_page_is_ever_locked(tmp_path):
+    """Regression test: idle polls must not be counted before a page has ever
+    been seen locked, or the watchdog would exit on its own during collection,
+    before any worker has taken a lease.
+
+    That is not a hypothetical corner case: run-test.sh starts the watchdog
+    ahead of pytest deliberately, specifically to cover a wedge during
+    collection too, and a Level-3 pass collects roughly 330k tests through a
+    conftest that imports torch -- minutes, not seconds. At the defaults
+    (5s poll interval, 12 idle polls) the buggy version exits after 60s of
+    an empty lock file, which collection alone comfortably outlasts; every
+    wedge for the rest of that ~22h run would then go uncaught, silently,
+    since the "no page locked ... exiting" line looks the same whether the
+    run is actually over or the watchdog simply gave up too early.
+
+    Drives `watch()` on a background thread because it blocks for the whole
+    watch, and this test needs to observe it still running mid-watch, then
+    later observe it firing -- both from the outside.
+    """
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    poll_interval = 0.1
+    idle_polls = 3
+    # Comfortably longer than idle_polls * poll_interval: the exact window the
+    # buggy version needed to give up on a still-empty lock file.
+    wait_before_lock = poll_interval * idle_polls * 5
+
+    # daemon=True: watch() has no cooperative way to stop it early, so if an
+    # assertion below fails, let the thread be reaped with the process rather
+    # than block the test on joining it.
+    thread = threading.Thread(
+        target=watchdog.watch,
+        args=(str(lockfile), 1, 1, 1),
+        kwargs=dict(poll_interval_s=poll_interval, idle_polls=idle_polls),
+        daemon=True)
+    thread.start()
+
+    time.sleep(wait_before_lock)
+    assert thread.is_alive(), \
+        'watchdog exited before any page was ever locked; it must wait ' \
+        'indefinitely until a worker actually takes a lease'
+
+    child, err_path, err_file = _spawn_wedge_child(tmp_path, lockfile)
+    try:
+        thread.join(timeout=10)
+        assert not thread.is_alive(), \
+            'watchdog did not fire once a page was locked with an expired deadline'
+        ret = child.wait(timeout=5)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait()
+        err_file.close()
+
+    assert ret == -signal.SIGKILL, f'expected the child to die by SIGKILL, got {ret}'
 
 
 @pytest.mark.timeout(90)

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -354,3 +354,44 @@ def test_watchdog_relays_a_wedged_workers_stack_dump(tmp_path, capsys):
     assert f'stack of pid {child.pid} on GPU 0' in relayed, relayed
     assert not pathlib.Path(watchdog.dump_path(str(lockfile), child.pid)).exists(), \
         'the dump must be deleted as soon as it is relayed'
+
+
+def test_dump_survives_a_worker_that_dies_during_its_grace_period(tmp_path, capsys):
+    """The common exit path must still yield the stack.
+
+    A SIGTERMed worker usually dies on its own inside the grace period -- the
+    HIP runtime aborting on the fault that wedged it -- and that path once
+    discarded the entry silently, with `_sweep_dumps` deleting the file
+    unread on the next poll because its pid was gone. The dump is the entire
+    reason the SIGTERM was sent, so it is exactly the case that must not lose
+    it.
+    """
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    child, _, err_file = _spawn_wedge_child(tmp_path, lockfile, tag='_grace')
+    pathlib.Path(watchdog.dump_path(str(lockfile), child.pid)).write_text(
+        'Current thread 0x1 (most recent call first):\n'
+        '  File "test_flash.py", line 9 in test_wedged_here\n')
+    fd = os.open(str(lockfile), os.O_RDWR)
+    try:
+        pending: dict[int, watchdog._Staged] = {}
+        # A long grace, so the only way out of `pending` is the child dying.
+        poll = lambda: watchdog._poll_once(fd, str(lockfile), 1, threshold_ns=10**9,  # noqa: E731
+                                           grace_ns=10**12, pending=pending)
+        poll()
+        assert list(pending) == [0], pending
+        child.kill()
+        child.wait(timeout=5)
+        poll()
+        assert pending == {}, 'a dead worker must not stay staged'
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait()
+        err_file.close()
+        os.close(fd)
+
+    relayed = capsys.readouterr().err
+    assert 'test_wedged_here' in relayed, relayed
+    assert 'exited during its grace period' in relayed, relayed
+    assert not pathlib.Path(watchdog.dump_path(str(lockfile), child.pid)).exists()

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -30,6 +30,7 @@ die on SIGKILL, which no handler can intercept.
 
 import os
 import signal
+import struct
 import subprocess
 import sys
 import threading
@@ -189,6 +190,42 @@ def test_escalation_does_not_sigkill_a_replacement_that_took_the_same_page(tmp_p
         for handle in (wedged_err, replacement_err):
             if handle is not None:
                 handle.close()
+        os.close(fd)
+
+
+def test_escalation_is_cancelled_when_the_worker_recovers(tmp_path):
+    """A SIGTERMed worker that got going again must not be SIGKILLed.
+
+    SIGTERM is a stack dump, not a death -- `plugin.py` registers it with
+    faulthandler and chain=False -- so a test that was merely slow rather than
+    wedged can finish inside the grace period. The page then goes back to 0
+    (between tests) or takes a fresh stamp, while the lock and the pid are
+    unchanged, so escalating on those two alone kills a healthy worker.
+    """
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    fd = os.open(str(lockfile), os.O_RDWR)
+    pending: dict[int, watchdog._Staged] = {}
+    poll = lambda: watchdog._poll_once(fd, 1, threshold_ns=10**9, grace_ns=0,  # noqa: E731
+                                       pending=pending)
+
+    child, _, err_file = _spawn_wedge_child(tmp_path, lockfile, tag='_recovers')
+    try:
+        assert poll() is True
+        assert list(pending) == [0], pending
+
+        # The slow test finishes: same process, same lease, fresh heartbeat.
+        os.pwrite(fd, struct.pack('<Q', 0), 0)
+
+        assert poll() is True
+        assert pending == {}, 'a recovered worker must not stay staged for SIGKILL'
+        # grace_ns=0, so any SIGKILL would already have gone out.
+        time.sleep(0.5)
+        assert child.poll() is None, 'SIGKILLed a worker that had recovered'
+    finally:
+        child.kill()
+        child.wait()
+        err_file.close()
         os.close(fd)
 
 

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -312,7 +312,7 @@ def test_a_stale_pidfd_reports_gone_rather_than_signalling_a_reissued_pid(capsys
     """
     victim = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])
     pidfd = watchdog._pidfd_open(victim.pid)
-    assert pidfd is not None, 'expected pidfd support on this kernel'
+    assert pidfd is not None, 'the module asserts pidfd support at import'
     victim.kill()
     victim.wait(timeout=10)   # dead *and* reaped: the number is free to be reissued
     try:

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -22,10 +22,13 @@ to test that a background `threading.Timer` could not run during the wedge,
 gave a result inconsistent with that theory -- the Timer fired anyway. So
 nothing here depends on GIL semantics: `os.read` on an empty pipe blocks in
 the kernel regardless of GIL state, and what is checked afterwards is only
-what is directly observable -- the process does not return from that call on
-a plain SIGTERM (because faulthandler.register replaces the default terminate
-action), it does produce a stack dump naming the blocked frame, and it does
-die on SIGKILL, which no handler can intercept.
+what is directly observable -- it produces a stack dump naming the blocked
+frame, and it dies on SIGKILL, which no handler can intercept.
+
+The wedge child registers faulthandler with the default `chain=False`, unlike
+`plugin.py`, which uses `chain=True` so SIGTERM still ends a real worker. That
+is deliberate: the child models the process SIGTERM cannot end, which is the
+only case SIGKILL exists for and the one worth testing here.
 """
 
 import os
@@ -63,6 +66,8 @@ fcntl.fcntl(f, fcntl.F_SETLK, claim)
 os.pwrite(f.fileno(), struct.pack('<Q', max(1, time.monotonic_ns() - backdate_ns)),
           PAGE_SIZE * page)
 os.pwrite(f.fileno(), struct.pack('<q', os.getpid()), PAGE_SIZE * page + 8)
+# chain=False on purpose: survive SIGTERM, so the escalation to SIGKILL is
+# what these tests exercise. A real worker uses chain=True and dies.
 faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
 r, w = os.pipe()
 print('READY', flush=True)
@@ -289,8 +294,13 @@ def test_end_to_end_wedged_worker_is_replaced_and_run_stays_green(pytester, monk
             watchdog_proc.communicate()
 
     assert result.ret is not None, 'session did not terminate'
-    assert 'SIGTERM' in watchdog_err, watchdog_err
-    assert 'SIGKILL' in watchdog_err, watchdog_err
+    # Not `'SIGKILL' in ...`: SIGTERM ends a real worker now, so the follow-up
+    # line is "no SIGKILL needed" -- which contains the word and would pass
+    # whatever happened. Assert the signal actually sent; the worker's death is
+    # evidenced by the outcomes below, xdist reporting it as crashed. Nothing
+    # here asserts on the watchdog's *next* poll, which may never come: the
+    # session ends as soon as the replacement finishes the remaining tests.
+    assert watchdog_err.count('sent SIGTERM') >= 1, watchdog_err
 
     outcomes = result.parseoutcomes()
     # 5 of the 6 parametrizations never touch the wedge; they must all still

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -62,6 +62,7 @@ fcntl.fcntl(f, fcntl.F_SETLK, claim)
 # backdate_ns=0 gives a fresh stamp instead: a healthy worker, to be left alone.
 os.pwrite(f.fileno(), struct.pack('<Q', max(1, time.monotonic_ns() - backdate_ns)),
           PAGE_SIZE * page)
+os.pwrite(f.fileno(), struct.pack('<q', os.getpid()), PAGE_SIZE * page + 8)
 faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
 r, w = os.pipe()
 print('READY', flush=True)
@@ -395,3 +396,42 @@ def test_dump_survives_a_worker_that_dies_during_its_grace_period(tmp_path, caps
     assert 'test_wedged_here' in relayed, relayed
     assert 'exited during its grace period' in relayed, relayed
     assert not pathlib.Path(watchdog.dump_path(str(lockfile), child.pid)).exists()
+
+
+def test_a_replacement_is_not_killed_for_inheriting_a_stale_stamp(tmp_path, capsys):
+    """A page holds an expired stamp exactly when a replacement lands on it.
+
+    The watchdog SIGKILLs a wedged worker, whose stamp is by definition past
+    the threshold, and xdist hands the replacement the page it just vacated.
+    Until that replacement writes, the page reads locked-and-ancient. Judging
+    it on the stamp alone kills a worker that started milliseconds ago -- and
+    escalation offers no reprieve, so it dies for good.
+
+    Simulated by locking the page and writing an ancient stamp owned by some
+    *other* pid, which is what the window looks like from outside.
+    """
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    child, _, err_file = _spawn_wedge_child(tmp_path, lockfile, tag='_fresh')
+    fd = os.open(str(lockfile), os.O_RDWR)
+    try:
+        # Ancient stamp, but stamped by a pid that is not the lock holder.
+        os.pwrite(fd, struct.pack('<Q', max(1, time.monotonic_ns() - _STALE_NS)), 0)
+        os.pwrite(fd, struct.pack('<q', child.pid + 1), 8)
+
+        pending: dict[int, watchdog._Staged] = {}
+        assert watchdog._poll_once(fd, str(lockfile), 1, threshold_ns=10**9,
+                                   grace_ns=0, pending=pending) is True
+        assert pending == {}, 'staged a kill against a stamp written by someone else'
+        assert 'SIGTERM' not in capsys.readouterr().err
+
+        # Once the holder writes its own stamp, it is judged normally again.
+        os.pwrite(fd, struct.pack('<q', child.pid), 8)
+        watchdog._poll_once(fd, str(lockfile), 1, threshold_ns=10**9,
+                            grace_ns=0, pending=pending)
+        assert list(pending) == [0], 'a stamp owned by the holder must still be judged'
+    finally:
+        child.kill()
+        child.wait()
+        err_file.close()
+        os.close(fd)

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -57,6 +57,7 @@ fcntl.fcntl(f, fcntl.F_SETLK, claim)
 # wall-clock timing to age one out. max(1, ...) because monotonic_ns() is time
 # since boot and could in principle be smaller than the offset -- 1 is still a
 # valid ancient stamp, whereas 0 would read as "between tests" and be skipped.
+# backdate_ns=0 gives a fresh stamp instead: a healthy worker, to be left alone.
 os.pwrite(f.fileno(), struct.pack('<Q', max(1, time.monotonic_ns() - backdate_ns)),
           PAGE_SIZE * page)
 faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
@@ -64,7 +65,6 @@ r, w = os.pipe()
 print('READY', flush=True)
 os.read(r, 1)  # blocks forever: nobody ever writes to w
 """
-
 
 _STALE_NS = 10_000_000_000
 
@@ -83,14 +83,25 @@ def _spawn_wedge_child(tmp_path, lockfile, page=0, backdate_ns=_STALE_NS, tag=''
 
 @pytest.mark.timeout(30)
 def test_watchdog_sigterms_then_sigkills_a_process_wedged_in_a_c_call(tmp_path):
-    """The escalation logic in isolation, against a real wedged process."""
+    """The escalation logic in isolation, against a real wedged process.
+
+    `watch()` never returns, so the assertion is on the child rather than on
+    the watcher: a daemon thread runs the poll loop and is reaped with the
+    process, and `child.wait` is what bounds the test. The `timeout` mark above
+    cannot be relied on for that -- this repo dropped pytest-timeout, so in a
+    clean environment it is an unknown mark that does nothing.
+    """
     lockfile = tmp_path / 'gpulock'
     lockfile.touch()
     child, err_path, err_file = _spawn_wedge_child(tmp_path, lockfile)
     try:
-        watchdog.watch(str(lockfile), workers=1, threshold_s=1, grace_s=2,
-                        poll_interval_s=0.1, idle_polls=5)
-        ret = child.wait(timeout=10)
+        watcher = threading.Thread(
+            target=watchdog.watch,
+            args=(str(lockfile), 1, 1, 2),
+            kwargs=dict(poll_interval_s=0.1),
+            daemon=True)
+        watcher.start()
+        ret = child.wait(timeout=20)
     finally:
         if child.poll() is None:
             child.kill()
@@ -181,56 +192,37 @@ def test_escalation_does_not_sigkill_a_replacement_that_took_the_same_page(tmp_p
         os.close(fd)
 
 
-
 @pytest.mark.timeout(30)
-def test_watchdog_waits_indefinitely_before_first_page_is_ever_locked(tmp_path):
-    """Regression test: idle polls must not be counted before a page has ever
-    been seen locked, or the watchdog would exit on its own during collection,
-    before any worker has taken a lease.
+def test_watchdog_never_stops_on_its_own(tmp_path):
+    """The service invariant: it does not decide for itself when to stop.
 
-    That is not a hypothetical corner case: run-test.sh starts the watchdog
-    ahead of pytest deliberately, specifically to cover a wedge during
-    collection too, and a Level-3 pass collects roughly 330k tests through a
-    conftest that imports torch -- minutes, not seconds. At the defaults
-    (5s poll interval, 12 idle polls) the buggy version exits after 60s of
-    an empty lock file, which collection alone comfortably outlasts; every
-    wedge for the rest of that ~22h run would then go uncaught, silently,
-    since the "no page locked ... exiting" line looks the same whether the
-    run is actually over or the watchdog simply gave up too early.
+    Both halves matter. An empty lock file must not end the watch -- that is
+    the state during collection, before any worker has leased, and again while
+    a killed worker's replacement re-imports torch, and an earlier revision
+    exited after 60s of it and took the lock file with it. And having fired,
+    it must still not stop: one wedge does not end a pass, and the remaining
+    workers are exactly what it is there for.
 
-    Drives `watch()` on a background thread because it blocks for the whole
-    watch, and this test needs to observe it still running mid-watch, then
-    later observe it firing -- both from the outside.
+    Runs on a daemon thread because `watch()` blocks forever by design; the
+    thread is reaped with the process.
     """
     lockfile = tmp_path / 'gpulock'
     lockfile.touch()
     poll_interval = 0.1
-    idle_polls = 3
-    # Comfortably longer than idle_polls * poll_interval: the exact window the
-    # buggy version needed to give up on a still-empty lock file.
-    wait_before_lock = poll_interval * idle_polls * 5
 
-    # daemon=True: watch() has no cooperative way to stop it early, so if an
-    # assertion below fails, let the thread be reaped with the process rather
-    # than block the test on joining it.
     thread = threading.Thread(
         target=watchdog.watch,
         args=(str(lockfile), 1, 1, 1),
-        kwargs=dict(poll_interval_s=poll_interval, idle_polls=idle_polls),
+        kwargs=dict(poll_interval_s=poll_interval),
         daemon=True)
     thread.start()
 
-    time.sleep(wait_before_lock)
-    assert thread.is_alive(), \
-        'watchdog exited before any page was ever locked; it must wait ' \
-        'indefinitely until a worker actually takes a lease'
+    time.sleep(poll_interval * 20)
+    assert thread.is_alive(), 'watchdog stopped while the lock file was empty'
 
     child, err_path, err_file = _spawn_wedge_child(tmp_path, lockfile)
     try:
-        thread.join(timeout=10)
-        assert not thread.is_alive(), \
-            'watchdog did not fire once a page was locked with a stale heartbeat'
-        ret = child.wait(timeout=5)
+        ret = child.wait(timeout=10)
     finally:
         if child.poll() is None:
             child.kill()
@@ -238,6 +230,8 @@ def test_watchdog_waits_indefinitely_before_first_page_is_ever_locked(tmp_path):
         err_file.close()
 
     assert ret == -signal.SIGKILL, f'expected the child to die by SIGKILL, got {ret}'
+    time.sleep(poll_interval * 20)
+    assert thread.is_alive(), 'watchdog stopped after acting on one wedge'
 
 
 @pytest.mark.timeout(90)
@@ -277,12 +271,15 @@ def test_end_to_end_wedged_worker_is_replaced_and_run_stays_green(pytester, monk
         [sys.executable, '-m', 'pytest_gpu_lease.watchdog',
          '--lockfile', str(lockfile), '--workers', '2',
          '--threshold', '1', '--grace', '2',
-         '--poll_interval', '0.2', '--idle_polls', '15'],
+         '--poll_interval', '0.2'],
         stderr=subprocess.PIPE, text=True)
     try:
         result = pytester.runpytest_subprocess(
             '-n', '2', '--max-worker-restart', '4', '-p', 'xdist', timeout=60)
-        _, watchdog_err = watchdog_proc.communicate(timeout=15)
+        # The watchdog is a service: it is stopped by whoever started it, never
+        # by itself. Doing that here also covers the SIGTERM shutdown path.
+        watchdog_proc.terminate()
+        _, watchdog_err = watchdog_proc.communicate(timeout=30)
     finally:
         if watchdog_proc.poll() is None:
             watchdog_proc.kill()

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -194,42 +194,6 @@ def test_escalation_does_not_sigkill_a_replacement_that_took_the_same_page(tmp_p
         os.close(fd)
 
 
-def test_escalation_is_cancelled_when_the_worker_recovers(tmp_path):
-    """A SIGTERMed worker that got going again must not be SIGKILLed.
-
-    SIGTERM is a stack dump, not a death -- `plugin.py` registers it with
-    faulthandler and chain=False -- so a test that was merely slow rather than
-    wedged can finish inside the grace period. The page then goes back to 0
-    (between tests) or takes a fresh stamp, while the lock and the pid are
-    unchanged, so escalating on those two alone kills a healthy worker.
-    """
-    lockfile = tmp_path / 'gpulock'
-    lockfile.touch()
-    fd = os.open(str(lockfile), os.O_RDWR)
-    pending: dict[int, watchdog._Staged] = {}
-    poll = lambda: watchdog._poll_once(fd, str(lockfile), 1, threshold_ns=10**9,  # noqa: E731
-                                       grace_ns=0, pending=pending)
-
-    child, _, err_file = _spawn_wedge_child(tmp_path, lockfile, tag='_recovers')
-    try:
-        assert poll() is True
-        assert list(pending) == [0], pending
-
-        # The slow test finishes: same process, same lease, fresh heartbeat.
-        os.pwrite(fd, struct.pack('<Q', 0), 0)
-
-        assert poll() is True
-        assert pending == {}, 'a recovered worker must not stay staged for SIGKILL'
-        # grace_ns=0, so any SIGKILL would already have gone out.
-        time.sleep(0.5)
-        assert child.poll() is None, 'SIGKILLed a worker that had recovered'
-    finally:
-        child.kill()
-        child.wait()
-        err_file.close()
-        os.close(fd)
-
-
 @pytest.mark.timeout(30)
 def test_watchdog_never_stops_on_its_own(tmp_path):
     """The service invariant: it does not decide for itself when to stop.

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -51,9 +51,13 @@ page = int(sys.argv[2])
 f = open(lockfile, 'r+b')
 claim = struct.pack(STRUCT_FLOCK, fcntl.F_WRLCK, os.SEEK_SET, PAGE_SIZE * page, PAGE_SIZE, 0)
 fcntl.fcntl(f, fcntl.F_SETLK, claim)
-# Deadline already in the past, so the watchdog acts on its very first poll
-# rather than this test also depending on wall-clock timing to expire one.
-os.pwrite(f.fileno(), struct.pack('<Q', time.monotonic_ns() - 1_000_000_000), PAGE_SIZE * page)
+# Backdate the heartbeat well past any threshold these tests use, so the
+# watchdog acts on its very first poll rather than this test also depending on
+# wall-clock timing to age one out. max(1, ...) because monotonic_ns() is time
+# since boot and could in principle be smaller than the offset -- 1 is still a
+# valid ancient stamp, whereas 0 would read as "between tests" and be skipped.
+os.pwrite(f.fileno(), struct.pack('<Q', max(1, time.monotonic_ns() - 10_000_000_000)),
+          PAGE_SIZE * page)
 faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
 r, w = os.pipe()
 print('READY', flush=True)
@@ -165,7 +169,7 @@ def test_watchdog_waits_indefinitely_before_first_page_is_ever_locked(tmp_path):
     try:
         thread.join(timeout=10)
         assert not thread.is_alive(), \
-            'watchdog did not fire once a page was locked with an expired deadline'
+            'watchdog did not fire once a page was locked with a stale heartbeat'
         ret = child.wait(timeout=5)
     finally:
         if child.poll() is None:
@@ -184,7 +188,9 @@ def test_end_to_end_wedged_worker_is_replaced_and_run_stays_green(pytester, monk
     alongside the nested pytest session exactly as run-test.sh will run it
     (own process, same lock file, `--threshold`/`--grace` sized in seconds
     instead of the real 600s/30s -- this test cannot wait out the real
-    default). Assertions: the wedged worker's stack dump names the wedged
+    default; that the fuse can be shortened from the watchdog's command line
+    alone, with nothing set on the worker side, is the protocol working as
+    intended). Assertions: the wedged worker's stack dump names the wedged
     frame, the other five tests still pass despite that worker being killed
     mid-run, and the session terminates at all -- a leaked lease or a dead
     watchdog would otherwise hang it.
@@ -193,7 +199,6 @@ def test_end_to_end_wedged_worker_is_replaced_and_run_stays_green(pytester, monk
     lockfile.touch()
     monkeypatch.delenv('GPU_LEASE_PIN', raising=False)
     monkeypatch.setenv('GPU_LEASE_LOCKFILE', str(lockfile))
-    monkeypatch.setenv('GPU_LEASE_BUDGET_S', '1')
 
     pytester.makepyfile("""
         import os

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -29,6 +29,7 @@ die on SIGKILL, which no handler can intercept.
 """
 
 import os
+import pathlib
 import signal
 import struct
 import subprocess
@@ -159,8 +160,8 @@ def test_escalation_does_not_sigkill_a_replacement_that_took_the_same_page(tmp_p
     fd = os.open(str(lockfile), os.O_RDWR)
     pending: dict[int, watchdog._Staged] = {}
     # grace_ns=0: the second poll escalates immediately if it is going to at all.
-    poll = lambda: watchdog._poll_once(fd, 1, threshold_ns=10**9, grace_ns=0,
-                                       pending=pending)
+    poll = lambda: watchdog._poll_once(fd, str(lockfile), 1, threshold_ns=10**9,  # noqa: E731
+                                       grace_ns=0, pending=pending)
 
     wedged, _, wedged_err = _spawn_wedge_child(tmp_path, lockfile, tag='_wedged')
     replacement = replacement_err = None
@@ -206,8 +207,8 @@ def test_escalation_is_cancelled_when_the_worker_recovers(tmp_path):
     lockfile.touch()
     fd = os.open(str(lockfile), os.O_RDWR)
     pending: dict[int, watchdog._Staged] = {}
-    poll = lambda: watchdog._poll_once(fd, 1, threshold_ns=10**9, grace_ns=0,  # noqa: E731
-                                       pending=pending)
+    poll = lambda: watchdog._poll_once(fd, str(lockfile), 1, threshold_ns=10**9,  # noqa: E731
+                                       grace_ns=0, pending=pending)
 
     child, _, err_file = _spawn_wedge_child(tmp_path, lockfile, tag='_recovers')
     try:
@@ -355,3 +356,37 @@ def test_a_stale_pidfd_reports_gone_rather_than_signalling_a_reissued_pid(capsys
     finally:
         os.close(pidfd)
     assert 'already gone' in capsys.readouterr().err
+
+
+def test_watchdog_relays_a_wedged_workers_stack_dump(tmp_path, capsys):
+    """The dump reaches the pass's stderr through the watchdog, not directly.
+
+    A worker cannot write it to the shared stream itself: a dump is many small
+    writes, so several workers dumping at once would splice. It writes a file
+    of its own and the watchdog, the one serial writer, relays it before the
+    SIGKILL -- after which nobody is left to ask.
+    """
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    child, _, err_file = _spawn_wedge_child(tmp_path, lockfile, tag='_dump')
+    pathlib.Path(watchdog.dump_path(str(lockfile), child.pid)).write_text(
+        'Current thread 0x00007f00 (most recent call first):\n'
+        '  File "test_flash.py", line 42 in test_wedges_here\n')
+    fd = os.open(str(lockfile), os.O_RDWR)
+    try:
+        pending: dict[int, watchdog._Staged] = {}
+        poll = lambda: watchdog._poll_once(fd, str(lockfile), 1, threshold_ns=10**9,  # noqa: E731
+                                           grace_ns=0, pending=pending)
+        poll()          # stages the SIGTERM
+        poll()          # grace is 0, so this escalates and should relay first
+    finally:
+        child.kill()
+        child.wait()
+        err_file.close()
+        os.close(fd)
+
+    relayed = capsys.readouterr().err
+    assert 'test_wedges_here' in relayed, relayed
+    assert f'stack of pid {child.pid} on GPU 0' in relayed, relayed
+    assert not pathlib.Path(watchdog.dump_path(str(lockfile), child.pid)).exists(), \
+        'the dump must be deleted as soon as it is relayed'

--- a/python/pytest-gpu-lease/tests/test_watchdog.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog.py
@@ -48,6 +48,7 @@ from pytest_gpu_lease.plugin import PAGE_SIZE, STRUCT_FLOCK
 
 lockfile = sys.argv[1]
 page = int(sys.argv[2])
+backdate_ns = int(sys.argv[3])
 f = open(lockfile, 'r+b')
 claim = struct.pack(STRUCT_FLOCK, fcntl.F_WRLCK, os.SEEK_SET, PAGE_SIZE * page, PAGE_SIZE, 0)
 fcntl.fcntl(f, fcntl.F_SETLK, claim)
@@ -56,7 +57,7 @@ fcntl.fcntl(f, fcntl.F_SETLK, claim)
 # wall-clock timing to age one out. max(1, ...) because monotonic_ns() is time
 # since boot and could in principle be smaller than the offset -- 1 is still a
 # valid ancient stamp, whereas 0 would read as "between tests" and be skipped.
-os.pwrite(f.fileno(), struct.pack('<Q', max(1, time.monotonic_ns() - 10_000_000_000)),
+os.pwrite(f.fileno(), struct.pack('<Q', max(1, time.monotonic_ns() - backdate_ns)),
           PAGE_SIZE * page)
 faulthandler.register(signal.SIGTERM, file=sys.stderr, all_threads=True)
 r, w = os.pipe()
@@ -65,13 +66,16 @@ os.read(r, 1)  # blocks forever: nobody ever writes to w
 """
 
 
-def _spawn_wedge_child(tmp_path, lockfile, page=0):
+_STALE_NS = 10_000_000_000
+
+
+def _spawn_wedge_child(tmp_path, lockfile, page=0, backdate_ns=_STALE_NS, tag=''):
     child_script = tmp_path / f'wedge_child_{page}.py'
     child_script.write_text(_WEDGE_CHILD)
-    err_path = tmp_path / f'child_{page}.err'
+    err_path = tmp_path / f'child_{page}{tag}.err'
     err_file = open(err_path, 'wb')
     child = subprocess.Popen(
-        [sys.executable, str(child_script), str(lockfile), str(page)],
+        [sys.executable, str(child_script), str(lockfile), str(page), str(backdate_ns)],
         stdout=subprocess.PIPE, stderr=err_file, text=True)
     assert child.stdout.readline().strip() == 'READY'
     return child, err_path, err_file
@@ -120,6 +124,62 @@ def test_getlk_reports_unlocked_after_holder_is_killed(tmp_path):
     finally:
         os.close(fd)
         err_file.close()
+
+
+@pytest.mark.timeout(30)
+def test_escalation_does_not_sigkill_a_replacement_that_took_the_same_page(tmp_path):
+    """A staged SIGKILL must follow the pid, not the page.
+
+    Regression test. The SIGTERMed worker often dies on its own inside the
+    grace period -- the HIP runtime aborting on a fault is the usual way -- and
+    xdist replaces it. The replacement takes the lowest free page, i.e. very
+    often the one just vacated, and can be heartbeating there well before the
+    grace period is up. Escalating on "page is still locked" alone would then
+    SIGKILL a perfectly healthy worker, drop the entry, and be free to do it
+    again on the next one.
+
+    Driven through `_poll_once` directly so the two halves -- SIGTERM staged,
+    then escalation re-checked -- are two explicit calls rather than a timing
+    coincidence inside `watch()`.
+    """
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    fd = os.open(str(lockfile), os.O_RDWR)
+    pending: dict[int, watchdog._Staged] = {}
+    # grace_ns=0: the second poll escalates immediately if it is going to at all.
+    poll = lambda: watchdog._poll_once(fd, 1, threshold_ns=10**9, grace_ns=0,
+                                       pending=pending)
+
+    wedged, _, wedged_err = _spawn_wedge_child(tmp_path, lockfile, tag='_wedged')
+    replacement = replacement_err = None
+    try:
+        assert poll() is True
+        assert list(pending) == [0] and pending[0].pid == wedged.pid, pending
+
+        wedged.kill()  # the SIGTERMed worker dies on its own, releasing page 0
+        wedged.wait(timeout=5)
+
+        # ...and its replacement takes the same page, with a fresh heartbeat.
+        replacement, _, replacement_err = _spawn_wedge_child(
+            tmp_path, lockfile, backdate_ns=0, tag='_replacement')
+
+        assert poll() is True
+        assert pending == {}, 'stale escalation must be dropped once the pid changes'
+        # `poll()` is not enough: SIGKILL is delivered asynchronously, so a
+        # child signalled a microsecond ago still reads as running. Waiting is
+        # what makes the absence of a kill observable.
+        with pytest.raises(subprocess.TimeoutExpired):
+            replacement.wait(timeout=2)
+    finally:
+        for child in (wedged, replacement):
+            if child is not None and child.poll() is None:
+                child.kill()
+                child.wait()
+        for handle in (wedged_err, replacement_err):
+            if handle is not None:
+                handle.close()
+        os.close(fd)
+
 
 
 @pytest.mark.timeout(30)
@@ -236,3 +296,28 @@ def test_end_to_end_wedged_worker_is_replaced_and_run_stays_green(pytester, monk
     # 5 of the 6 parametrizations never touch the wedge; they must all still
     # pass despite the sixth worker being killed and replaced mid-run.
     assert outcomes.get('passed', 0) >= 5, outcomes
+
+
+def test_a_stale_pidfd_reports_gone_rather_than_signalling_a_reissued_pid(capsys):
+    """The identity half of the escalation guard, in isolation.
+
+    `_getlk` says whether a page still needs its holder killed, but there is
+    always a gap between that answer and the signal, and a pid reaped inside
+    that gap can be reissued to anything. A pidfd names one process for the
+    life of the fd, so the worst case degrades from "SIGKILL an innocent
+    process" to "ESRCH, and say so".
+
+    Deliberately not asserting that some bystander survived: pid reuse cannot
+    be forced on demand, so this checks the property that makes reuse
+    unreachable instead of trying to stage it.
+    """
+    victim = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])
+    pidfd = watchdog._pidfd_open(victim.pid)
+    assert pidfd is not None, 'expected pidfd support on this kernel'
+    victim.kill()
+    victim.wait(timeout=10)   # dead *and* reaped: the number is free to be reissued
+    try:
+        watchdog._send(victim.pid, signal.SIGKILL, 'stale handle', pidfd)
+    finally:
+        os.close(pidfd)
+    assert 'already gone' in capsys.readouterr().err

--- a/python/pytest-gpu-lease/tests/test_watchdog_gpu.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog_gpu.py
@@ -178,21 +178,22 @@ if _TEST_LEVEL >= 1:
         monkeypatch.setenv('GPU_LEASE_LOCKFILE', str(lockfile))
         pytester.makepyfile(_WATCHDOG_SUITE)
 
-        # idle_polls is deliberately generous. A replacement worker re-imports
-        # torch before it reaches its first test and takes a lease, so with both
-        # workers killed at once the lock file can legitimately show no locks
-        # for several seconds; a short idle window would let the watchdog
-        # self-exit mid-run.
         watchdog = subprocess.Popen(
             [sys.executable, '-m', 'pytest_gpu_lease.watchdog',
              '--lockfile', str(lockfile), '--workers', '2',
              '--threshold', '10', '--grace', '5',
-             '--poll_interval', '1', '--idle_polls', '30'],
+             '--poll_interval', '1'],
             stderr=subprocess.PIPE, text=True)
         try:
             result = pytester.runpytest_subprocess(
                 '-n', '2', '--max-worker-restart', '9999', '-p', 'xdist', timeout=300)
-            _, watchdog_err = watchdog.communicate(timeout=120)
+            # Stopped from outside, like run-test.sh does: the watchdog never
+            # decides on its own that a pass is over. This run is the case that
+            # would have fooled a rule based on an idle lock file -- both
+            # workers are killed at once, and neither replacement holds a lease
+            # until it has re-imported torch.
+            watchdog.terminate()
+            _, watchdog_err = watchdog.communicate(timeout=60)
         finally:
             if watchdog.poll() is None:
                 watchdog.kill()

--- a/python/pytest-gpu-lease/tests/test_watchdog_gpu.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog_gpu.py
@@ -1,0 +1,174 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""End-to-end watchdog test against a genuinely wedged GPU.
+
+Everything else in this package wedges a process with `os.read` on an empty
+pipe, which proves the signalling but not the thing the feature exists for: a
+Triton kernel that never retires, a device sync that therefore never returns,
+and a worker that no in-process timeout can interrupt. That is what this file
+reproduces.
+
+Opt-in via ``GPU_LEASE_GPU_TESTS=1``. It occupies two GPUs for about a minute
+and deliberately hangs kernels on them, so it must not run by accident
+alongside a real pass -- the nested session leases from its own lock file and
+so cannot see, or be seen by, a pass already using those devices.
+
+Measured on gfx1201 before this was written, since the whole design rests on
+it: the wedged process sits in `R` (spinning in userspace on the sync, not
+uninterruptible), SIGKILL reaps it in 0.11s, and the GPU is immediately
+reusable afterwards -- two subsequent workloads on the same device passed.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytest_plugins = ['pytester']
+
+_OPT_IN = 'GPU_LEASE_GPU_TESTS'
+
+
+def _skip_reason() -> str | None:
+    if not os.getenv(_OPT_IN):
+        return f'set {_OPT_IN}=1 to run (hangs two GPUs for ~1 minute)'
+    try:
+        import torch
+        import triton  # noqa: F401
+    except ImportError as exc:
+        return f'needs torch and triton ({exc})'
+    if not torch.cuda.is_available():
+        return 'needs a GPU'
+    if torch.cuda.device_count() < 2:
+        return 'needs 2 GPUs: the nested session runs -n 2'
+    return None
+
+
+_SKIP = _skip_reason()
+pytestmark = pytest.mark.skipif(_SKIP is not None, reason=_SKIP or '')
+
+
+# The nested suite. `good` and `bad` differ only in the spin count handed to
+# one kernel -- same launch, same comparison afterwards -- so the wedge is
+# reached the way a real test reaches it: by comparing a GPU result, which
+# syncs, rather than by calling synchronize() explicitly.
+_NESTED_SUITE = '''
+import torch
+import triton
+import triton.language as tl
+
+import pytest
+
+
+@triton.jit
+def vecadd_spin(x_ptr, y_ptr, out_ptr, spin_ptr, n, BLOCK: tl.constexpr):
+    """out = x + y, after spinning `*spin_ptr` times.
+
+    The trip count is read from device memory so it cannot be constant-folded,
+    and the body is a floating-point recurrence feeding the store, so it can
+    be neither strength-reduced (fp add/mul are not associative, so the closed
+    form is not a legal rewrite) nor deleted as dead. At spin=0 the loop does
+    not execute and the kernel is an ordinary vector add.
+    """
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n
+    acc = tl.load(x_ptr + offs, mask=mask, other=0.0) + tl.load(y_ptr + offs, mask=mask, other=0.0)
+    limit = tl.load(spin_ptr)
+    i = tl.zeros((), dtype=tl.int64)
+    while i < limit:
+        acc = acc * 0.9999999 + 1.0
+        i += 1
+    tl.store(out_ptr + offs, acc, mask=mask)
+
+
+def _vecadd(device, spin):
+    n = 4096
+    x = torch.rand(n, device=device)
+    y = torch.rand(n, device=device)
+    out = torch.empty_like(x)
+    spin_t = torch.tensor([spin], dtype=torch.int64, device=device)
+    vecadd_spin[(triton.cdiv(n, 1024),)](x, y, out, spin_t, n, BLOCK=1024)
+    # The sync that hangs. Comparing the result is what a normal test does, and
+    # it is what forces the device sync -- calling synchronize() by hand would
+    # work too but would not resemble the workload this protects.
+    torch.testing.assert_close(out, x + y)
+
+
+@pytest.fixture(scope='session')
+def warm_device(gpu_device):
+    """Bind this worker to its leased GPU, then compile the kernel once.
+
+    set_device is not optional. Tensors carry their device, but Triton launches
+    on the *current* one, so leasing cuda:1 and never setting it launches the
+    kernel on device 0 against device-1 pointers -- which faults the GPU
+    ("Memory access fault ... kernel: vecadd_spin") rather than failing
+    cleanly, and looks nothing like the wedge under test.
+
+    Compiling here keeps JIT out of the timed window. Measured cold at 1.1s,
+    far under the threshold, but a slower machine should not be able to fail
+    this test for a reason unrelated to what it checks.
+    """
+    torch.cuda.set_device(gpu_device)
+    _vecadd(gpu_device, 0)
+    return gpu_device
+
+
+@pytest.mark.parametrize('kind', ['good', 'bad', 'bad', 'good'])
+def test_vecadd(kind, warm_device):
+    _vecadd(warm_device, 0 if kind == 'good' else 2 ** 50)
+'''
+
+
+def test_wedged_gpu_worker_is_killed_and_session_survives(pytester, monkeypatch, tmp_path):
+    """Two of four tests hang the GPU; the run must still finish, correctly.
+
+    Checks, in order of what would hurt most to lose:
+
+    * no INTERNALERROR -- the failure mode that ended a real pass at 80%, and
+      the reason `_tolerate_closed_worker_channel` exists. Two workers dying
+      close together is exactly how that race is reached.
+    * both `good` tests pass, including any that had to be requeued off a
+      killed worker.
+    * the watchdog escalated: SIGTERM first (faulthandler turns it into a
+      stack dump rather than a death, so the wedged worker survives it), then
+      SIGKILL once the grace period expires.
+    """
+    lockfile = tmp_path / 'gpulock'
+    lockfile.touch()
+    monkeypatch.delenv('GPU_LEASE_PIN', raising=False)
+    monkeypatch.setenv('GPU_LEASE_LOCKFILE', str(lockfile))
+    pytester.makepyfile(_NESTED_SUITE)
+
+    # idle_polls is deliberately generous. A replacement worker re-imports
+    # torch before it reaches its first test and takes a lease, so with both
+    # workers killed at once the lock file can legitimately show no locks for
+    # several seconds; a short idle window would let the watchdog self-exit
+    # mid-run.
+    watchdog = subprocess.Popen(
+        [sys.executable, '-m', 'pytest_gpu_lease.watchdog',
+         '--lockfile', str(lockfile), '--workers', '2',
+         '--threshold', '10', '--grace', '5',
+         '--poll_interval', '1', '--idle_polls', '30'],
+        stderr=subprocess.PIPE, text=True)
+    try:
+        result = pytester.runpytest_subprocess(
+            '-n', '2', '--max-worker-restart', '9999', '-p', 'xdist', timeout=300)
+        _, watchdog_err = watchdog.communicate(timeout=120)
+    finally:
+        if watchdog.poll() is None:
+            watchdog.kill()
+            watchdog.communicate()
+
+    assert result.ret is not None, 'nested session never terminated'
+
+    transcript = '\n'.join(result.outlines + result.errlines)
+    assert 'INTERNALERROR' not in transcript, transcript[-4000:]
+
+    outcomes = result.parseoutcomes()
+    assert outcomes.get('passed', 0) == 2, (outcomes, transcript[-4000:])
+
+    assert watchdog_err.count('SIGTERM') >= 2, watchdog_err
+    assert watchdog_err.count('SIGKILL') >= 2, watchdog_err

--- a/python/pytest-gpu-lease/tests/test_watchdog_gpu.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog_gpu.py
@@ -1,7 +1,7 @@
 # Copyright © 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""End-to-end watchdog test against a genuinely wedged GPU.
+"""End-to-end watchdog tests against a genuinely wedged GPU.
 
 Everything else in this package wedges a process with `os.read` on an empty
 pipe, which proves the signalling but not the thing the feature exists for: a
@@ -9,18 +9,27 @@ Triton kernel that never retires, a device sync that therefore never returns,
 and a worker that no in-process timeout can interrupt. That is what this file
 reproduces.
 
-Opt-in via ``GPU_LEASE_GPU_TESTS=1``. It occupies two GPUs for about a minute
-and deliberately hangs kernels on them, so it must not run by accident
-alongside a real pass -- the nested session leases from its own lock file and
-so cannot see, or be seen by, a pass already using those devices.
+Nothing here runs by default. ``GPU_LEASE_TEST_LEVEL`` selects what is defined
+at all, in the spirit of the flash suite's ``FOR_RELEASE``:
 
-Measured on gfx1201 before this was written, since the whole design rests on
-it: the wedged process sits in `R` (spinning in userspace on the sync, not
-uninterruptible), SIGKILL reaps it in 0.11s, and the GPU is immediately
-reusable afterwards -- two subsequent workloads on the same device passed.
+* ``0`` (default) -- this module defines no tests.
+* ``1`` -- the watchdog test. Hangs two GPUs for about a minute.
+* ``2`` -- also the pytest-timeout control, which additionally needs
+  pytest-timeout installed (this repo no longer depends on it) and hangs one
+  GPU for as long as it takes to prove a timeout did not fire.
+
+They are off by default because they deliberately hang kernels on shared
+devices, and because the nested sessions lease from their own lock file and so
+cannot see -- or be seen by -- a real pass already using those GPUs.
+
+Measured on gfx1201 before any of this was written, since the whole design
+rests on it: the wedged process sits in `R` (spinning in userspace on the
+sync, not uninterruptible), SIGKILL reaps it in 0.11s, and the GPU is
+immediately reusable afterwards.
 """
 
 import os
+import re
 import subprocess
 import sys
 
@@ -28,12 +37,10 @@ import pytest
 
 pytest_plugins = ['pytester']
 
-_OPT_IN = 'GPU_LEASE_GPU_TESTS'
+_TEST_LEVEL = int(os.getenv('GPU_LEASE_TEST_LEVEL', '0'))
 
 
-def _skip_reason() -> str | None:
-    if not os.getenv(_OPT_IN):
-        return f'set {_OPT_IN}=1 to run (hangs two GPUs for ~1 minute)'
+def _hardware_skip_reason() -> str | None:
     try:
         import torch
         import triton  # noqa: F401
@@ -46,15 +53,19 @@ def _skip_reason() -> str | None:
     return None
 
 
-_SKIP = _skip_reason()
-pytestmark = pytest.mark.skipif(_SKIP is not None, reason=_SKIP or '')
+# Level decides what exists; hardware decides whether it can run. Kept apart so
+# that asking for these tests on a machine without GPUs reports why, instead of
+# silently collecting nothing. Not evaluated at level 0, where importing torch
+# would be pure cost for a module that defines nothing.
+_HW_SKIP = _hardware_skip_reason() if _TEST_LEVEL >= 1 else None
+pytestmark = pytest.mark.skipif(_HW_SKIP is not None, reason=_HW_SKIP or '')
 
 
-# The nested suite. `good` and `bad` differ only in the spin count handed to
-# one kernel -- same launch, same comparison afterwards -- so the wedge is
-# reached the way a real test reaches it: by comparing a GPU result, which
-# syncs, rather than by calling synchronize() explicitly.
-_NESTED_SUITE = '''
+# Shared by both nested suites below: the kernel, and the fixture that binds a
+# worker to its leased GPU. `good` and `bad` differ only in the spin count
+# handed to this one kernel -- same launch, same comparison afterwards -- so the
+# wedge is reached the way a real test reaches it, by comparing a GPU result.
+_KERNEL = '''
 import torch
 import triton
 import triton.language as tl
@@ -84,6 +95,9 @@ def vecadd_spin(x_ptr, y_ptr, out_ptr, spin_ptr, n, BLOCK: tl.constexpr):
     tl.store(out_ptr + offs, acc, mask=mask)
 
 
+WEDGE = 2 ** 50   # ~1e15 iterations: no wall clock will outlast it
+
+
 def _vecadd(device, spin):
     n = 4096
     x = torch.rand(n, device=device)
@@ -108,67 +122,195 @@ def warm_device(gpu_device):
     cleanly, and looks nothing like the wedge under test.
 
     Compiling here keeps JIT out of the timed window. Measured cold at 1.1s,
-    far under the threshold, but a slower machine should not be able to fail
-    this test for a reason unrelated to what it checks.
+    far under any threshold used here, but a slower machine should not be able
+    to fail these tests for a reason unrelated to what they check.
     """
     torch.cuda.set_device(gpu_device)
     _vecadd(gpu_device, 0)
     return gpu_device
-
-
-@pytest.mark.parametrize('kind', ['good', 'bad', 'bad', 'good'])
-def test_vecadd(kind, warm_device):
-    _vecadd(warm_device, 0 if kind == 'good' else 2 ** 50)
 '''
 
 
-def test_wedged_gpu_worker_is_killed_and_session_survives(pytester, monkeypatch, tmp_path):
-    """Two of four tests hang the GPU; the run must still finish, correctly.
+_WATCHDOG_SUITE = _KERNEL + '''
 
-    Checks, in order of what would hurt most to lose:
+@pytest.mark.parametrize('kind', ['good', 'bad', 'bad', 'good'])
+def test_vecadd(kind, warm_device):
+    _vecadd(warm_device, 0 if kind == 'good' else WEDGE)
+'''
 
-    * no INTERNALERROR -- the failure mode that ended a real pass at 80%, and
-      the reason `_tolerate_closed_worker_channel` exists. Two workers dying
-      close together is exactly how that race is reached.
-    * both `good` tests pass, including any that had to be requeued off a
-      killed worker.
-    * the watchdog escalated: SIGTERM first (faulthandler turns it into a
-      stack dump rather than a death, so the wedged worker survives it), then
-      SIGKILL once the grace period expires.
-    """
-    lockfile = tmp_path / 'gpulock'
-    lockfile.touch()
-    monkeypatch.delenv('GPU_LEASE_PIN', raising=False)
-    monkeypatch.setenv('GPU_LEASE_LOCKFILE', str(lockfile))
-    pytester.makepyfile(_NESTED_SUITE)
 
-    # idle_polls is deliberately generous. A replacement worker re-imports
-    # torch before it reaches its first test and takes a lease, so with both
-    # workers killed at once the lock file can legitimately show no locks for
-    # several seconds; a short idle window would let the watchdog self-exit
-    # mid-run.
-    watchdog = subprocess.Popen(
-        [sys.executable, '-m', 'pytest_gpu_lease.watchdog',
-         '--lockfile', str(lockfile), '--workers', '2',
-         '--threshold', '10', '--grace', '5',
-         '--poll_interval', '1', '--idle_polls', '30'],
-        stderr=subprocess.PIPE, text=True)
-    try:
-        result = pytester.runpytest_subprocess(
-            '-n', '2', '--max-worker-restart', '9999', '-p', 'xdist', timeout=300)
-        _, watchdog_err = watchdog.communicate(timeout=120)
-    finally:
-        if watchdog.poll() is None:
-            watchdog.kill()
-            watchdog.communicate()
+# Runs in definition order, and the order is the point: a passing test, then a
+# Python-level hang that pytest-timeout must catch, then a GPU hang it cannot.
+_TIMEOUT_CONTROL_SUITE = _KERNEL + '''
+import time
 
-    assert result.ret is not None, 'nested session never terminated'
 
-    transcript = '\n'.join(result.outlines + result.errlines)
-    assert 'INTERNALERROR' not in transcript, transcript[-4000:]
+def test_vecadd_good(warm_device):
+    _vecadd(warm_device, 0)
 
-    outcomes = result.parseoutcomes()
-    assert outcomes.get('passed', 0) == 2, (outcomes, transcript[-4000:])
 
-    assert watchdog_err.count('SIGTERM') >= 2, watchdog_err
-    assert watchdog_err.count('SIGKILL') >= 2, watchdog_err
+def test_python_level_hang(warm_device):
+    time.sleep(3600)
+
+
+def test_vecadd_wedged(warm_device):
+    _vecadd(warm_device, WEDGE)
+'''
+
+
+if _TEST_LEVEL >= 1:
+    def test_wedged_gpu_worker_is_killed_and_session_survives(pytester, monkeypatch, tmp_path):
+        """Two of four tests hang the GPU; the run must still finish, correctly.
+
+        Checks, in order of what would hurt most to lose:
+
+        * no INTERNALERROR -- the failure mode that ended a real pass at 80%,
+          and the reason `_tolerate_closed_worker_channel` exists. Two workers
+          dying close together is exactly how that race is reached.
+        * both `good` tests pass, including any requeued off a killed worker.
+        * the watchdog escalated: SIGTERM first (faulthandler turns it into a
+          stack dump rather than a death, so the wedged worker survives it),
+          then SIGKILL once the grace period expires.
+        """
+        lockfile = tmp_path / 'gpulock'
+        lockfile.touch()
+        monkeypatch.delenv('GPU_LEASE_PIN', raising=False)
+        monkeypatch.setenv('GPU_LEASE_LOCKFILE', str(lockfile))
+        pytester.makepyfile(_WATCHDOG_SUITE)
+
+        # idle_polls is deliberately generous. A replacement worker re-imports
+        # torch before it reaches its first test and takes a lease, so with both
+        # workers killed at once the lock file can legitimately show no locks
+        # for several seconds; a short idle window would let the watchdog
+        # self-exit mid-run.
+        watchdog = subprocess.Popen(
+            [sys.executable, '-m', 'pytest_gpu_lease.watchdog',
+             '--lockfile', str(lockfile), '--workers', '2',
+             '--threshold', '10', '--grace', '5',
+             '--poll_interval', '1', '--idle_polls', '30'],
+            stderr=subprocess.PIPE, text=True)
+        try:
+            result = pytester.runpytest_subprocess(
+                '-n', '2', '--max-worker-restart', '9999', '-p', 'xdist', timeout=300)
+            _, watchdog_err = watchdog.communicate(timeout=120)
+        finally:
+            if watchdog.poll() is None:
+                watchdog.kill()
+                watchdog.communicate()
+
+        assert result.ret is not None, 'nested session never terminated'
+
+        transcript = '\\n'.join(result.outlines + result.errlines)
+        assert 'INTERNALERROR' not in transcript, transcript[-4000:]
+
+        outcomes = result.parseoutcomes()
+        assert outcomes.get('passed', 0) == 2, (outcomes, transcript[-4000:])
+
+        assert watchdog_err.count('SIGTERM') >= 2, watchdog_err
+        assert watchdog_err.count('SIGKILL') >= 2, watchdog_err
+
+
+if _TEST_LEVEL >= 2:
+    # Long enough that a slow machine cannot make it fire late by accident,
+    # short enough that the wall clock below is many times it.
+    _CONTROL_TIMEOUT_S = 5
+    _CONTROL_WALL_S = 40
+
+    def _verdict(transcript: str, name: str) -> str | None:
+        """The PASSED/FAILED/ERROR pytest recorded for `name`, or None.
+
+        Scoped to the span between this test's `-v` line and the next one. The
+        lease announcement goes to stderr, unbuffered, and lands between a test
+        name and its verdict, so a search that just scans forward from the name
+        would run past the end of the test and pick up its successor's verdict
+        -- which for the wedged test is the difference between "no verdict, as
+        predicted" and a false pass.
+        """
+        segment = re.search(rf'::{re.escape(name)}\b(.*?)(?=^\S+\.py::|\Z)',
+                            transcript, re.S | re.M)
+        if segment is None:
+            return None
+        found = re.search(r'\b(PASSED|FAILED|ERROR)\b', segment.group(1))
+        return found.group(1) if found else None
+
+    def test_pytest_timeout_cannot_interrupt_a_wedged_kernel(pytester, tmp_path):
+        """Control for the watchdog: show pytest-timeout does not cover this.
+
+        This is the claim the whole feature rests on -- a Level-3 pass ran
+        265,282 tests in 15h46m under `--timeout=300` and reported zero
+        timeouts -- so it is worth demonstrating rather than asserting.
+        pytest-timeout's signal method arms `setitimer(ITIMER_REAL)` and raises
+        from a SIGALRM handler, and CPython runs a Python-level signal handler
+        only when the main thread reaches a bytecode boundary. A thread inside
+        an unreturning device sync reaches none.
+
+        Both halves matter. A run where the timeout simply never fires proves
+        nothing -- the plugin might not be loaded, or the option misspelled --
+        so the same session first hangs in `time.sleep`, where the timeout
+        *must* fire. What separates the two cases is only where the main
+        thread is parked.
+
+        Deliberately without xdist: nothing here should be attributable to the
+        combination pytest#2223 warns about.
+        """
+        pytest.importorskip(
+            'pytest_timeout',
+            reason='the control needs the very plugin the repo dropped; '
+                   'pip install pytest-timeout to run it')
+        import torch
+
+        nested = pytester.makepyfile(_TIMEOUT_CONTROL_SUITE)
+        transcript_path = tmp_path / 'nested.out'
+
+        env = dict(os.environ)
+        env.pop('GPU_LEASE_LOCKFILE', None)
+        # Pin rather than lease: with no xdist there is nothing to coordinate,
+        # and pinning keeps this off the lock file entirely. Highest ordinal on
+        # the theory that a pass, if one is running, started at 0.
+        env['GPU_LEASE_PIN'] = str(torch.cuda.device_count() - 1)
+        # Without this the transcript is block-buffered and lost when we kill
+        # the process -- which we always do, since it never finishes.
+        env['PYTHONUNBUFFERED'] = '1'
+
+        with open(transcript_path, 'w') as sink:
+            proc = subprocess.Popen(
+                [sys.executable, '-m', 'pytest', str(nested), '-v',
+                 '-p', 'no:xdist', '-p', 'no:cacheprovider',
+                 '--timeout', str(_CONTROL_TIMEOUT_S), '--timeout-method', 'signal'],
+                stdout=sink, stderr=subprocess.STDOUT, cwd=str(pytester.path), env=env)
+            try:
+                proc.wait(timeout=_CONTROL_WALL_S)
+                finished = True
+            except subprocess.TimeoutExpired:
+                finished = False
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait(timeout=60)
+
+        transcript = transcript_path.read_text()
+
+        # pytest-timeout is loaded and armed the way this test intends. Checked
+        # from the header rather than from a "Timeout >5.0s" message, because
+        # that message lives in the FAILURES section, which a session killed
+        # mid-test never prints.
+        assert f'timeout: {float(_CONTROL_TIMEOUT_S)}s' in transcript, transcript[-3000:]
+        assert 'timeout method: signal' in transcript, transcript[-3000:]
+
+        # The GPU is fine and the kernel is right: the ordinary case passes.
+        assert _verdict(transcript, 'test_vecadd_good') == 'PASSED', transcript[-3000:]
+
+        # ...and the timeout does fire, when the main thread is in Python.
+        assert _verdict(transcript, 'test_python_level_hang') == 'FAILED', \
+            f'pytest-timeout did not fire on time.sleep\n{transcript[-3000:]}'
+
+        # Same timeout, same session, same vecadd kernel -- only the spin count
+        # differs from the passing case above. No verdict at all, and the
+        # session had to be killed from outside.
+        assert 'test_vecadd_wedged' in transcript, transcript[-3000:]
+        assert _verdict(transcript, 'test_vecadd_wedged') is None, \
+            f'expected no verdict for the wedged test, got one:\n{transcript[-3000:]}'
+        assert not finished, (
+            f'the wedged test was expected to outlast a {_CONTROL_TIMEOUT_S}s timeout '
+            f'for the full {_CONTROL_WALL_S}s, but the session exited on its own\n'
+            f'{transcript[-3000:]}')

--- a/python/pytest-gpu-lease/tests/test_watchdog_gpu.py
+++ b/python/pytest-gpu-lease/tests/test_watchdog_gpu.py
@@ -168,9 +168,10 @@ if _TEST_LEVEL >= 1:
           and the reason `_tolerate_closed_worker_channel` exists. Two workers
           dying close together is exactly how that race is reached.
         * both `good` tests pass, including any requeued off a killed worker.
-        * the watchdog escalated: SIGTERM first (faulthandler turns it into a
-          stack dump rather than a death, so the wedged worker survives it),
-          then SIGKILL once the grace period expires.
+        * the watchdog acted: a SIGTERM per wedged worker, and a stack dump
+          relayed for each. SIGTERM is expected to end them -- faulthandler
+          runs with chain=True -- so SIGKILL is the last resort and normally
+          does not appear at all.
         """
         lockfile = tmp_path / 'gpulock'
         lockfile.touch()
@@ -207,8 +208,10 @@ if _TEST_LEVEL >= 1:
         outcomes = result.parseoutcomes()
         assert outcomes.get('passed', 0) == 2, (outcomes, transcript[-4000:])
 
-        assert watchdog_err.count('SIGTERM') >= 2, watchdog_err
-        assert watchdog_err.count('SIGKILL') >= 2, watchdog_err
+        assert watchdog_err.count('sent SIGTERM') >= 2, watchdog_err
+        # The dump is the point of the SIGTERM; assert it arrived rather than
+        # asserting on SIGKILL, which a worker that obeys SIGTERM never needs.
+        assert watchdog_err.count('stack of pid') >= 2, watchdog_err
 
 
 if _TEST_LEVEL >= 2:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,5 @@
 tqdm
 pytest-xdist>=1.15  # Need worker_id fixture to identify GPU
 pytest-select
-pytest-timeout
 filelock
 ./python/pytest-gpu-lease


### PR DESCRIPTION
# Overview

This PR replaces pytest-timeout with a watchdog service to monitor the
heartbeat information supplied by the pytest-xdist workers into the GPU lease
lock file.

Right now `pytest-xdist`+`pytest-timeout` is not safe from indefinitely
running kernels, and pytest-timeout will not work since a Python signal
handler is only called when the main thread reaches a bytecode boundary, which
a thread parked in a HIP call never does.

Meanwhile `--timeout-method=thread` creates one thread for every testing case,
which is expensive and still error prone: the thread still runs inside the
worker process.

The watchdog process added by this PR detects the stall from *outside* the
wedged process and escalates SIGTERM then SIGKILL, turning an indefinite wedge
into a fast, attributed failure with a stack dump.

## Major Changes

* [`gpu_lease`] Heartbeat each worker's lease page, so a wedge is
  visible without any cooperation from the wedged process.
  + Use env var `GPU_LEASE_LOCKFILE` as the lock file, if specified.
    - watchdog starts earlier than pytest.
    - Also gates the stack dump below: with no watchdog, nothing reads one.
  + Protocol: an 8-byte `time.monotonic_ns()` stamp at the page base, then the
    pid that wrote it. Stamp rewritten before every test and zeroed after; zero
    means "between tests".
    - The pid is what stops a replacement being killed for the expired stamp it
      inherits on the page the watchdog just cleared. Written stamp-first so a
      half-written pair reads as (new stamp, old pid) and is skipped.
    - Note this protocol is not free from pid rollover (which is rare).
  + Registers SIGTERM with `faulthandler` to dump the stack into a per-pid
    file, prefixed with `GPU_LEASE_LOCKFILE`.
    - `faulthandler` is pure C without the GIL, and hence cannot forward the
      dump to pytest through execnet pipes.
    - Worker will terminate after the dump (`chain=True`).
* [`watchdog`] New `python -m pytest_gpu_lease.watchdog`: polls the lock file
  and escalates SIGTERM, a grace period, then SIGKILL on an expired page.
  + pid is retrieved from `fcntl(F_GETLK)` but the signal is sent through
    a pidfd to avoid a time-of-check-to-time-of-use race. There is no way to
    verify that the pid still refers to the same process.
    - So it needs Linux 5.3+, and asserts at import rather than degrading to
      `os.kill`. Narrower than ROCm, which still supports RHEL 8.10; see [ci].
  + A service: never stops on its own and removes the lock file and any dumps
    on SIGTERM.
  + Relays the per-pid stack dump written by `gpu_lease` in the worker process
    to stderr.
* [ci] Rewrite `run-test.sh` into an orchestrator of pytest-xdist and watchdog.
  + Run watchdog and pytest in background and stop both with SIGTERM
    - Need to trap all signals. Trapping EXIT is not enough.
  + Reuse pass's `.err` file.
  + Fatal if a watchdog was wanted and did not start, unless the watchdog is
    opted out with `USE_WATCHDOG=0`.
  + `watchdog` is automatically disabled on systems without pidfd (notably,
    RHEL 8.10).
  + Accepts `-k EXPR` and passes it through to pytest.
* [test] Two GPU tests, opt-in via `GPU_LEASE_TEST_LEVEL` (0 none, 1 the
  watchdog test, 2 also the pytest-timeout control); they hang real GPUs.
  + The control demonstrates the premise rather than asserting it: in one
    session under `--timeout=5`, a `time.sleep` hang IS caught and a wedged
    Triton kernel is NOT — same kernel and launch, only the spin count differs.

## Minor Changes

* [`gpu_lease`] Fix `STRUCT_FLOCK`: it should be `hhqqi`.
  - Also assert `sizeof(off_t) == 8`. No plan to support 32-bit `off_t`.
* [`gpu_lease`] Guard xdist's `WorkerController.sendcommand` against an
  already-closed peer channel, applied from `pytest_configure` — xdist itself
  is not modified or pinned.
  + `worker_errordown -> remove_node -> check_schedule -> _send_tests` raises
    `OSError: cannot send (already closed?)` as an INTERNALERROR that ends the
    session; one real pass died at 80% with 65,169 tests never dispatched.
  + Usually triggered by several stalled workers being killed at once, which a
    watchdog makes *more* likely — hence the fix ships alongside.
  + Patched at `sendcommand` because every `--dist` mode funnels through it and
    `WorkerController.shutdown` already wraps it in the same `except OSError`.
  + Only a peer that has gone: channel closed, or EPIPE/EBADF/ECONNRESET/
    ESHUTDOWN. Anything else re-raises, so a full disk is not filed as a
    crashed worker and its tests quietly dropped.
* [requirements-dev.txt] remove `pytest-timeout`.

## Note

The design rests on behaviour measured on 4x gfx1201, not assumed: a wedged
process sits in `R`, spinning in userspace on the sync rather than
uninterruptible `D`; SIGKILL reaps it in 0.11s; and the GPU is immediately
reusable by the replacement worker.

# Known Issues

* [ci] `pytest-timeout` still loads until it is uninstalled from existing venvs.
* [test] The watchdog will not work if `-k` selects only tests that do not use
  the `gpu_id` fixture.
  + Intentional: not all tests need the watchdog.
* [test] The pytest-timeout control test needs the plugin this branch
  deliberately drops.
* [`pytest_gpu_lease`] The package is installed non-editable, so it must be
  reinstalled for changes to take effect.
* [ci] `kill -9` on the CI script leaves the watchdog running and its
  `/dev/shm` lock file and stack dumps behind, since no trap can catch
  SIGKILL. The orphan is inert — its lock file fd is opened once, so it polls a
  deleted inode, sees no locks and signals nothing — but it has to be cleared
  by hand. `ps` names the file it was watching.
* The INTERNALERROR is not expected to stop as a result of removing
  pytest-timeout — it comes from GPU aborts, not from that plugin. Those
  short-sequence aborts are upstream's, and those tests stay red.
