### PR TITLE
Fix various race conditions

### DIFF
--- a/include/aotriton/_internal/aiter_hip_common.h
+++ b/include/aotriton/_internal/aiter_hip_common.h
@@ -104,6 +104,8 @@ public:
   AiterAsmKernel(const char* name, const char* hsaco);
   ~AiterAsmKernel();
   void launch_kernel(const AiterAsmKernelArgs& kargs);
+  // Writes path_cache_ on first call. Caller ensures thread safety; the lazy
+  // callback of OnDeviceKernel::get_kernel already runs under its write lock.
   pstring_view get_package_path(hipStream_t stream, pstring_type& persistant_storage, std::string& aiter_module) const;
 };
 

--- a/include/aotriton/_internal/on_device_kernel.h
+++ b/include/aotriton/_internal/on_device_kernel.h
@@ -59,9 +59,8 @@ public:
   }
   ~OnDeviceKernel();
 
-  // TODO: Make it const and add mutable to members
-  // Essentials is returned by value. A reference to essentials_ outlives the
-  // lock that guards it, and clear_decompressed_image() invalidates .image.
+  // CAVEAT: calling clear_decompressed_image will also invalidate Essentials.image.
+  //         clear_decompressed_image/clear_device_kernel route is not well-tested and should be avoided in production.
   std::tuple<hipFunction_t, Essentials> get_kernel(int device_id,
                                                    std::function<OnDiskKernelInfo()> lazy);
   void clear_device_kernel();

--- a/include/aotriton/_internal/on_device_kernel.h
+++ b/include/aotriton/_internal/on_device_kernel.h
@@ -60,8 +60,10 @@ public:
   ~OnDeviceKernel();
 
   // TODO: Make it const and add mutable to members
-  std::tuple<hipFunction_t, const Essentials&> get_kernel(int device_id,
-                                                          std::function<OnDiskKernelInfo()> lazy);
+  // Essentials is returned by value. A reference to essentials_ outlives the
+  // lock that guards it, and clear_decompressed_image() invalidates .image.
+  std::tuple<hipFunction_t, Essentials> get_kernel(int device_id,
+                                                   std::function<OnDiskKernelInfo()> lazy);
   void clear_device_kernel();
   void clear_decompressed_image();
 #if AOTRITON_BUILD_FOR_TUNING

--- a/include/aotriton/_internal/on_device_kernel.h
+++ b/include/aotriton/_internal/on_device_kernel.h
@@ -59,6 +59,7 @@ public:
   }
   ~OnDeviceKernel();
 
+  // TODO: Make it const and add mutable to members
   // CAVEAT: calling clear_decompressed_image will also invalidate Essentials.image.
   //         clear_decompressed_image/clear_device_kernel route is not well-tested and should be avoided in production.
   std::tuple<hipFunction_t, Essentials> get_kernel(int device_id,

--- a/modules/flash/csrc/aiter/mha_fwd.cc
+++ b/modules/flash/csrc/aiter/mha_fwd.cc
@@ -215,8 +215,7 @@ float fmha_fwd_v3(mha_fwd_args a, const ck_tile::stream_config& s)
 
     AiterAsmKernel* impl_ptr = nullptr;
     static std::mutex impl_ptr_mutex;
-    static thread_local std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>>
-        impl_ptr_map;
+    static std::unordered_map<std::string, std::unique_ptr<AiterAsmKernel>> impl_ptr_map;
 #define LOCK_IMPL_PTR_MAP   std::lock_guard<std::mutex> lock(impl_ptr_mutex)
 
     const auto& cfg     = it->second;

--- a/v3src/aiter_hip_common.cc
+++ b/v3src/aiter_hip_common.cc
@@ -42,8 +42,8 @@ AiterAsmKernel::launch_kernel(const AiterAsmKernelArgs& kargs) {
                      HIP_LAUNCH_PARAM_BUFFER_SIZE,
                      kargs.arg_size_ptr,
                      HIP_LAUNCH_PARAM_END };
-  int device_id;
-  AOTRITON_HIP_CHECK_RETURN(hipGetDevice(&device_id));
+  hipDevice_t device_id;
+  AOTRITON_HIP_CHECK_RETURN(hipStreamGetDevice(kargs.stream, &device_id));
   pstring_type persistant_storage;
   std::string  aiter_module;
   auto lazy = [&]() -> OnDeviceKernel::OnDiskKernelInfo {

--- a/v3src/on_device_kernel.cc
+++ b/v3src/on_device_kernel.cc
@@ -17,14 +17,17 @@ OnDeviceKernel::~OnDeviceKernel() {
   clear_decompressed_image();
 }
 
-std::tuple<hipFunction_t, const OnDeviceKernel::Essentials&>
+std::tuple<hipFunction_t, OnDeviceKernel::Essentials>
 OnDeviceKernel::get_kernel(int device_id,
                            std::function<OnDiskKernelInfo()> lazy) {
   hipFunction_t func = nullptr;
+  Essentials essentials;
   // Use reader lock to peek the state
   {
     std::shared_lock lock(funcache_mutex_);
     func = cfind_function(device_id);
+    if (func)
+      essentials = essentials_;
   }
 
   if (!func) {
@@ -37,8 +40,9 @@ OnDeviceKernel::get_kernel(int device_id,
       std::tie(func, err) = load_for_device(device_id,
                                             lazy());
     }
+    essentials = essentials_;
   }
-  return {func, essentials_};
+  return {func, essentials};
 }
 
 

--- a/v3src/on_device_kernel.cc
+++ b/v3src/on_device_kernel.cc
@@ -20,29 +20,24 @@ OnDeviceKernel::~OnDeviceKernel() {
 std::tuple<hipFunction_t, OnDeviceKernel::Essentials>
 OnDeviceKernel::get_kernel(int device_id,
                            std::function<OnDiskKernelInfo()> lazy) {
-  hipFunction_t func = nullptr;
-  Essentials essentials;
   // Use reader lock to peek the state
   {
     std::shared_lock lock(funcache_mutex_);
-    func = cfind_function(device_id);
+    auto func = cfind_function(device_id);
     if (func)
-      essentials = essentials_;
+      return {func, essentials_};
   }
 
+  // Use writer lock to initialize the module for device
+  std::unique_lock lock(funcache_mutex_);
+  // Check again, in case another waiter has initialized the device
+  auto func = cfind_function(device_id);
   if (!func) {
-    // Use writer lock to initialize the module for device
-    std::unique_lock lock(funcache_mutex_);
-    // Check again, in case another waiter has initialized the device
-    func = cfind_function(device_id);
-    if (!func) {
-      hipError_t err;
-      std::tie(func, err) = load_for_device(device_id,
-                                            lazy());
-    }
-    essentials = essentials_;
+    hipError_t err;
+    std::tie(func, err) = load_for_device(device_id,
+                                          lazy());
   }
-  return {func, essentials};
+  return {func, essentials_};
 }
 
 

--- a/v3src/triton_kernel.cc
+++ b/v3src/triton_kernel.cc
@@ -56,8 +56,8 @@ TritonKernel::invoke(std::string_view kernel_name,
                      hipStream_t stream) {
   AOTRITON_LOG(LOG_DEBUG, "Invoking TritonKernel %p with kernel_name = \"%.*s\"",
                static_cast<const void*>(this), int(kernel_name.size()), kernel_name.data());
-  int device_id;
-  AOTRITON_HIP_CHECK_RETURN(hipGetDevice(&device_id));
+  hipDevice_t device_id;
+  AOTRITON_HIP_CHECK_RETURN(hipStreamGetDevice(stream, &device_id));
   std::string stem_name;
   auto lazy = [&]() -> OnDeviceKernel::OnDiskKernelInfo {
     stem_name = construct_stem_name(kernel_name, func_name, ksig_psel_, ksig_copt_, arch_name);
@@ -97,8 +97,8 @@ TritonKernel::direct_invoke(std::string_view mangled_kernel_function_name,
                static_cast<const void*>(this),
                int(mangled_kernel_function_name.size()), mangled_kernel_function_name.data(),
                struct_of_args);
-  int device_id;
-  AOTRITON_HIP_CHECK_RETURN(hipGetDevice(&device_id));
+  hipDevice_t device_id;
+  AOTRITON_HIP_CHECK_RETURN(hipStreamGetDevice(stream, &device_id));
   auto lazy = [&]() -> OnDeviceKernel::OnDiskKernelInfo {
     // UNMAINTAINED: legacy package_path layout. The flatzip migration left
     // aks2_entry empty here because direct_invoke has no live callers.

--- a/v3src/util.cc
+++ b/v3src/util.cc
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <aotriton/util.h>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <string_view>
@@ -65,13 +67,28 @@ std::unordered_map<std::string, GpuClassifier> LazyGpu::string_to_classifier = {
 Gpu
 getGpuFromStream(hipStream_t stream) {
   static std::unordered_map<hipDevice_t, Gpu> device_to_arch;
+  static std::shared_mutex device_to_arch_mutex;
   hipDevice_t dev;
   hipError_t err = hipStreamGetDevice(stream, &dev);
   if (err != hipSuccess)
     return GPU_ARCH_UNKNOWN;
+
+  // Use reader lock to peek the cache
+  {
+    std::shared_lock lock(device_to_arch_mutex);
+    auto iter = device_to_arch.find(dev);
+    if (iter != device_to_arch.end())
+      return iter->second;
+  }
+
+  // Use writer lock to classify the device
+  std::unique_lock lock(device_to_arch_mutex);
+  // Check again, in case another waiter has classified this device
+  auto iter = device_to_arch.find(dev);
+  if (iter != device_to_arch.end())
+    return iter->second;
   LazyGpu lazy(dev);
-  device_to_arch.try_emplace(dev, lazy);
-  return device_to_arch[dev];
+  return device_to_arch.emplace(dev, lazy).first->second;
 }
 
 bool isArchExperimentallySupported(hipStream_t stream) {
@@ -94,21 +111,32 @@ bool isArchTechPreview(hipStream_t stream) {
 
 int getMultiProcessorCount(hipStream_t stream) {
   static std::unordered_map<hipDevice_t, int> device_to_CUs;
+  static std::shared_mutex device_to_CUs_mutex;
   hipDevice_t dev;
   hipError_t err = hipStreamGetDevice(stream, &dev);
   if (err != hipSuccess)
     return 40;  // A guessed number
 
-  auto iter = device_to_CUs.find(dev);
-  if (iter == device_to_CUs.end()) {
-    hipDeviceProp_t prop;
-    err = hipGetDeviceProperties(&prop, dev);
-    if (err != hipSuccess)
-      return 40;  // A guessed number
-    device_to_CUs[dev] = prop.multiProcessorCount;
-    return prop.multiProcessorCount;
+  // Use reader lock to peek the cache
+  {
+    std::shared_lock lock(device_to_CUs_mutex);
+    auto iter = device_to_CUs.find(dev);
+    if (iter != device_to_CUs.end())
+      return iter->second;
   }
-  return iter->second;
+
+  // Use writer lock to query the device
+  std::unique_lock lock(device_to_CUs_mutex);
+  // Check again, in case another waiter has queried this device
+  auto iter = device_to_CUs.find(dev);
+  if (iter != device_to_CUs.end())
+    return iter->second;
+  hipDeviceProp_t prop;
+  err = hipGetDeviceProperties(&prop, dev);
+  if (err != hipSuccess)
+    return 40;  // A guessed number
+  device_to_CUs[dev] = prop.multiProcessorCount;
+  return prop.multiProcessorCount;
 }
 
 template class TensorView<1>;


### PR DESCRIPTION
# Overview

AOTriton is normally called from a Python C/C++ extension holding the GIL,
which incidentally serialized every lazy initialization in the C++ runtime.
That assumption is gone: PyTorch FSDP now calls AOTriton functions concurrently
without holding the GIL. In the future, free-threaded Python (`python3.14t`)
will remove it entirely. All shared mutable state in the runtime must therefore
be assumed concurrently accessed.

Starting from the known race on `device_to_arch` in `v3src/util.cc`, this PR
audits the C++ runtime for GIL-dependent lazy initialization and fixes what it
found.

This PR does not introduce any public API or ABI change.

## Major Changes

* [util] Guard the per-device property caches of `getGpuFromStream` and
  `getMultiProcessorCount` with a `shared_mutex`.
  + `shared_lock` fast path / `unique_lock` slow path with re-lookup, per
    `OnDeviceKernel::get_kernel`. Caching behavior is unchanged.
* [shim] Replace all `hipGetDevice` with `hipStreamGetDevice`.
  + `hipGetDevice` uses the thread's ambient current device, which can differ
    from the stream's.
* [shim] Return `Essentials` by value from `OnDeviceKernel::get_kernel`.
  + An attempt to fix the dangling `const Essentials&` when
    `clear_decompressed_image()` is called.
  + But it failed because `Essentials::image` becomes dangling anyway.
  + The change is kept for a future design revision of the `clear_*` functions.
    - However, this is very low priority since `clear_*` is rarely needed in
      production.
* [aiter] Drop `thread_local` from `mha_fwd`'s `AiterAsmKernel` cache, matching
  `mha_bwd.cc`.
  + `thread_local impl_ptr_map` will create a copy of the kernel for each new
    thread.

# Known Issues

* [shim] `AiterAsmKernel::get_package_path` is not thread-safe. It is designed
  to be called inside `OnDeviceKernel::get_kernel`, which already holds its
  write lock.
* [shim] `Essentials.image` points into the `PackedKernel` decompression
  buffer, so `clear_decompressed_image()` invalidates it for any holder of a
  copy. A proper fix is indefinitely deferred. Do not call `clear_*()` for now.
* [aiter] `impl_ptr_map` in `mha_fwd.cc` and `mha_bwd.cc` is keyed on the bare
  `knl_name` without `arch`. It is safe for now: installation of GPUs with
  different architectures on the same node is not supported.
* [shim] `PackedKernel::open` holds one process-wide mutex across `openat` plus
  the full LZMA decompress, so N threads warming N different kernels fully
  serialize. Not fixed by design: warmup into VRAM is I/O bound, and using N
  threads for it is a caller-side design error.
* [internal] `KernelFineControl::ensure_initialized` (`v3src/cpp_tune.cc`) does
  an unguarded lazy `shared_ptr` init on a `mutable` vector. Not fixed: thread
  safety is guaranteed on the Python side, and only reentrance is required.
* [api] `attn_bwd_params` carries `mutable` lazy tensors and `attn_bwd` calls
  `free()` on them through a `const&`, so sharing one params object across
  threads is a double-free. Caller-side precondition, not changed here.

# Tests

```bash
bash .ci/build-test.sh gfx942 triton-3.7.0+gitdb82b800.aotriton0.14-cp313-cp313-linux_x86_64.whl
bash .ci/run-test.sh 0 0 split
bash .ci/run-test.sh 0 0 fused
```
In a Debian 13 container.

However, no multi-threaded runtime test was added or run.
