### PR TITLE
FlyDSL Integration PR1: Introduce PON and Deserializable ChoiceView

### DIFF
--- a/modules/flash/tune/entry.py
+++ b/modules/flash/tune/entry.py
@@ -1,7 +1,7 @@
 # Copyright © 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-from aotriton.tune.utils import parse_python
+from aotriton.utils import parse_pon
 from dataclasses import dataclass, asdict
 
 '''
@@ -31,7 +31,7 @@ class FlashEntry:
 
     @staticmethod
     def parse_text(line: str) -> "FlashEntry":
-        d = parse_python(line)
+        d = parse_pon(line)
         return FlashEntry(**d)
 
     @staticmethod
@@ -72,7 +72,7 @@ class FlashInputMetadata(FlashEntry):
 
     @staticmethod
     def parse_text(line: str) -> "FlashEntry":
-        d = parse_python(line)
+        d = parse_pon(line)
         return FlashInputMetadata(**d)
 
     @staticmethod

--- a/python/template_instantiation/ir/__init__.py
+++ b/python/template_instantiation/ir/__init__.py
@@ -10,7 +10,8 @@ from .override import (
     Predicate, VarRef, ValueFn, Override,
     eq, ne, lt, gt, le, ge,
 )
-from .functional import Functional, ChoiceView
+from .choices import ChoiceView, ChoiceVarAbsent
+from .functional import Functional, FunctionalChoiceView
 
 __all__ = [
     'typed_choice', 'TypedChoice', 'cfield',
@@ -18,5 +19,6 @@ __all__ = [
     'Axis', 'assign_godel', 'godel_of',
     'Predicate', 'VarRef', 'ValueFn', 'Override',
     'eq', 'ne', 'lt', 'gt', 'le', 'ge',
-    'Functional', 'ChoiceView',
+    'Functional', 'ChoiceView', 'ChoiceVarAbsent',
+    'FunctionalChoiceView',
 ]

--- a/python/template_instantiation/ir/choices.py
+++ b/python/template_instantiation/ir/choices.py
@@ -1,0 +1,72 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+ChoiceView — the interface for reading one instantiation's pinned choices.
+
+`ChoiceView` was one concrete class (`ir/functional.py`), constructed from a
+`Functional` and reading its `choice`/`resolved` tables. That works for the
+generator, which always has a linked `Functional` in hand. It does not work
+for a build-time driver, which has only the plain `{name: literal}` dict
+parsed out of a signature string: there is no IR behind it, and no `Functional`
+to build one from.
+
+The tempting shortcut is to let such a driver subscript the bare dict and be
+done. That gives two spellings for "read this kernel's pinned choices" -- a
+mapping on one side and an object on the other -- so any code that wants to
+work with both (a kernel description that must be readable by the generator
+*and* by a driver) has to branch on which it was handed. Make the shared
+surface explicit instead: `ChoiceView` is an ABC, and each side supplies its
+own backing.
+
+`FunctionalChoiceView` (`ir/functional.py`) is the `Functional`-backed one, and
+is what `Functional.choices` returns. A mapping-backed implementation is
+declared by whoever parses the wire text, next to the parsing.
+
+**The interface is `arg(aname)` + attribute access, and nothing else.**
+`tc`/`arg_tc` -- which hand back the raw `TypedChoice` -- are deliberately NOT
+on the ABC. A `TypedChoice` is a `Functional`-side object; a parsed dict never
+carried one, because only the literal survives the wire format. Putting them on
+the interface would force a mapping-backed implementation to declare two
+methods whose only possible body is a raise, which states "this view has these
+operations" and then denies it. They live on `FunctionalChoiceView` alone, so a
+caller that needs one is asking for a Functional and finds that out from the
+type.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class ChoiceVarAbsent(AttributeError):
+    """Raised by a ChoiceView when a predicate reads a choice variable (or, for
+    a mapping-backed view, a key) it does not have. Subclasses AttributeError
+    so getattr/hasattr duck-typing still behaves, but
+    KernelDescription.is_functional_disabled catches it specifically to emit a
+    write-your-own-@ati.disable diagnostic (a cited disable predicate that reads
+    a variable absent from the citing kernel)."""
+
+
+class ChoiceView(ABC):
+    """Ergonomic accessor over one instantiation's pinned choices.
+
+    Attribute access is keyed by *choice-variable name*: `choices.T_io` returns
+    the variable's signature. `.arg(aname)` reads a resolved argument by its
+    real (kernel-signature) name -- the form to use for an operand whose axis
+    variable is named differently, e.g. `choices.arg('Q')` rather than
+    `choices.T_io` (see `ir/axis.py`'s `Axis.signature_name` for why the two
+    can differ)."""
+
+    # A slotted class is dict-free only if EVERY base is slotted, so an ABC
+    # without this silently re-adds `__dict__` to `FunctionalChoiceView` and
+    # undoes its `__slots__`. One view is cached per Functional and functionals
+    # are enumerated in bulk, so that is a per-instantiation dict on the widest
+    # object in the generator.
+    __slots__ = ()
+
+    @abstractmethod
+    def arg(self, aname):
+        """The resolved (post-override) signature for a real argument name."""
+
+    @abstractmethod
+    def __getattr__(self, var):
+        """The signature for a choice variable, by attribute access."""

--- a/python/template_instantiation/ir/functional.py
+++ b/python/template_instantiation/ir/functional.py
@@ -22,21 +22,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from .choices import ChoiceView, ChoiceVarAbsent
+
 if TYPE_CHECKING:
     from .typed_choice import TypedChoice
 
 
-class ChoiceVarAbsent(AttributeError):
-    """Raised by ChoiceView when a predicate reads a choice variable the functional
-    does not have. Subclasses AttributeError so getattr/hasattr duck-typing still
-    behaves, but is_functional_disabled catches it specifically to emit a
-    write-your-own-@ati.disable diagnostic (a cited disable predicate that reads a
-    variable absent from the citing kernel)."""
-
-
-class ChoiceView:
-    """Ergonomic accessor over a Functional's pinned choices
-    Step 1.5.md §6, ati+newbinds_rev1.md §5).
+class FunctionalChoiceView(ChoiceView):
+    """`ChoiceView` backed by a Functional (Step 1.5.md §6,
+    ati+newbinds_rev1.md §5).
 
     Attribute access is keyed by *choice-variable name*: `f.choices.T_io` returns
     the variable's triton signature. `.tc(var)` returns the raw TypedChoice;
@@ -108,9 +102,9 @@ class Functional:
 
     @property
     def choices(self) -> ChoiceView:
-        """Cached ergonomic accessor; see ChoiceView."""
+        """Cached ergonomic accessor; see FunctionalChoiceView."""
         if self._choices_view is None:
-            self._choices_view = ChoiceView(self)
+            self._choices_view = FunctionalChoiceView(self)
         return self._choices_view
 
     @property

--- a/python/template_instantiation/ir/kdesc.py
+++ b/python/template_instantiation/ir/kdesc.py
@@ -455,7 +455,7 @@ class KernelDescription(Interface):
         # firing disables). Orthogonal to tuning: disabling excludes invalid input
         # combinations from generation, which any kernel may need — tunable or not.
         # A kernel with no @ati.disable has an empty `disables` list -> never fires.
-        from .functional import ChoiceVarAbsent
+        from .choices import ChoiceVarAbsent
         from ..builder import DescriptionError
         for d in self._built.disables:
             try:

--- a/python/test/test_choices_view.py
+++ b/python/test/test_choices_view.py
@@ -1,7 +1,7 @@
 # Copyright © 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Unit test for Functional.choices accessor view (executive plan Step 1.5)."""
+"""Unit tests for the ChoiceView interface and its Functional-backed backing."""
 
 import sys
 from pathlib import Path
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from aotriton.template_instantiation.ir import (
     TypedChoice, Axis, Override, eq, Interface,
+    ChoiceView, ChoiceVarAbsent, FunctionalChoiceView,
 )
 
 
@@ -93,6 +94,52 @@ def test_arg_reads_resolved():
 def test_view_is_cached():
     f = _functional(bias_type=1)
     assert f.choices is f.choices
+
+
+def test_functional_view_is_a_choiceview():
+    f = _functional(bias_type=1)
+    assert isinstance(f.choices, ChoiceView)
+
+
+def test_bare_choiceview_uninstantiable():
+    # ChoiceView is an ABC (ir/choices.py): it declares the interface but has
+    # no backing of its own, so instantiating it directly must fail, naming
+    # every unimplemented abstract method.
+    try:
+        ChoiceView()
+    except TypeError as e:
+        msg = str(e)
+        for name in ('arg', '__getattr__'):
+            assert name in msg, f'{name!r} missing from TypeError message: {msg!r}'
+        return
+    raise AssertionError('expected TypeError instantiating ChoiceView')
+
+
+def test_tc_and_arg_tc_are_not_on_the_interface():
+    # tc/arg_tc hand back a raw TypedChoice, which only a Functional has. They
+    # are deliberately NOT part of the ABC: requiring them would force a
+    # mapping-backed view to declare two methods whose only possible body is a
+    # raise -- an interface that advertises an operation and then denies it. A
+    # caller needing a TypedChoice must hold a FunctionalChoiceView, and finds
+    # that out from the type rather than at the call.
+    assert ChoiceView.__abstractmethods__ == frozenset({'arg', '__getattr__'})
+    assert not hasattr(ChoiceView, 'tc')
+    assert not hasattr(ChoiceView, 'arg_tc')
+    assert callable(FunctionalChoiceView.tc)
+    assert callable(FunctionalChoiceView.arg_tc)
+
+
+def test_unknown_var_raises_choice_var_absent():
+    # The absent-variable signal is ChoiceVarAbsent, a declared AttributeError
+    # subclass, so getattr/hasattr duck-typing still behaves while
+    # is_functional_disabled can catch it specifically.
+    f = _functional(bias_type=1)
+    try:
+        _ = f.choices.NoSuchVar
+    except ChoiceVarAbsent as e:
+        assert isinstance(e, AttributeError)
+        return
+    raise AssertionError('expected ChoiceVarAbsent')
 
 
 def main():

--- a/python/test/test_pon.py
+++ b/python/test/test_pon.py
@@ -1,0 +1,143 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for python/utils/pon.py: `parse_pon` / `render_pon` round-trip
+and the build-time rejection of un-representable strings."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import pytest
+
+from aotriton.utils import parse_pon, render_pon
+
+
+def test_round_trip_scalars():
+    d = {'a': 1, 'b': -1, 'flag': True, 'off': False, 'nothing': None,
+         'pi': 3.5, 'name': 'transposed'}
+    assert parse_pon(render_pon(d)) == d
+
+
+def test_round_trip_tuple_and_list():
+    d = {'shape': (1, 2), 'items': [0, 1, 2], 'nested': (('a', 'b'), 3)}
+    assert parse_pon(render_pon(d)) == d
+
+
+def test_render_pon_emits_no_spaces():
+    # THE wire-protocol invariant. ExaidProxy.write joins its arguments with
+    # ' ' and testrun's first() splits them back on ' ', so one space inside a
+    # PON token does not corrupt that value -- it re-tokenizes the whole
+    # command. repr((1, 2)) would have produced '(1, 2)'.
+    text = render_pon({'shape': (1, 2), 'items': [0, 1, 2],
+                       'nested': (('a', 'b'), 3), 'name': 'transposed'})
+    assert ' ' not in text, text
+
+
+def test_render_pon_single_element_tuple_keeps_comma():
+    # '(1)' would read back as the int 1, silently changing the type.
+    assert render_pon({'t': (1,)}) == 't=(1,)'
+    assert parse_pon(render_pon({'t': (1,)})) == {'t': (1,)}
+
+
+def test_render_pon_rejects_string_with_space():
+    with pytest.raises(ValueError, match='spacey'):
+        render_pon({'spacey': 'two words'})
+
+
+def test_round_trip_custom_separator():
+    d = {'BLOCK_M': 64, 'CAUSAL': True}
+    text = render_pon(d, sep=' ')
+    assert ';' not in text
+    assert parse_pon(text, sep=' ') == d
+
+
+def test_render_pon_quotes_strings():
+    # The unified (quoted) dialect: a str value is rendered with its repr(),
+    # not bare -- 'transposed', never transposed.
+    assert render_pon({'v_lds_layout': 'transposed'}) == "v_lds_layout='transposed'"
+
+
+def test_render_pon_rejects_unrepresentable_string():
+    # A string whose repr() is not a plain single-quoted form (here: it
+    # contains a single quote itself) cannot be represented by this grammar --
+    # render_pon must raise, naming the offending key, rather than silently
+    # emitting text that only a full Python-repr unescaper could read back.
+    with pytest.raises(ValueError, match='bad_key'):
+        render_pon({'bad_key': "can't"})
+
+
+def test_render_pon_rejects_separator_inside_a_string():
+    # NOT the same guard as the space one: at the default sep this renders
+    # a='x;y', which parse_pon splits mid-string.
+    with pytest.raises(ValueError, match='sep_in_value'):
+        render_pon({'sep_in_value': 'x;y'})
+
+
+def test_render_pon_rejects_a_separator_from_its_own_grammar():
+    # sep=',' collides with the container separator _render_value emits, so
+    # x=[1,2] would come back as three tokens, the first being 'x=[1'.
+    with pytest.raises(ValueError, match='grammar'):
+        render_pon({'x': [1, 2]}, sep=',')
+
+
+def test_render_pon_rejects_a_key_with_an_equals_sign():
+    # a=b=1 parses without error into {'a': 'b=1'} -- the wrong dict, quietly.
+    with pytest.raises(ValueError, match='a=b'):
+        render_pon({'a=b': 1})
+
+
+def test_render_pon_rejects_a_key_with_a_space():
+    # An assert would vanish under `python -O`, which is where corrupt wire
+    # text is hardest to trace; this is a ValueError for that reason.
+    with pytest.raises(ValueError, match='two words'):
+        render_pon({'two words': 1})
+
+
+def test_render_pon_rejects_non_finite_floats():
+    # repr(nan) is the bare identifier 'nan': it clears the space guard and
+    # then dies in the reader's ast.literal_eval, in another process.
+    for bad in (float('nan'), float('inf'), float('-inf')):
+        with pytest.raises(ValueError, match='nonfinite'):
+            render_pon({'nonfinite': bad})
+
+
+def test_parse_pon_names_the_token_that_has_no_equals():
+    with pytest.raises(ValueError, match='garbage'):
+        parse_pon('a=1;garbage;b=2')
+
+
+def test_flash_entry_round_trips_through_pon():
+    from aotriton.tune.registry import load_flash_entry_module
+
+    modules_dir = Path(__file__).resolve().parents[2] / 'modules'
+    FlashEntry = load_flash_entry_module(modules_dir=modules_dir).FlashEntry
+
+    e = FlashEntry(dtype='bfloat16', hdim=(64, 128), seqlen_q=256, seqlen_k=512,
+                   causal=True, dropout_p=0.5, bias_type=1)
+    d = parse_pon(e.as_text())
+    assert FlashEntry(**d) == e
+
+
+def main():
+    """Standalone runner. Every test here runs without pytest -- `pytest.raises`
+    is a plain context manager, not a fixture -- so nothing is skipped and a
+    failure is a non-zero exit. Same shape as test_choices_view.py's."""
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    failures = 0
+    for fn in fns:
+        try:
+            fn()
+        except Exception as e:
+            failures += 1
+            print(f'FAIL: {fn.__name__}: {type(e).__name__}: {e}')
+    if failures:
+        print(f'FAILED: {failures} of {len(fns)} pon tests.')
+        return 1
+    print(f'OK: {len(fns)} pon tests passed.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/python/test/test_pon.py
+++ b/python/test/test_pon.py
@@ -53,6 +53,33 @@ def test_round_trip_custom_separator():
     assert parse_pon(text, sep=' ') == d
 
 
+def test_every_pair_is_space_free_under_a_space_separator():
+    # The invariant is on the PAIR, not on the joined string. With sep=' ' the
+    # joins are spaces by construction, so "no spaces anywhere" is the wrong
+    # assertion -- and the obvious way to write it, exempting sep=' ', disables
+    # the check in the one mode where a stray space is fatal rather than untidy,
+    # because here a space IS the token boundary.
+    d = {'BLOCK_M': 64, 'name': 'transposed', 'shape': (1, 2)}
+    text = render_pon(d, sep=' ')
+    assert parse_pon(text, sep=' ') == d
+    pairs = text.split(' ')
+    assert len(pairs) == len(d), text      # no pair split itself in two
+    for pair in pairs:
+        assert '=' in pair and ' ' not in pair, pair
+
+
+def test_render_pon_rejects_string_with_space_under_any_separator():
+    # Not a property of the ';' wire alone. Under sep=' ' a space-bearing value
+    # is not merely untransportable, it is unparseable: the reader splits mid
+    # string and ast.literal_eval sees an unterminated literal. So the refusal
+    # is unconditional, and a caller wanting a space in a value encodes it
+    # (U+2423, a full-width space) rather than the format growing a quoting
+    # layer every reader would have to implement.
+    for sep in (';', ' ', '|'):
+        with pytest.raises(ValueError, match='spacey'):
+            render_pon({'spacey': 'two words'}, sep=sep)
+
+
 def test_render_pon_quotes_strings():
     # The unified (quoted) dialect: a str value is rendered with its repr(),
     # not bare -- 'transposed', never transposed.

--- a/python/test/test_pon.py
+++ b/python/test/test_pon.py
@@ -80,6 +80,22 @@ def test_render_pon_rejects_string_with_space_under_any_separator():
             render_pon({'spacey': 'two words'}, sep=sep)
 
 
+def test_parse_pon_names_the_key_whose_value_is_malformed():
+    # literal_eval reports SyntaxError for most malformed wire text and
+    # ValueError only for text that parses but is not a literal. Both arrive
+    # as one ValueError naming the key, the token and the line -- this reads
+    # text a human never typed, so "unterminated string literal (detected at
+    # line 1)" on its own is not a diagnosis.
+    for bad, original in (("BLOCK_M=64;name='unterminated", SyntaxError),
+                          ('BLOCK_M=64;name=no_such_name', ValueError),
+                          ('BLOCK_M=64;shape=[1,', SyntaxError)):
+        with pytest.raises(ValueError, match='name|shape') as exc:
+            parse_pon(bad)
+        assert 'parse_pon' in str(exc.value)
+        assert bad in str(exc.value)              # the whole line, for context
+        assert isinstance(exc.value.__cause__, original)   # nothing discarded
+
+
 def test_render_pon_quotes_strings():
     # The unified (quoted) dialect: a str value is rendered with its repr(),
     # not bare -- 'transposed', never transposed.

--- a/python/tune/utils.py
+++ b/python/tune/utils.py
@@ -39,15 +39,6 @@ def configure_logging_with_flush():
 def safeload(s):
     return json.loads(s) if s else None
 
-def parse_python(line: str) -> dict:
-    args = line.split(';')
-    d = {}
-    for assignment in args:
-        # print(f'{assignment=}', file=sys.stderr)
-        k, v = assignment.split('=', maxsplit=1)
-        d[k] = eval(v)
-    return d
-
 def asdict_shallow(obj) -> dict:
     return {field.name: getattr(obj, field.name) for field in fields(obj)}
 

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -5,9 +5,12 @@ from .lazy_file import LazyFile
 from .registry import RegistryRepository
 from .dict2json import dict2json
 from .log import log
+from .pon import parse_pon, render_pon
 
 __all__ = [
     "LazyFile",
     "RegistryRepository",
     "log",
+    "parse_pon",
+    "render_pon",
 ]

--- a/python/utils/pon.py
+++ b/python/utils/pon.py
@@ -112,6 +112,10 @@ def parse_pon(line: str, sep: str = ';') -> dict:
     literal (int, float, quoted string, tuple, list, `True`/`False`/`None`);
     anything else -- notably a bare identifier or a call -- raises rather
     than executing.
+
+    Every malformed input raises `ValueError` naming the offending key or
+    token and the line it came from, whatever `literal_eval` raised
+    underneath; the original is chained as `__cause__`.
     """
     _check_sep(sep)
     d = {}
@@ -124,8 +128,28 @@ def parse_pon(line: str, sep: str = ';') -> dict:
             raise ValueError(
                 f'parse_pon: {assignment!r} is not a key=value pair (no '
                 f'{"="!r}) in {line!r} (sep={sep!r})')
-        k, v = assignment.split('=', maxsplit=1)
-        d[k.strip()] = ast.literal_eval(v.strip())
+        k, v = (s.strip() for s in assignment.split('=', maxsplit=1))
+        try:
+            d[k] = ast.literal_eval(v)
+        except (ValueError, TypeError, SyntaxError) as e:
+            # Same reason as the branch above, and the same error type on
+            # purpose. `literal_eval` reports SyntaxError for most malformed
+            # wire text -- an unterminated string, a truncated list, a bad
+            # numeric literal -- and ValueError only for text that parses but
+            # is not a literal, such as a bare identifier. Letting both
+            # propagate untouched leaves "PON could not read this" as two
+            # different exception types, one of which names neither the key,
+            # the token, nor the line it came from.
+            #
+            # Narrowing to ValueError makes the failure one catchable thing
+            # and matches what this function already raises for a pair with
+            # no `=`. `from e` keeps the original type and message reachable
+            # as __cause__, so the distinction between "not a literal" and
+            # "malformed syntax" is preserved for anyone who needs it -- it
+            # simply stops being the caller's problem to discriminate.
+            raise ValueError(
+                f'parse_pon: value of {k!r} is not a Python literal: {v!r} '
+                f'in {line!r} (sep={sep!r})') from e
     return d
 
 

--- a/python/utils/pon.py
+++ b/python/utils/pon.py
@@ -4,18 +4,19 @@
 """PON (Plain / Python Object Notation): a safe, separator-configurable
 `k=v;k=v` wire format, and the one home for both reading and writing it.
 
-`aotriton.tune.utils.parse_python` -- the format's original reader -- splits a
-line on `;`, then on `=` with `maxsplit=1`, then calls `eval(v)` on the value.
-Two problems: the `eval` can execute arbitrary code, and the separator is
-hard-coded to `;`, so a caller whose wire separator is something else (a
-space-separated `--signature`/`--hints` command line, say) cannot reuse it and
-writes its own splitter instead.
+The format's original reader was `aotriton.tune.utils.parse_python`, removed
+here: it split a line on `;`, then on `=` with `maxsplit=1`, then called
+`eval(v)` on the value. Two problems. The `eval` executed whatever the wire
+carried -- and this wire carries text a worker process wrote, not text a human
+typed. And the separator was hard-coded to `;`, so a caller whose wire
+separator is something else (a space-separated `--signature`/`--hints` command
+line, say) could not reuse it and wrote its own splitter instead.
 
 `parse_pon` keeps the shape and fixes both: `ast.literal_eval` accepts exactly
 the forms build inputs use -- ints, floats, quoted strings, tuples, lists,
 `True`/`False`/`None` -- and raises on anything else, including bare
-identifiers. `sep` defaults to `';'` so it is a drop-in for every
-`parse_python` caller (`FlashEntry.parse_text`,
+identifiers. `sep` defaults to `';'`, which is what made it a drop-in for the
+two readers that used to call `eval` (`FlashEntry.parse_text`,
 `FlashInputMetadata.parse_text`); a caller with a different wire separator
 passes `sep=' '` and gets the same parser rather than a second spelling of it.
 

--- a/python/utils/pon.py
+++ b/python/utils/pon.py
@@ -31,18 +31,34 @@ Python-repr unescaper could read back. Holding the grammar down to that is what
 lets a reader outside Python strip exactly one pair of surrounding single
 quotes and be done.
 
-**A PON string contains NO SPACES.** This is a hard property of the format, not
-a cosmetic one, and it is why `render_pon` cannot simply call `repr()` on a
-container: `repr((1, 2))` is `'(1, 2)'`, with a space after the comma.
+**EVERY `k=v` PAIR CONTAINS NO SPACES, whatever `sep` is.** That is a hard
+property of the format, not a cosmetic one, and it is why `render_pon` cannot
+simply call `repr()` on a container: `repr((1, 2))` is `'(1, 2)'`, with a space
+after the comma.
 
-The reason is the exaid/testrun wire protocol. `ExaidProxy.write`
-(`python/tune/exaid.py`) joins its arguments with `' '`, and the worker's
-`first()` (`python/tune/testrun.py`) splits the line back apart on `' '`. A
-single embedded space therefore does not corrupt the value -- it silently
-re-tokenizes the whole command, so a later positional argument is read from the
-middle of an earlier one. `render_pon` renders containers with a bare `,`
-separator and rejects any value whose rendering would contain a space,
-including a `str` with a space inside it.
+Note what this does and does not say. The invariant is on the *pair*, not on
+the rendered string: with the default `sep=';'` the whole string is space-free,
+but with `sep=' '` the separators themselves are spaces and the string is a
+command line by construction. Both are the same rule -- no space may appear
+anywhere a reader would not expect a token boundary.
+
+Two consumers pin it from opposite directions. The exaid/testrun wire protocol
+needs the `;` form to survive as ONE token: `ExaidProxy.write`
+(`python/tune/exaid.py`) joins its arguments with `' '` and the worker's
+`first()` (`python/tune/testrun.py`) splits the line back apart on `' '`, so an
+embedded space does not corrupt a value -- it silently re-tokenizes the whole
+command, and a later positional argument is read from the middle of an earlier
+one. The cmake/ninja rule generator needs the `' '` form for the opposite
+reason: `;` is cmake's own list separator when it reads a file, so a
+`;`-joined string would be split by cmake before the rule ever saw it. There
+the space-free pair is what keeps each `k=v` a single cmake token.
+
+**A value may therefore never contain a space, under any `sep`.** This is a
+deliberate limitation and not an oversight: it keeps the strings short and the
+grammar small enough that no consumer needs a quoting layer, and nothing in
+this tree wants a space inside a value. A future caller that genuinely does
+should encode it -- U+2423 OPEN BOX, a full-width space, or a private-use
+codepoint -- rather than teaching every reader to unescape.
 
 **What `render_pon` rejects, and why the list is what it is.** The round-trip
 promise above -- `parse_pon(render_pon(d)) == d` -- is not a property of the
@@ -198,8 +214,10 @@ def _render_value(k, v, sep) -> str:
 def render_pon(d: dict, sep: str = ';') -> str:
     """Render `{k1: v1, k2: v2, ...}` as `"k1=v1<sep>k2=v2..."`.
 
-    `parse_pon(render_pon(d)) == d` for any `d` this function accepts, and the
-    result never contains a space. A `str` value must round-trip through a
+    `parse_pon(render_pon(d)) == d` for any `d` this function accepts, and
+    every `k=v` pair it emits is space-free. The rendered string as a whole is
+    therefore space-free too under the default `sep=';'`, and contains spaces
+    only at the joins when `sep=' '`. A `str` value must round-trip through a
     plain single-quoted `repr()` -- `repr(v) == "'" + v + "'"` -- or this
     raises `ValueError` naming the offending key; that precondition is what
     lets a reader outside Python strip exactly one pair of surrounding single
@@ -214,12 +232,21 @@ def render_pon(d: dict, sep: str = ';') -> str:
     _check_sep(sep)
     for k in d:
         _check_key(k, sep)
-    text = sep.join(f'{k}={_render_value(k, v, sep)}' for k, v in d.items())
-    # Belt and braces: _render_value rejects spaces per value, but a caller
-    # passing sep=' ' would reintroduce them at the joins, and that is legal --
-    # a space-separated --signature string is a command line, not a single
-    # wire token.
-    # Only assert the property the per-value checks are responsible for.
-    assert sep == ' ' or ' ' not in text, (
-        f'render_pon: emitted a space with sep={sep!r}: {text!r}')
-    return text
+    pairs = [f'{k}={_render_value(k, v, sep)}' for k, v in d.items()]
+    # The invariant checked where it is stated: on the PAIR, not on the joined
+    # string. Checking the join instead has to special-case sep=' ' -- and the
+    # obvious spelling of that exemption, `sep == ' ' or ' ' not in text`,
+    # disables the check in precisely the mode where a stray space is fatal
+    # rather than merely untidy, since there a space IS the token boundary.
+    #
+    # `_check_key` and `_render_value` already reject a space on either side of
+    # the `=`, so this cannot fire today. It is here so a rendering path added
+    # around them later cannot quietly emit a pair that re-tokenizes -- and it
+    # raises rather than asserts because `python -O` drops asserts, and a build
+    # running under -O is exactly where corrupt wire text is hardest to trace.
+    for pair in pairs:
+        if ' ' in pair:
+            raise ValueError(
+                f'render_pon: pair {pair!r} contains a space; every k=v pair '
+                f'must be space-free whatever sep is (sep={sep!r})')
+    return sep.join(pairs)

--- a/python/utils/pon.py
+++ b/python/utils/pon.py
@@ -4,6 +4,22 @@
 """PON (Plain / Python Object Notation): a safe, separator-configurable
 `k=v;k=v` wire format, and the one home for both reading and writing it.
 
+**PON is strict on write and tolerant on read**, in the network-protocol sense,
+and that asymmetry is deliberate rather than an accident of implementation.
+`render_pon` emits exactly one dialect and refuses anything it could not read
+back unambiguously; `parse_pon` accepts whatever `ast.literal_eval` does. What
+the reader happens to accept beyond what the writer emits -- double-quoted
+strings, for instance -- is **not a promise**, and a caller should not build on
+it: the writer's grammar is the contract, and the reader's extra tolerance
+exists so that a stray hand-written line or an older producer does not become
+an outage.
+
+Most of what follows is a consequence of that rule rather than a separate
+decision. The refusal list under "What `render_pon` rejects" is the write-strict
+half enumerated; `parse_pon` narrowing every malformed input to one `ValueError`
+while chaining the original as `__cause__` is the read-tolerant half -- one
+outcome for the caller to handle, full detail kept for whoever wants it.
+
 The format's original reader was `aotriton.tune.utils.parse_python`, removed
 here: it split a line on `;`, then on `=` with `maxsplit=1`, then called
 `eval(v)` on the value. Two problems. The `eval` executed whatever the wire

--- a/python/utils/pon.py
+++ b/python/utils/pon.py
@@ -1,0 +1,225 @@
+# Copyright © 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""PON (Plain / Python Object Notation): a safe, separator-configurable
+`k=v;k=v` wire format, and the one home for both reading and writing it.
+
+`aotriton.tune.utils.parse_python` -- the format's original reader -- splits a
+line on `;`, then on `=` with `maxsplit=1`, then calls `eval(v)` on the value.
+Two problems: the `eval` can execute arbitrary code, and the separator is
+hard-coded to `;`, so a caller whose wire separator is something else (a
+space-separated `--signature`/`--hints` command line, say) cannot reuse it and
+writes its own splitter instead.
+
+`parse_pon` keeps the shape and fixes both: `ast.literal_eval` accepts exactly
+the forms build inputs use -- ints, floats, quoted strings, tuples, lists,
+`True`/`False`/`None` -- and raises on anything else, including bare
+identifiers. `sep` defaults to `';'` so it is a drop-in for every
+`parse_python` caller (`FlashEntry.parse_text`,
+`FlashInputMetadata.parse_text`); a caller with a different wire separator
+passes `sep=' '` and gets the same parser rather than a second spelling of it.
+
+`render_pon` is the matching writer: `repr()`-compatible per value, not
+`str()`, so every value it emits is exactly what `ast.literal_eval` (hence
+`parse_pon`) would read back -- the format is round-trippable in both
+directions, and there is only one dialect. For `str` values specifically,
+`render_pon` requires `repr(v) == "'" + v + "'"`: single-quoted, nothing
+escaped. If a value ever stops satisfying that (a quote, backslash, or
+non-printable character in it), it raises loudly, naming the key, at the point
+the wire text is built -- rather than silently emitting text that only a full
+Python-repr unescaper could read back. Holding the grammar down to that is what
+lets a reader outside Python strip exactly one pair of surrounding single
+quotes and be done.
+
+**A PON string contains NO SPACES.** This is a hard property of the format, not
+a cosmetic one, and it is why `render_pon` cannot simply call `repr()` on a
+container: `repr((1, 2))` is `'(1, 2)'`, with a space after the comma.
+
+The reason is the exaid/testrun wire protocol. `ExaidProxy.write`
+(`python/tune/exaid.py`) joins its arguments with `' '`, and the worker's
+`first()` (`python/tune/testrun.py`) splits the line back apart on `' '`. A
+single embedded space therefore does not corrupt the value -- it silently
+re-tokenizes the whole command, so a later positional argument is read from the
+middle of an earlier one. `render_pon` renders containers with a bare `,`
+separator and rejects any value whose rendering would contain a space,
+including a `str` with a space inside it.
+
+**What `render_pon` rejects, and why the list is what it is.** The round-trip
+promise above -- `parse_pon(render_pon(d)) == d` -- is not a property of the
+grammar, it is a property of the writer refusing everything the grammar cannot
+carry. Three of those refusals are about text that would parse *without error*
+into a different dict, which is the failure mode worth being loud about:
+
+* a `sep` that is one of `,[]()='"\\` -- the characters this writer emits
+  structurally, so a pair boundary and a container boundary become the same
+  thing (`sep=','` turns `x=[1,2]` into three tokens);
+* a key holding `=`, a space or `sep` -- keys are written unquoted, so
+  `{'a=b': 1}` renders `a=b=1` and reads back as `{'a': 'b=1'}`;
+* a `str` value holding `sep` -- `{'a': 'x;y'}` renders `a='x;y'` and the
+  reader splits the string in half.
+
+And one about text that fails loudly, but in the wrong process: a non-finite
+float renders as the bare identifier `nan`/`inf`, which only `literal_eval`
+finds out about, at read time, on the far side of the wire.
+"""
+
+import ast
+import math
+
+# Characters a separator may not be, because `render_pon` writes them itself
+# and `parse_pon` reads them back structurally. `=` splits a pair; `,` `[` `]`
+# `(` `)` delimit the containers `_render_value` emits with a bare `,`; `'`
+# quotes a string; `\` cannot appear in a value at all. A `sep` drawn from this
+# set makes the two functions disagree about where a token ends -- `sep=','` on
+# `{'x': [1, 2]}` renders `x=[1,2]` and parses back as three tokens, the first
+# of which is `x=[1` (`SyntaxError: '[' was never closed`). Separator
+# configurability is this module's reason to exist, so the separators that do
+# not work are rejected rather than left to fail downstream.
+_SEP_FORBIDDEN = frozenset(",[]()='\"\\")
+
+
+def _check_sep(sep):
+    """One character, and not one of the grammar's own."""
+    if not isinstance(sep, str) or len(sep) != 1:
+        raise ValueError(
+            f'pon: sep must be exactly one character, got {sep!r}')
+    if sep in _SEP_FORBIDDEN:
+        raise ValueError(
+            f'pon: sep={sep!r} is part of PON\'s own grammar '
+            f'({"".join(sorted(_SEP_FORBIDDEN))}) and cannot separate pairs')
+
+
+def parse_pon(line: str, sep: str = ';') -> dict:
+    """Parse `"k1=v1<sep>k2=v2..."` into `{k1: v1, k2: v2, ...}`.
+
+    Each value is decoded with `ast.literal_eval`, so it must be a Python
+    literal (int, float, quoted string, tuple, list, `True`/`False`/`None`);
+    anything else -- notably a bare identifier or a call -- raises rather
+    than executing.
+    """
+    _check_sep(sep)
+    d = {}
+    for assignment in filter(None, (a.strip() for a in line.split(sep))):
+        if '=' not in assignment:
+            # Naming the token AND the line: this is the hardened replacement
+            # for parse_python's eval(), so it reads worker wire text that a
+            # human never typed, and a bare `ValueError: not enough values to
+            # unpack` says nothing about which field arrived malformed.
+            raise ValueError(
+                f'parse_pon: {assignment!r} is not a key=value pair (no '
+                f'{"="!r}) in {line!r} (sep={sep!r})')
+        k, v = assignment.split('=', maxsplit=1)
+        d[k.strip()] = ast.literal_eval(v.strip())
+    return d
+
+
+def _check_key(k, sep):
+    """A key must survive the same round trip its value does.
+
+    `_render_value` guards values only, and a key is written to the wire
+    unquoted and unescaped -- so `{'a=b': 1}` renders `a=b=1`, which
+    `parse_pon` reads back as `{'a': 'b=1'}`: no error, wrong dict. A key with
+    a space used to be caught by `render_pon`'s trailing `assert`, which
+    vanishes under `python -O`, i.e. exactly the mode where corrupt wire text
+    is hardest to trace. These are `ValueError`s for that reason.
+    """
+    if not isinstance(k, str) or not k:
+        raise ValueError(
+            f'render_pon: key {k!r} must be a non-empty str')
+    if '=' in k:
+        raise ValueError(
+            f'render_pon: key {k!r} contains {"="!r}, which parse_pon reads as '
+            f'the key/value boundary -- the pair would read back with a '
+            f'truncated key and the rest of the key glued onto the value')
+    if sep in k or ' ' in k:
+        raise ValueError(
+            f'render_pon: key {k!r} contains a separator (sep={sep!r}) or a '
+            f'space; either one re-tokenizes the pair')
+    if not k.isprintable():
+        raise ValueError(
+            f'render_pon: key {k!r} contains a non-printable character')
+
+
+def _render_value(k, v, sep) -> str:
+    """One PON value: `repr()`-equivalent, but with no spaces anywhere.
+
+    Recurses through tuples/lists rather than calling `repr()` on them, because
+    `repr` separates container elements with `', '` and a space breaks the wire
+    protocol (see the module docstring). The single-element tuple keeps its
+    trailing comma -- `(1,)`, not `(1)`, which would read back as a plain int.
+    """
+    if isinstance(v, str):
+        if repr(v) != "'" + v + "'":
+            raise ValueError(
+                f"render_pon: value of {k!r} ({v!r}) does not round-trip "
+                f"through a plain single-quoted repr() (it contains a quote, "
+                f"backslash, or non-printable character) -- PON cannot "
+                f"represent it")
+        if ' ' in v:
+            raise ValueError(
+                f"render_pon: value of {k!r} ({v!r}) contains a space. A PON "
+                f"string is passed as one token on the exaid/testrun wire, "
+                f"which splits on ' ', so an embedded space silently "
+                f"re-tokenizes the whole command")
+        # The SEPARATOR, not just a space. These are two different hazards and
+        # the space guard above covers only one of them: `{'a': 'x;y'}` at the
+        # default sep renders `a='x;y'`, and parse_pon splits it mid-string
+        # into `a='x` and `y'` -- a SyntaxError from literal_eval, or worse a
+        # value that happens to parse. A str is the only value kind that can
+        # carry an arbitrary character, so this is the only place it can hide.
+        if sep in v:
+            raise ValueError(
+                f"render_pon: value of {k!r} ({v!r}) contains the separator "
+                f"{sep!r}; parse_pon would split the string in half")
+        return repr(v)
+    if isinstance(v, float) and not math.isfinite(v):
+        # repr(nan) is 'nan' -- a bare identifier, so it clears the space guard
+        # below and then dies in parse_pon's ast.literal_eval, at read time, in
+        # another process. Reachable: tune/utils.py already carries a
+        # sanitize_float for the NaN/Inf that turn up in tuning data.
+        raise ValueError(
+            f'render_pon: value of {k!r} is {v!r}, which renders as a bare '
+            f'identifier that ast.literal_eval (hence parse_pon) rejects; PON '
+            f'cannot represent a non-finite float')
+    if isinstance(v, tuple):
+        inner = ','.join(_render_value(k, x, sep) for x in v)
+        return f'({inner},)' if len(v) == 1 else f'({inner})'
+    if isinstance(v, list):
+        return '[' + ','.join(_render_value(k, x, sep) for x in v) + ']'
+    out = repr(v)
+    if ' ' in out:
+        raise ValueError(
+            f"render_pon: value of {k!r} ({v!r}) renders as {out!r}, which "
+            f"contains a space; PON values must be space-free (see the module "
+            f"docstring on the exaid/testrun wire protocol)")
+    return out
+
+
+def render_pon(d: dict, sep: str = ';') -> str:
+    """Render `{k1: v1, k2: v2, ...}` as `"k1=v1<sep>k2=v2..."`.
+
+    `parse_pon(render_pon(d)) == d` for any `d` this function accepts, and the
+    result never contains a space. A `str` value must round-trip through a
+    plain single-quoted `repr()` -- `repr(v) == "'" + v + "'"` -- or this
+    raises `ValueError` naming the offending key; that precondition is what
+    lets a reader outside Python strip exactly one pair of surrounding single
+    quotes instead of implementing a full Python-repr unescaper.
+
+    `sep`, the keys and the values are all checked against the SAME grammar,
+    because the round-trip promise above is only true if all three respect it:
+    a separator drawn from the container syntax, a key holding an `=`, or a
+    string value holding the separator each produce text that parses without
+    error into the wrong dict.
+    """
+    _check_sep(sep)
+    for k in d:
+        _check_key(k, sep)
+    text = sep.join(f'{k}={_render_value(k, v, sep)}' for k, v in d.items())
+    # Belt and braces: _render_value rejects spaces per value, but a caller
+    # passing sep=' ' would reintroduce them at the joins, and that is legal --
+    # a space-separated --signature string is a command line, not a single
+    # wire token.
+    # Only assert the property the per-value checks are responsible for.
+    assert sep == ' ' or ' ' not in text, (
+        f'render_pon: emitted a space with sep={sep!r}: {text!r}')
+    return text


### PR DESCRIPTION
# Overview

Prelude to the FlyDSL (`flyc`) kernel integration.

This PR formalizes the wire protocol used by exaid and names it "Plain Object
Notation" (PON). PON will be used as the serialization format between the build
targets written by `aotriton.generate` and the processes that compile flyc
hsaco kernels.

## Major Changes

* [`pon`] Formalize existing `k=v;k=v` wire format as "PON".
  + Implemented in `python/utils/pon.py`
  + Writer API: `render_pon(d: dict, sep: str = ';') -> str`
  + Reader API: `parse_pon(line: str, sep: str = ';') -> dict`
    - Uses `ast.literal_eval` for better security
  + Defaults to `;` as the separator, which is what `exaid` uses
  + A space separator is supported because `;` is CMake's list separator and
    thus cannot survive when reading PON text from CMake
  + String values are single-quoted.
    - `"` is supported by `parse_pon`'s `literal_eval` now, but no guarantees in the future
    - Strings containing single quotes or spaces are not supported
  + No space is allowed in `k=v` pairs; users who need spaces should use
    U+2423 or similar instead.
* [ir] Split `ChoiceView` into an ABC (`ir/choices.py`) over the existing
  concrete class, now `FunctionalChoiceView` (`ir/functional.py`).
  + Subclasses of `ChoiceView` deserialized from PON will be added in a later PR
